### PR TITLE
bugfix(route): fix isito virtual host method matching not working

### DIFF
--- a/pkg/router/configutility.go
+++ b/pkg/router/configutility.go
@@ -18,6 +18,7 @@
 package router
 
 import (
+	"mosn.io/mosn/pkg/protocol"
 	"regexp"
 	"sort"
 
@@ -42,6 +43,10 @@ func (cu *configUtility) MatchHeaders(requestHeaders api.HeaderMap, configHeader
 	for _, cfgHeaderData := range configHeaders {
 		cfgName := cfgHeaderData.Name.Get()
 		cfgValue := cfgHeaderData.Value
+		if cfgName == "method" {
+			cfgName = protocol.MosnHeaderMethod
+		}
+
 		// if a condition is not matched, return false
 		// all condition matched, return true
 		value, ok := requestHeaders.Get(cfgName)


### PR DESCRIPTION
### Issues associated with this PR

#1088 

### Solutions
check tcp http routing params work normally in MOSN
1. tcp routing params seems work normally in Istio 1.4.6, 1.5.1 is pending to be confirmed
1. found http method param not working normally in 1.4.6, fix in the first commit, other params is pending to be confirmed
1. maybe it's possible to use consistent hash to speed up matching route params, and maybe time complexity and space complexity should be considered and benchmark testing should be done when using consistent hash 

### UT result
on the way

### Benchmark
on the way

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
