### PR TITLE
stop healthchecking when removing cluster from ClusterManager

### DIFF
--- a/pkg/types/upstream.go
+++ b/pkg/types/upstream.go
@@ -101,6 +101,9 @@ type Cluster interface {
 
 	// Add health check callbacks in health checker
 	AddHealthCheckCallbacks(cb HealthCheckCb)
+
+	// Shutdown the healthcheck routine, if exists
+	StopHealthChecking()
 }
 
 // HostPredicate checks wether the host is matched the metadata

--- a/pkg/upstream/cluster/cluster.go
+++ b/pkg/upstream/cluster/cluster.go
@@ -134,6 +134,12 @@ func (sc *simpleCluster) AddHealthCheckCallbacks(cb types.HealthCheckCb) {
 	}
 }
 
+func (sc *simpleCluster) StopHealthChecking() {
+	if sc.healthChecker != nil {
+		sc.healthChecker.Stop()
+	}
+}
+
 type clusterInfo struct {
 	name                 string
 	clusterType          v2.ClusterType

--- a/pkg/upstream/cluster/cluster_manager.go
+++ b/pkg/upstream/cluster/cluster_manager.go
@@ -155,6 +155,14 @@ func (cm *clusterManager) RemovePrimaryCluster(clusterNames ...string) error {
 	}
 	// delete all of them
 	for _, clusterName := range clusterNames {
+		v, ok := cm.clustersMap.Load(clusterName)
+		if !ok {
+			// In theory there's still a chance that cluster was just removed by another routine after the upper for-loop check.
+			continue
+		}
+		c := v.(types.Cluster)
+		c.StopHealthChecking()
+
 		cm.clustersMap.Delete(clusterName)
 		store.RemoveClusterConfig(clusterName)
 		if log.DefaultLogger.GetLogLevel() >= log.INFO {


### PR DESCRIPTION
- add `StopHealthChecking()` interface and implementation for `Cluster`
- invoke it when removing cluster