### PR TITLE
optimize lb healthy host

### DIFF
--- a/pkg/types/upstream.go
+++ b/pkg/types/upstream.go
@@ -113,9 +113,6 @@ type HostPredicate func(Host) bool
 type HostSet interface {
 	// Hosts returns all hosts that make up the set at the current time.
 	Hosts() []Host
-
-	// HealthyHosts returns all healthy hosts
-	HealthyHosts() []Host
 }
 
 // Host is an upstream host

--- a/pkg/upstream/cluster/benchmark_test.go
+++ b/pkg/upstream/cluster/benchmark_test.go
@@ -31,92 +31,6 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
-// BenchmarkHostSetRefresh test host heatlthy state changed
-func BenchmarkHostSetRefresh(b *testing.B) {
-	subsetKeys := [][]string{
-		[]string{"zone", "version"},
-		[]string{"zone"},
-	}
-	createHostSet := func(m map[int]api.Metadata) *hostSet {
-		count := 0
-		for cnt := range m {
-			count += cnt
-		}
-		pool := makePool(count)
-		totalHosts := make([]types.Host, 0, count)
-		for cnt, meta := range m {
-			totalHosts = append(totalHosts, pool.MakeHosts(cnt, meta)...)
-		}
-		hs := &hostSet{}
-		hs.setFinalHost(totalHosts)
-		for _, meta := range m {
-			for _, keys := range subsetKeys {
-				kvs := ExtractSubsetMetadata(keys, meta)
-				hs.createSubset(func(h types.Host) bool {
-					return HostMatches(kvs, h)
-				})
-			}
-		}
-		return hs
-	}
-	b.Run("RefreshSimple100", func(b *testing.B) {
-		config := map[int]api.Metadata{
-			100: nil,
-		}
-		hs := createHostSet(config)
-		host := hs.Hosts()[50]
-		for i := 0; i < b.N; i++ {
-			if i%2 == 0 {
-				host.SetHealthFlag(api.FAILED_ACTIVE_HC)
-			} else {
-				host.ClearHealthFlag(api.FAILED_ACTIVE_HC)
-			}
-			hs.refreshHealthHost(host)
-		}
-	})
-	b.Run("RefreshSimple1000", func(b *testing.B) {
-		config := map[int]api.Metadata{
-			1000: nil,
-		}
-		hs := createHostSet(config)
-		host := hs.Hosts()[500]
-		for i := 0; i < b.N; i++ {
-			if i%2 == 0 {
-				host.SetHealthFlag(api.FAILED_ACTIVE_HC)
-			} else {
-				host.ClearHealthFlag(api.FAILED_ACTIVE_HC)
-			}
-			hs.refreshHealthHost(host)
-		}
-	})
-	b.Run("RefreshMeta1000", func(b *testing.B) {
-		config := map[int]api.Metadata{
-			100: nil,
-			300: api.Metadata{
-				"zone":    "a",
-				"version": "1.0",
-			},
-			400: api.Metadata{
-				"zone":    "a",
-				"version": "2.0",
-			},
-			200: api.Metadata{
-				"zone": "b",
-			},
-		}
-		hs := createHostSet(config)
-		host := hs.Hosts()[150] // zone:a, version:1.0
-		for i := 0; i < b.N; i++ {
-			if i%2 == 0 {
-				host.SetHealthFlag(api.FAILED_ACTIVE_HC)
-			} else {
-				host.ClearHealthFlag(api.FAILED_ACTIVE_HC)
-			}
-			hs.refreshHealthHost(host)
-		}
-	})
-}
-
 func BenchmarkHostConfig(b *testing.B) {
 	host := &simpleHost{
 		hostname:      "Testhost",
@@ -304,6 +218,21 @@ func BenchmarkRandomLB(b *testing.B) {
 	})
 }
 
+func BenchmarkRandomLBWithUnhealthyHost(b *testing.B) {
+	hostSet := &hostSet{}
+	hosts := makePool(10).MakeHosts(10, nil)
+	hostSet.setFinalHost(hosts)
+	lb := newRandomLoadBalancer(hostSet)
+	for i := 0; i < 5; i++ {
+		hosts[i].SetHealthFlag(api.FAILED_ACTIVE_HC)
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			lb.ChooseHost(nil)
+		}
+	})
+}
+
 func BenchmarkRoundRobinLB(b *testing.B) {
 	hostSet := &hostSet{}
 	hosts := makePool(10).MakeHosts(10, nil)
@@ -314,6 +243,22 @@ func BenchmarkRoundRobinLB(b *testing.B) {
 			lb.ChooseHost(nil)
 		}
 	})
+}
+
+func BenchmarkRoundRobinLBWithUnhealthyHost(b *testing.B) {
+	hostSet := &hostSet{}
+	hosts := makePool(10).MakeHosts(10, nil)
+	hostSet.setFinalHost(hosts)
+	lb := rrFactory.newRoundRobinLoadBalancer(hostSet)
+	for i := 0; i < 5; i++ {
+		hosts[i].SetHealthFlag(api.FAILED_OUTLIER_CHECK)
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			lb.ChooseHost(nil)
+		}
+	})
+
 }
 
 func BenchmarkSubsetLB(b *testing.B) {

--- a/pkg/upstream/cluster/cluster.go
+++ b/pkg/upstream/cluster/cluster.go
@@ -84,13 +84,6 @@ func newSimpleCluster(clusterConfig v2.Cluster) *simpleCluster {
 	if clusterConfig.HealthCheck.ServiceName != "" {
 		log.DefaultLogger.Infof("[upstream] [cluster] [new cluster] cluster %s have health check", clusterConfig.Name)
 		cluster.healthChecker = healthcheck.CreateHealthCheck(clusterConfig.HealthCheck)
-		cluster.healthChecker.AddHostCheckCompleteCb(func(host types.Host, changedState bool, isHealthy bool) {
-			if changedState {
-				log.DefaultLogger.Infof("[upstream] [cluster] host %s state change to %v", host.AddressString(), isHealthy)
-				cluster.hostSet.refreshHealthHost(host)
-			}
-		})
-
 	}
 	return cluster
 }

--- a/pkg/upstream/cluster/health.go
+++ b/pkg/upstream/cluster/health.go
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"mosn.io/api"
+)
+
+// health flag resue for same address
+// TODO: use one map for all reuse data
+var healthStore = sync.Map{}
+
+func GetHealthFlagPointer(addr string) *uint64 {
+	v, _ := healthStore.LoadOrStore(addr, func() *uint64 {
+		f := uint64(0)
+		return &f
+	}())
+	p, _ := v.(*uint64)
+	return p
+}
+
+func SetHealthFlag(p *uint64, flag api.HealthFlag) {
+	if p == nil {
+		return
+	}
+	f := atomic.LoadUint64(p)
+	f |= uint64(flag)
+	atomic.StoreUint64(p, f)
+}
+
+func ClearHealthFlag(p *uint64, flag api.HealthFlag) {
+	if p == nil {
+		return
+	}
+	f := atomic.LoadUint64(p)
+	f &= ^uint64(flag)
+	atomic.StoreUint64(p, f)
+}

--- a/pkg/upstream/cluster/health_test.go
+++ b/pkg/upstream/cluster/health_test.go
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"sync"
+	"testing"
+
+	"mosn.io/api"
+)
+
+func TestHealthFlag(t *testing.T) {
+	// clear health store
+	healthStore = sync.Map{}
+	addr := "127.0.0.1:8080"
+	testHost := &simpleHost{
+		healthFlags: GetHealthFlagPointer(addr),
+	}
+	if !testHost.Health() {
+		t.Fatal("default host is not healthy")
+	}
+	testHost.SetHealthFlag(api.FAILED_ACTIVE_HC)
+	if testHost.Health() {
+		t.Fatal("host is healthy, but expected not")
+	}
+	if !testHost.ContainHealthFlag(api.FAILED_ACTIVE_HC) {
+		t.Fatal("host is not contain failed active")
+	}
+	testHost.SetHealthFlag(api.FAILED_OUTLIER_CHECK)
+	if testHost.Health() {
+		t.Fatal("host is healthy, but expected not")
+	}
+	if !testHost.ContainHealthFlag(api.FAILED_OUTLIER_CHECK) {
+		t.Fatal("host is not contain failed outlier")
+	}
+	testHost.ClearHealthFlag(api.FAILED_OUTLIER_CHECK)
+	if testHost.ContainHealthFlag(api.FAILED_OUTLIER_CHECK) {
+		t.Fatal("clear outlier failed")
+	}
+	if testHost.Health() {
+		t.Fatal("host is healthy, but expected not")
+	}
+	testHost.ClearHealthFlag(api.FAILED_ACTIVE_HC)
+	if !testHost.Health() {
+		t.Fatal("host expected healthy, but not")
+	}
+}
+
+func TestHealthFlagShare(t *testing.T) {
+	// clear health store
+	healthStore = sync.Map{}
+
+	addr := "127.0.0.1:8080"
+	testHost := &simpleHost{
+		healthFlags: GetHealthFlagPointer(addr),
+	}
+	testHost2 := &simpleHost{
+		healthFlags: GetHealthFlagPointer(addr),
+	}
+	testHost.SetHealthFlag(api.FAILED_ACTIVE_HC)
+	if testHost2.Health() {
+		t.Fatal("test host2 should be unhealthy")
+	}
+	// concurrency read / set
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+	go func() {
+		for i := 0; i < 100000; i++ {
+			testHost.Health()
+		}
+		wg.Done()
+	}()
+	go func() {
+		for i := 0; i < 100000; i++ {
+			testHost2.SetHealthFlag(api.FAILED_ACTIVE_HC)
+		}
+		wg.Done()
+	}()
+	go func() {
+		for i := 0; i < 100000; i++ {
+			testHost.SetHealthFlag(api.FAILED_OUTLIER_CHECK)
+		}
+		wg.Done()
+	}()
+	wg.Wait()
+}

--- a/pkg/upstream/cluster/host.go
+++ b/pkg/upstream/cluster/host.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"net"
 	"sync"
+	"sync/atomic"
 
 	"mosn.io/api"
 	v2 "mosn.io/mosn/pkg/config/v2"
@@ -38,7 +39,7 @@ type simpleHost struct {
 	metaData      api.Metadata
 	tlsDisable    bool
 	weight        uint32
-	healthFlags   uint64
+	healthFlags   *uint64
 }
 
 func NewSimpleHost(config v2.Host, clusterInfo types.ClusterInfo) types.Host {
@@ -53,6 +54,7 @@ func NewSimpleHost(config v2.Host, clusterInfo types.ClusterInfo) types.Host {
 		metaData:      config.MetaData,
 		tlsDisable:    config.TLSDisable,
 		weight:        config.Weight,
+		healthFlags:   GetHealthFlagPointer(config.Address),
 	}
 }
 
@@ -117,23 +119,23 @@ func (sh *simpleHost) CreateConnection(context context.Context) types.CreateConn
 }
 
 func (sh *simpleHost) ClearHealthFlag(flag api.HealthFlag) {
-	sh.healthFlags &= ^uint64(flag)
+	ClearHealthFlag(sh.healthFlags, flag)
 }
 
 func (sh *simpleHost) ContainHealthFlag(flag api.HealthFlag) bool {
-	return sh.healthFlags&uint64(flag) > 0
+	return atomic.LoadUint64(sh.healthFlags)&uint64(flag) > 0
 }
 
 func (sh *simpleHost) SetHealthFlag(flag api.HealthFlag) {
-	sh.healthFlags |= uint64(flag)
+	SetHealthFlag(sh.healthFlags, flag)
 }
 
 func (sh *simpleHost) HealthFlag() api.HealthFlag {
-	return api.HealthFlag(sh.healthFlags)
+	return api.HealthFlag(atomic.LoadUint64(sh.healthFlags))
 }
 
 func (sh *simpleHost) Health() bool {
-	return sh.healthFlags == 0
+	return atomic.LoadUint64(sh.healthFlags) == 0
 }
 
 // net.Addr reuse for same address, valid in simple type

--- a/pkg/upstream/cluster/host_set.go
+++ b/pkg/upstream/cluster/host_set.go
@@ -29,10 +29,6 @@ type hostSet struct {
 	once     sync.Once
 	mux      sync.RWMutex
 	allHosts []types.Host
-	// if refresh is true, the healthyHosts needs to refresh
-	refresh       bool
-	refreshNotify []func(host types.Host)
-	healthyHosts  []types.Host
 }
 
 // Hosts do not needs lock, becasue it "immutable"
@@ -40,64 +36,18 @@ func (hs *hostSet) Hosts() []types.Host {
 	return hs.allHosts
 }
 
-func (hs *hostSet) HealthyHosts() []types.Host {
-	hs.mux.RLock()
-	defer hs.mux.RUnlock()
-	return hs.healthyHosts
-}
-
-// refresh notify do not needs lock, the createSubset will not be called in concurrency
-// once the refreshNotify slice have been created, it will not be changed
-func (hs *hostSet) addRefreshNotify(f func(host types.Host)) {
-	hs.refreshNotify = append(hs.refreshNotify, f)
-}
-
-func (hs *hostSet) getRefreshNotify() []func(host types.Host) {
-	return hs.refreshNotify
-}
-
-func (hs *hostSet) resetHealthyHosts() {
-	healthyHosts := make([]types.Host, 0, len(hs.allHosts))
-	for _, h := range hs.allHosts {
-		if h.Health() {
-			healthyHosts = append(healthyHosts, h)
-		}
-	}
-	hs.mux.Lock()
-	defer hs.mux.Unlock()
-	hs.healthyHosts = healthyHosts
-
-}
-
-// refreshHealthHost resetHealthyHosts, and send a notify
-func (hs *hostSet) refreshHealthHost(host types.Host) {
-	hs.resetHealthyHosts()
-	// send refresh notify
-	refreshs := hs.getRefreshNotify()
-	for _, refresh := range refreshs {
-		refresh(host)
-	}
-}
-
 func (hs *hostSet) createSubset(predicate types.HostPredicate) types.HostSet {
 	allHosts := hs.Hosts()
 	var subHosts []types.Host
-	var healthyHosts []types.Host
 	for _, h := range allHosts {
 		if predicate(h) {
 			subHosts = append(subHosts, h)
-			if h.Health() {
-				healthyHosts = append(healthyHosts, h)
-			}
 		}
 	}
 	sub := &subHostSet{
-		predicate:    predicate,
-		allHosts:     subHosts,
-		healthyHosts: healthyHosts,
+		predicate: predicate,
+		allHosts:  subHosts,
 	}
-	// register refresh notify
-	hs.addRefreshNotify(sub.refresh)
 	return sub
 }
 
@@ -117,7 +67,6 @@ func (hs *hostSet) setFinalHost(hosts []types.Host) {
 			allHosts = append(allHosts, h)
 		}
 		hs.allHosts = allHosts
-		hs.resetHealthyHosts()
 		if log.DefaultLogger.GetLogLevel() >= log.INFO {
 			log.DefaultLogger.Infof("[upstream] [host set] update host, final host total: %d", len(hs.allHosts))
 		}
@@ -128,39 +77,12 @@ func (hs *hostSet) setFinalHost(hosts []types.Host) {
 // the member and healthy states is sync from hostSet that created it
 // no callbacks can be added in subset hostset
 type subHostSet struct {
-	mux          sync.RWMutex
-	allHosts     []types.Host
-	healthyHosts []types.Host
-	predicate    types.HostPredicate
+	mux       sync.RWMutex
+	allHosts  []types.Host
+	predicate types.HostPredicate
 }
 
 // Hosts do not need lock, because it is "immutable"
 func (sub *subHostSet) Hosts() []types.Host {
 	return sub.allHosts
-}
-
-func (sub *subHostSet) HealthyHosts() []types.Host {
-	sub.mux.RLock()
-	defer sub.mux.RUnlock()
-
-	return sub.healthyHosts
-}
-
-func (sub *subHostSet) resetHealthyHosts() {
-	healthyHosts := make([]types.Host, 0, len(sub.allHosts))
-	for _, h := range sub.allHosts {
-		if h.Health() {
-			healthyHosts = append(healthyHosts, h)
-		}
-	}
-	sub.mux.Lock()
-	defer sub.mux.Unlock()
-	sub.healthyHosts = healthyHosts
-}
-
-func (sub *subHostSet) refresh(host types.Host) {
-	if !sub.predicate(host) {
-		return
-	}
-	sub.resetHealthyHosts()
 }

--- a/pkg/upstream/cluster/host_set_test.go
+++ b/pkg/upstream/cluster/host_set_test.go
@@ -18,7 +18,6 @@
 package cluster
 
 import (
-	"fmt"
 	"testing"
 
 	"mosn.io/api"
@@ -52,68 +51,5 @@ func TestHostSetDistinct(t *testing.T) {
 	hs.setFinalHost(hosts)
 	if len(hs.Hosts()) != 1 {
 		t.Fatal("hostset distinct failed")
-	}
-}
-
-// Test Refresh healthy hosts
-func TestHostSetRefresh(t *testing.T) {
-	hs := &hostSet{}
-	configs := []simpleMockHostConfig{}
-	for i := 10000; i < 10010; i++ {
-		cfg := simpleMockHostConfig{
-			addr:      fmt.Sprintf("127.0.0.1:%d", i),
-			metaValue: "v1",
-		}
-		configs = append(configs, cfg)
-	}
-	for i := 11000; i < 11010; i++ {
-		cfg := simpleMockHostConfig{
-			addr:      fmt.Sprintf("127.0.0.1:%d", i),
-			metaValue: "v2",
-		}
-		configs = append(configs, cfg)
-	}
-	var hosts []types.Host
-	for _, cfg := range configs {
-		h := newSimpleMockHost(cfg.addr, cfg.metaValue)
-		hosts = append(hosts, h)
-	}
-	hs.setFinalHost(hosts)
-	if !(len(hs.allHosts) == len(hs.healthyHosts) &&
-		len(hs.allHosts) == 20) {
-		t.Fatalf("update host set not expected, %v", hs)
-	}
-	// create subset
-	subV1 := hs.createSubset(func(host types.Host) bool {
-		if host.Metadata()["key"] == "v1" {
-			return true
-		}
-		return false
-	})
-	subV2 := hs.createSubset(func(host types.Host) bool {
-		if host.Metadata()["key"] == "v2" {
-			return true
-		}
-		return false
-	})
-	// verify subv1 and subv2
-	if !(len(subV1.Hosts()) == 10 &&
-		len(subV2.Hosts()) == 10) {
-		t.Fatalf("create sub host set failed")
-	}
-	for _, h := range subV1.Hosts() {
-		if h.Metadata()["key"] != "v1" {
-			t.Fatal("sub host set v1 got unepxected host")
-		}
-	}
-	// mock health check set
-	allHosts := hs.Hosts()
-	host := allHosts[5] // mock one host healthy is changed
-	host.SetHealthFlag(api.FAILED_ACTIVE_HC)
-	hs.refreshHealthHost(host)
-	if !(len(hs.HealthyHosts()) == 19 &&
-		len(subV1.HealthyHosts()) == 9 &&
-		len(subV2.HealthyHosts()) == 10) {
-		t.Fatal("health check state changed not expected")
 	}
 }

--- a/pkg/upstream/cluster/lb_register_test.go
+++ b/pkg/upstream/cluster/lb_register_test.go
@@ -36,9 +36,9 @@ type headerLB struct {
 func (lb *headerLB) ChooseHost(ctx types.LoadBalancerContext) types.Host {
 	if headers := ctx.DownstreamHeaders(); headers != nil {
 		if value, ok := headers.Get(lb.key); ok {
-			hosts := lb.hostSet.HealthyHosts()
+			hosts := lb.hostSet.Hosts()
 			for _, h := range hosts {
-				if h.Hostname() == value {
+				if h.Health() && h.Hostname() == value {
 					return h
 				}
 			}

--- a/pkg/upstream/cluster/loadbalancer.go
+++ b/pkg/upstream/cluster/loadbalancer.go
@@ -71,18 +71,19 @@ func newRandomLoadBalancer(hosts types.HostSet) types.LoadBalancer {
 
 func (lb *randomLoadBalancer) ChooseHost(context types.LoadBalancerContext) types.Host {
 	targets := lb.hosts.Hosts()
-	if len(targets) == 0 {
+	total := len(targets)
+	if total == 0 {
 		return nil
 	}
 	lb.mutex.Lock()
 	defer lb.mutex.Unlock()
-	idx := lb.rand.Intn(len(targets))
-	for i := 0; i < len(targets); i++ {
+	idx := lb.rand.Intn(total)
+	for i := 0; i < total; i++ {
 		host := targets[idx]
 		if host.Health() {
 			return host
 		}
-		idx = (idx + 1) % len(targets)
+		idx = (idx + 1) % total
 	}
 	return nil
 }
@@ -121,11 +122,12 @@ func (f *roundRobinLoadBalancerFactory) newRoundRobinLoadBalancer(hosts types.Ho
 
 func (lb *roundRobinLoadBalancer) ChooseHost(context types.LoadBalancerContext) types.Host {
 	targets := lb.hosts.Hosts()
-	if len(targets) == 0 {
+	total := len(targets)
+	if total == 0 {
 		return nil
 	}
-	for i := 0; i < len(targets); i++ {
-		index := atomic.AddUint32(&lb.rrIndex, 1) % uint32(len(targets))
+	for i := 0; i < total; i++ {
+		index := atomic.AddUint32(&lb.rrIndex, 1) % uint32(total)
 		host := targets[index]
 		if host.Health() {
 			return host

--- a/pkg/upstream/cluster/mock_test.go
+++ b/pkg/upstream/cluster/mock_test.go
@@ -20,6 +20,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 
 	"mosn.io/api"
 	"mosn.io/mosn/pkg/network"
@@ -31,7 +32,7 @@ type mockHost struct {
 	name       string
 	addr       string
 	meta       api.Metadata
-	healthFlag uint64
+	healthFlag *uint64
 	types.Host
 }
 
@@ -48,19 +49,28 @@ func (h *mockHost) Metadata() api.Metadata {
 }
 
 func (h *mockHost) Health() bool {
-	return h.healthFlag == 0
+	if h.healthFlag == nil {
+		h.healthFlag = GetHealthFlagPointer(h.addr)
+	}
+	return atomic.LoadUint64(h.healthFlag) == 0
 }
 
 func (h *mockHost) ClearHealthFlag(flag api.HealthFlag) {
-	h.healthFlag &= ^uint64(flag)
+	if h.healthFlag == nil {
+		h.healthFlag = GetHealthFlagPointer(h.addr)
+	}
+	ClearHealthFlag(h.healthFlag, flag)
 }
 
 func (h *mockHost) SetHealthFlag(flag api.HealthFlag) {
-	h.healthFlag |= uint64(flag)
+	if h.healthFlag == nil {
+		h.healthFlag = GetHealthFlagPointer(h.addr)
+	}
+	SetHealthFlag(h.healthFlag, flag)
 }
 
 func (h *mockHost) HealthFlag() api.HealthFlag {
-	return api.HealthFlag(h.healthFlag)
+	return api.HealthFlag(atomic.LoadUint64(h.healthFlag))
 }
 
 type ipPool struct {

--- a/pkg/upstream/cluster/subset_loadbalancer_test.go
+++ b/pkg/upstream/cluster/subset_loadbalancer_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"sync"
 	"testing"
 
 	"mosn.io/api"
@@ -96,6 +97,9 @@ func exampleHostConfigs() (hosts []v2.Host) {
 }
 
 func createHostset(cfg []v2.Host) *hostSet {
+	// clear healthy flag
+	healthStore = sync.Map{}
+	// create
 	var hosts []types.Host
 	for _, h := range cfg {
 		host := &mockHost{


### PR DESCRIPTION
delete healthy hosts, lb use hosts and check wether the host is healthy.

benchmark (new)
```
BenchmarkHostConfig/Host.Config-4          	2000000000	         0.28 ns/op
BenchmarkUpdateClusterHosts/UpdateClusterHost-4         	    3000	    422221 ns/op
BenchmarkClusterManagerRemoveHosts/ClusterRemoveHosts-4 	    2000	   1044833 ns/op
BenchmarkClusterManagerAppendHosts/ClusterManagerAppendHosts-4         	    1000	   1371648 ns/op
BenchmarkRandomLB-4                                                    	10000000	       122 ns/op
BenchmarkRandomLBWithUnhealthyHost-4                                   	10000000	       146 ns/op
BenchmarkRoundRobinLB-4                                                	50000000	        31.3 ns/op
BenchmarkRoundRobinLBWithUnhealthyHost-4                               	30000000	        52.1 ns/op
BenchmarkSubsetLB/CtxZone-4                                            	10000000	       203 ns/op
BenchmarkSubsetLB/CtxZoneAndVersion-4                                  	 5000000	       212 ns/op
BenchmarkSubsetLB/CtxNotMatched-4                                      	10000000	       195 ns/op
```

The odler
```
BenchmarkHostSetRefresh/RefreshSimple100-4         	  500000	      2960 ns/op
BenchmarkHostSetRefresh/RefreshSimple1000-4        	   50000	     29851 ns/op
BenchmarkHostSetRefresh/RefreshMeta1000-4          	   30000	     59985 ns/op
BenchmarkHostConfig/Host.Config-4                  	2000000000	         0.61 ns/op
BenchmarkUpdateClusterHosts/UpdateClusterHost-4    	    3000	    489080 ns/op
BenchmarkClusterManagerRemoveHosts/ClusterRemoveHosts-4         	    2000	   1029225 ns/op
BenchmarkClusterManagerAppendHosts/ClusterManagerAppendHosts-4  	    2000	    993200 ns/op
BenchmarkRandomLB-4                                             	10000000	       163 ns/op
BenchmarkRoundRobinLB-4                                         	20000000	        64.7 ns/op
BenchmarkSubsetLB/CtxZone-4                                     	10000000	       201 ns/op
BenchmarkSubsetLB/CtxZoneAndVersion-4                           	10000000	       225 ns/op
BenchmarkSubsetLB/CtxNotMatched-4                               	10000000	       209 ns/op
```