### PR TITLE
auto detect os system for transfer_path.sh

### DIFF
--- a/transfer_path.sh
+++ b/transfer_path.sh
@@ -5,10 +5,23 @@ GREPSTR="grep sofastack.io/sofa-mosn -rl"
 CODES=("./pkg/" "./examples/codes/" "./test/" "./cmd/")
 # valid for MacOS (Drawin)
 # if you run the script in MacOS, you should use this one
-SED_CMD="sed -i ''"
+#SED_CMD="sed -i ''"
 # valid for Linux
 # if you run the script in Linux, you should use this one
 #SED_CMD="sed -i"
+
+# auto detect system
+SYSTEM=`uname -s`
+
+# valid for Linux
+OS="Linux"
+SED_CMD="sed -i"
+
+# valid for MacOS (Drawin)
+if [ $SYSTEM = "Darwin" ] ; then
+	OS="Darwin"
+	SED_CMD="sed -i ''"
+fi
 
 for CODE in "${CODES[@]}"
 do


### PR DESCRIPTION
### Issues associated with this PR

support both Linux and OSX for transfer_path.sh

### Solutions

add auto detect system code for support both Linux and OSX 

### UT result


### Benchmark


### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
