### PR TITLE
Optimize some logical for readOnce.

### DIFF
--- a/pkg/buffer/iobuffer.go
+++ b/pkg/buffer/iobuffer.go
@@ -28,7 +28,7 @@ import (
 	"mosn.io/mosn/pkg/types"
 )
 
-const AutoExpand = 1
+const AutoExpand = -1
 const MinRead = 1 << 9
 const MaxRead = 1 << 17
 const ResetOffMark = -1
@@ -376,11 +376,15 @@ func (b *IoBuffer) SetEOF(eof bool) {
 	b.eof = eof
 }
 
+//The expand parameter means the following:
+//A, if expand > 0, cap(newbuf) is calculated according to cap(oldbuf) and expand.
+//B, if expand == AutoExpand, cap(newbuf) is calculated only according to cap(oldbuf).
+//C, if expand == 0, only copy, buf not be expanded.
 func (b *IoBuffer) copy(expand int) {
 	var newBuf []byte
 	var bufp *[]byte
 
-	if expand > 0 {
+	if expand > 0 || expand == AutoExpand {
 		cap := cap(b.buf)
 		// when buf cap greater than MaxThreshold, start Slow Grow.
 		if cap < 2*MinRead {

--- a/pkg/buffer/iobuffer.go
+++ b/pkg/buffer/iobuffer.go
@@ -32,6 +32,8 @@ const MinRead = 1 << 9
 const MaxRead = 1 << 17
 const ResetOffMark = -1
 const DefaultSize = 1 << 4
+const MaxBufferLength = 1 << 20
+const MaxThreshold = 1 << 22
 
 var nullByte []byte
 
@@ -71,91 +73,48 @@ func (b *IoBuffer) Read(p []byte) (n int, err error) {
 	return
 }
 
-func (b *IoBuffer) ReadOnce(r io.Reader) (n int64, e error) {
-	var (
-		m               int
-		zeroTime        time.Time
-		conn            net.Conn
-		loop, ok, first = true, true, true
-	)
+func (b *IoBuffer) ReadOnce(r io.Reader) (n int64, err error) {
+	var m int
+	var zeroTime time.Time
 
-	if conn, ok = r.(net.Conn); !ok {
-		loop = false
-	}
-
-	if b.off >= len(b.buf) {
+	if b.off > 0 && b.off >= len(b.buf) {
 		b.Reset()
 	}
 
-	if b.off > 0 && len(b.buf)-b.off < 4*MinRead {
+	if b.off >= (cap(b.buf) - len(b.buf)) {
 		b.copy(0)
 	}
 
-	if cap(b.buf) == len(b.buf) {
+	// free max buffers avoid memleak
+	if b.off == len(b.buf) && cap(b.buf) > MaxBufferLength {
+		b.Free()
+		b.Alloc(MaxRead)
+	}
+
+	l := cap(b.buf) - len(b.buf)
+
+	conn, _ := r.(net.Conn)
+	if conn != nil {
+		// TODO: support configure
+		conn.SetReadDeadline(time.Now().Add(ConnReadTimeout))
+
+		m, err = r.Read(b.buf[len(b.buf):cap(b.buf)])
+
+		// Reset read deadline
+		conn.SetReadDeadline(zeroTime)
+	} else {
+		m, err = r.Read(b.buf[len(b.buf):cap(b.buf)])
+	}
+
+	b.buf = b.buf[0 : len(b.buf)+m]
+	n = int64(m)
+
+	// Not enough space anywhere, we need to allocate.
+	if l == m {
 		b.copy(MinRead)
 	}
 
-	for {
-		if first == false {
-			if free := cap(b.buf) - len(b.buf); free < MinRead {
-				// not enough space at end
-				if b.off+free < MinRead {
-					// not enough space using beginning of buffer;
-					// double buffer capacity
-					b.copy(MinRead)
-				} else {
-					b.copy(0)
-				}
-			}
-		}
-
-		l := cap(b.buf) - len(b.buf)
-
-		if conn != nil {
-			if first {
-				// TODO: support configure
-				conn.SetReadDeadline(time.Now().Add(ConnReadTimeout))
-			} else {
-				conn.SetReadDeadline(time.Now().Add(10 * time.Millisecond))
-			}
-
-			m, e = r.Read(b.buf[len(b.buf):cap(b.buf)])
-
-			// Reset read deadline
-			conn.SetReadDeadline(zeroTime)
-
-		} else {
-			m, e = r.Read(b.buf[len(b.buf):cap(b.buf)])
-		}
-
-		if m > 0 {
-			b.buf = b.buf[0 : len(b.buf)+m]
-			n += int64(m)
-		}
-
-		if e != nil {
-			if te, ok := e.(net.Error); ok && te.Timeout() && !first {
-				return n, nil
-			}
-			return n, e
-		}
-
-		if l != m {
-			loop = false
-		}
-
-		if n > MaxRead {
-			loop = false
-		}
-
-		if !loop {
-			break
-		}
-
-		first = false
-	}
-
-	return n, nil
+	return n, err
 }
 
 func (b *IoBuffer) ReadFrom(r io.Reader) (n int64, err error) {
@@ -424,7 +383,17 @@ func (b *IoBuffer) copy(expand int) {
 	var bufp *[]byte
 
 	if expand > 0 {
-		bufp = b.makeSlice(2*cap(b.buf) + expand)
+		cap := cap(b.buf)
+		// when buf cap greater than MaxThreshold, start Slow Grow.
+		if cap < 2*MinRead {
+			cap = 2 * MinRead
+		} else if cap < MaxThreshold {
+			cap = 2 * cap
+		} else {
+			cap = cap + cap/4
+		}
+
+		bufp = b.makeSlice(cap)
 		newBuf = *bufp
 		copy(newBuf, b.buf[b.off:])
 		PutBytes(b.b)

--- a/pkg/buffer/iobuffer_test.go
+++ b/pkg/buffer/iobuffer_test.go
@@ -243,7 +243,7 @@ func TestIoBufferReadOnce(t *testing.T) {
 	}
 	// expand buf
 	if b.Cap() != MinRead<<2 {
-		t.Errorf("Expect %d bytes but got %d", 1<<minShift, b.Cap())
+		t.Errorf("Expect %d bytes but got %d", MinRead<<2, b.Cap())
 	}
 
 	// third read  bsize - MinRead<<1
@@ -256,7 +256,7 @@ func TestIoBufferReadOnce(t *testing.T) {
 	}
 	// not expand buf
 	if b.Cap() != MinRead<<2 {
-		t.Errorf("Expect %d bytes but got %d", 1<<minShift, b.Cap())
+		t.Errorf("Expect %d bytes but got %d", MinRead<<2, b.Cap())
 	}
 	if !bytes.Equal(b.Bytes(), []byte(s)) {
 		t.Errorf("Expect got %s but got %s", s, b.Bytes())


### PR DESCRIPTION
### Issues associated with this PR
It can cause a mem-leak  when it requests a large amount of data.

### Solutions
A. buf multiplexing logic, which triggers recycling when the reusable space is no less than the free space.
B. buf expansion logic, adopt the method of segmentally slow start expansion (minimum according to 1k allocation, more than 1k and less than 4M increase at twice the speed, more than 4M increase at 1.5 times the speed).
C. Buf recovery logic. After the data on the buf is consumed, if the total size of the free buf exceeds 1M, it will be quickly recovered and the 128k buf will be pre-allocated for the next use.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
