### PR TITLE
fix prometheus flattern key

### DIFF
--- a/pkg/metrics/sink/prometheus/prometheus.go
+++ b/pkg/metrics/sink/prometheus/prometheus.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"bytes"
@@ -289,11 +290,9 @@ func writeFloat(w types.IoBuffer, f float64) (int, error) {
 	}
 }
 
-// name regex [a-zA-Z_:][a-zA-Z0-9_:]*
+// Only [a-zA-Z0-9:_] are valid in metric names, any other characters should be sanitized to an underscore.
+var flattenRegexp = regexp.MustCompile("[^a-zA-Z0-9_:]")
+
 func flattenKey(key string) string {
-	key = strings.Replace(key, " ", "_", -1)
-	key = strings.Replace(key, ".", "_", -1)
-	key = strings.Replace(key, "-", "_", -1)
-	key = strings.Replace(key, "=", "_", -1)
-	return key
+	return flattenRegexp.ReplaceAllString(key, "_")
 }

--- a/pkg/metrics/sink/prometheus/prometheus_test.go
+++ b/pkg/metrics/sink/prometheus/prometheus_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 
@@ -365,4 +366,36 @@ func BenchmarkPromSink_Filter(b *testing.B) {
 		}
 	})
 
+}
+
+func simpleFlattenKey(key string) string {
+	key = strings.Replace(key, " ", "_", -1)
+	key = strings.Replace(key, ".", "_", -1)
+	key = strings.Replace(key, "-", "_", -1)
+	key = strings.Replace(key, "=", "_", -1)
+	return key
+}
+
+func BenchmarkFlattenKey(b *testing.B) {
+	for _, key := range []string{
+		"simple",
+		"dot.replace",
+		"multi.dot.replace",
+		"equal=replace",
+		"blank replace",
+		"minus-replace",
+	} {
+		msg := fmt.Sprintf("benchkey:%s", key)
+		b.Run(msg, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				flattenKey(key)
+			}
+		})
+		replace_msg := fmt.Sprintf("bench_replace:%s", key)
+		b.Run(replace_msg, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				simpleFlattenKey(key)
+			}
+		})
+	}
 }

--- a/pkg/metrics/sink/prometheus/prometheus_test.go
+++ b/pkg/metrics/sink/prometheus/prometheus_test.go
@@ -256,11 +256,20 @@ func TestPrometheusFlatternKey(t *testing.T) {
 			input:  "listener_address:0.0.0.0:9529",
 			output: "listener_address:0_0_0_0:9529",
 		},
+		{
+			input:  "mosn data info=test flattern",
+			output: "mosn_data_info_test_flattern",
+		},
+		{
+			input:  "unexpected@data(1.2.3)",
+			output: "unexpected_data_1_2_3_",
+		},
 	}
 
 	for _, c := range testcase {
-		if flattenKey(c.input) != c.output {
-			t.Error("prometheus flattern key error:", c)
+		out := flattenKey(c.input)
+		if out != c.output {
+			t.Errorf("prometheus flattern key error, got %s, want %s", out, c.output)
 		}
 	}
 }


### PR DESCRIPTION
### Issues associated with this PR

Your PR should present related issues you want to solve.

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, details and the changes. At this time, Chinese is allowed to describe these.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark

#### before
```
BenchmarkPromSink_Flush-4    	       1	1122015271 ns/op
BenchmarkPromSink_Filter/common_flush-4         	      20	 103713589 ns/op
BenchmarkPromSink_Filter/filter_flush-4         	      30	  44465494 ns/op
```
#### now
```
BenchmarkPromSink_Flush-4    	       1	1285629149 ns/op
BenchmarkPromSink_Filter/common_flush-4         	       5	 219520915 ns/op
BenchmarkPromSink_Filter/filter_flush-4         	      30	  51701460 ns/op
BenchmarkFlattenKey/benchkey:simple-4           	 5000000	       314 ns/op
BenchmarkFlattenKey/bench_replace:simple-4      	30000000	        42.2 ns/op
BenchmarkFlattenKey/benchkey:dot.replace-4      	 3000000	       554 ns/op
BenchmarkFlattenKey/bench_replace:dot.replace-4 	20000000	       105 ns/op
BenchmarkFlattenKey/benchkey:multi.dot.replace-4         	 2000000	       859 ns/op
BenchmarkFlattenKey/bench_replace:multi.dot.replace-4    	10000000	       138 ns/op
BenchmarkFlattenKey/benchkey:equal=replace-4             	 3000000	       641 ns/op
BenchmarkFlattenKey/bench_replace:equal=replace-4        	10000000	       123 ns/op
BenchmarkFlattenKey/benchkey:blank_replace-4             	 2000000	       679 ns/op
BenchmarkFlattenKey/bench_replace:blank_replace-4        	10000000	       155 ns/op
BenchmarkFlattenKey/benchkey:minus-replace-4             	 2000000	       760 ns/op
BenchmarkFlattenKey/bench_replace:minus-replace-4        	10000000	       145 ns/op
```



### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
