### PR TITLE
fix upstream appendheader to upstream query string lost

### DIFF
--- a/pkg/stream/http2/stream.go
+++ b/pkg/stream/http2/stream.go
@@ -763,7 +763,7 @@ func (s *clientStream) AppendHeaders(ctx context.Context, headersIn api.HeaderMa
 	if path, ok := headersIn.Get(protocol.MosnHeaderPathKey); ok {
 		headersIn.Del(protocol.MosnHeaderPathKey)
 		if query != "" {
-			URI := fmt.Sprintf(scheme+"://%s%s?", req.Host, path, query)
+			URI := fmt.Sprintf(scheme+"://%s%s?%s", req.Host, path, query)
 			URL, _ = url.Parse(URI)
 		} else {
 			URI := fmt.Sprintf(scheme+"://%s%s", req.Host, path)


### PR DESCRIPTION
### Issues associated with this PR

#1030

### config

```json
"listeners":[
    {
        "name":"serverListener",
        "address": "127.0.0.1:2046",
        "bind_port": true,
        "filter_chains": [{
            "filters": [
                {
                    "type": "proxy",
                    "config": {
                        "downstream_protocol": "Http2",
                        "upstream_protocol": "Http1",
                        "router_config_name":"server_router"
                    }
                }
            ]
        }]
    },
    {
        "name":"clientListener",
        "address": "127.0.0.1:2045",
        "bind_port": true,
        "filter_chains": [{
            "filters": [
                {
                    "type": "proxy",
                    "config": {
                        "downstream_protocol": "Http1",
                        "upstream_protocol": "Http2",
                        "router_config_name":"client_router"
                    }
                }
            ]
        }]
    }
]
```

### request

if `curl "http://localhost:2045/aabb?aa=123"` mosn will be return 400 http code, and print `parse query parameters error,parameters = %!(EXTRA string=aa=123)`

### solution

upstream's AppendHeaders function format URI error, because lost query placeholder.
