### PR TITLE
add index field to enhance edf scheduler

### DIFF
--- a/pkg/upstream/cluster/edf_test.go
+++ b/pkg/upstream/cluster/edf_test.go
@@ -24,5 +24,9 @@ func Test(t *testing.T) {
 	assert.Equal(t, A, ele)
 	ele = edfScheduler.NextAndPush(weightFunc)
 	assert.Equal(t, C, ele)
+	ele = edfScheduler.NextAndPush(weightFunc)
+	assert.Equal(t, B, ele)
+	ele = edfScheduler.NextAndPush(weightFunc)
+	assert.Equal(t, A, ele)
 
 }


### PR DESCRIPTION
Add index field to enhance the edf scheduler. When the deadline is the same, the entry added first should has higher priority.