### PR TITLE
use edf wrr to cover the original smooth wrr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/TarsCloud/TarsGo v0.0.0-20181112071624-2d42457f2025
 	github.com/alibaba/sentinel-golang v0.2.1-0.20200509115140-6d505e23ef30
 	github.com/apache/dubbo-go-hessian2 v1.5.0
-	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae
 	github.com/envoyproxy/go-control-plane v0.8.0
 	github.com/gogo/googleapis v1.2.0 // indirect
@@ -26,8 +25,6 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
-	github.com/prometheus/common v0.6.0 // indirect
-	github.com/prometheus/procfs v0.0.3 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563
 	github.com/stretchr/testify v1.5.1
 	github.com/urfave/cli v1.20.0
@@ -35,7 +32,6 @@ require (
 	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae
-	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64 // indirect
 	google.golang.org/grpc v1.22.1
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/TarsCloud/TarsGo v0.0.0-20181112071624-2d42457f2025
 	github.com/alibaba/sentinel-golang v0.2.1-0.20200509115140-6d505e23ef30
 	github.com/apache/dubbo-go-hessian2 v1.5.0
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae
 	github.com/envoyproxy/go-control-plane v0.8.0
 	github.com/gogo/googleapis v1.2.0 // indirect
@@ -25,6 +26,8 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
+	github.com/prometheus/common v0.6.0 // indirect
+	github.com/prometheus/procfs v0.0.3 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563
 	github.com/stretchr/testify v1.5.1
 	github.com/urfave/cli v1.20.0
@@ -32,6 +35,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae
+	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64 // indirect
 	google.golang.org/grpc v1.22.1
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect

--- a/pkg/upstream/cluster/loadbalancer.go
+++ b/pkg/upstream/cluster/loadbalancer.go
@@ -46,7 +46,7 @@ func init() {
 	}
 	RegisterLBType(types.RoundRobin, rrFactory.newRoundRobinLoadBalancer)
 	RegisterLBType(types.Random, newRandomLoadBalancer)
-	RegisterLBType(types.WeightedRoundRobin, newWeightedRRLoadBalancer)
+	RegisterLBType(types.WeightedRoundRobin, newWRRLoadBalancer)
 	RegisterLBType(types.LeastActiveRequest, newleastActiveRequestLoadBalancer)
 }
 
@@ -155,13 +155,13 @@ func (lb *roundRobinLoadBalancer) HostNum(metadata api.MetadataMatchCriteria) in
  A round robin load balancer. When in weighted mode, EDF scheduling is used. When in not
  weighted mode, simple RR index selection is used.
 */
-type WeightedRRLoadBalancer struct {
+type WRRLoadBalancer struct {
 	*EdfLoadBalancer
 	rrIndex uint32
 }
 
-func newWeightedRRLoadBalancer(info types.ClusterInfo, hosts types.HostSet) types.LoadBalancer {
-	rrLB := &WeightedRRLoadBalancer{
+func newWRRLoadBalancer(info types.ClusterInfo, hosts types.HostSet) types.LoadBalancer {
+	rrLB := &WRRLoadBalancer{
 	}
 	rrLB.EdfLoadBalancer = newEdfLoadBalancerLoadBalancer(hosts, rrLB.unweightChooseHost, rrLB.hostWeight)
 	var idx uint32
@@ -175,20 +175,20 @@ func newWeightedRRLoadBalancer(info types.ClusterInfo, hosts types.HostSet) type
 	return rrLB
 }
 
-func (lb *WeightedRRLoadBalancer) IsExistsHosts(metadata api.MetadataMatchCriteria) bool {
+func (lb *WRRLoadBalancer) IsExistsHosts(metadata api.MetadataMatchCriteria) bool {
 	return len(lb.hosts.Hosts()) > 0
 }
 
-func (lb *WeightedRRLoadBalancer) HostNum(metadata api.MetadataMatchCriteria) int {
+func (lb *WRRLoadBalancer) HostNum(metadata api.MetadataMatchCriteria) int {
 	return len(lb.hosts.Hosts())
 }
 
-func (lb *WeightedRRLoadBalancer) hostWeight(item WeightItem) float64 {
+func (lb *WRRLoadBalancer) hostWeight(item WeightItem) float64 {
 	host := item.(types.Host)
 	return float64(host.Weight())
 }
 // do unweighted (fast) selection
-func (lb *WeightedRRLoadBalancer) unweightChooseHost(context types.LoadBalancerContext) types.Host {
+func (lb *WRRLoadBalancer) unweightChooseHost(context types.LoadBalancerContext) types.Host {
 	targets := lb.hosts.Hosts()
 	total := len(targets)
 	index := atomic.AddUint32(&lb.rrIndex, 1) % uint32(total)

--- a/pkg/upstream/cluster/loadbalancer.go
+++ b/pkg/upstream/cluster/loadbalancer.go
@@ -161,18 +161,16 @@ type WRRLoadBalancer struct {
 }
 
 func newWRRLoadBalancer(info types.ClusterInfo, hosts types.HostSet) types.LoadBalancer {
-	rrLB := &WRRLoadBalancer{
+	wrrLB := &WRRLoadBalancer{
 	}
-	rrLB.EdfLoadBalancer = newEdfLoadBalancerLoadBalancer(hosts, rrLB.unweightChooseHost, rrLB.hostWeight)
-	var idx uint32
+	wrrLB.EdfLoadBalancer = newEdfLoadBalancerLoadBalancer(hosts, wrrLB.unweightChooseHost, wrrLB.hostWeight)
 	hostsList := hosts.Hosts()
-	rrLB.mutex.Lock()
-	defer rrLB.mutex.Unlock()
+	wrrLB.mutex.Lock()
+	defer wrrLB.mutex.Unlock()
 	if len(hostsList) != 0 {
-		idx = rrLB.rand.Uint32() % uint32(len(hostsList))
+		wrrLB.rrIndex = wrrLB.rand.Uint32() % uint32(len(hostsList))
 	}
-	rrLB.rrIndex = idx
-	return rrLB
+	return wrrLB
 }
 
 func (lb *WRRLoadBalancer) IsExistsHosts(metadata api.MetadataMatchCriteria) bool {
@@ -187,6 +185,7 @@ func (lb *WRRLoadBalancer) hostWeight(item WeightItem) float64 {
 	host := item.(types.Host)
 	return float64(host.Weight())
 }
+
 // do unweighted (fast) selection
 func (lb *WRRLoadBalancer) unweightChooseHost(context types.LoadBalancerContext) types.Host {
 	targets := lb.hosts.Hosts()

--- a/pkg/upstream/cluster/loadbalancer_test.go
+++ b/pkg/upstream/cluster/loadbalancer_test.go
@@ -105,7 +105,7 @@ func TestWRRLB(t *testing.T) {
 	// 1:2:3:4
 	hs := &hostSet{}
 	hs.setFinalHost(hosts)
-	lb := newSmoothWeightedRRLoadBalancer(nil, hs)
+	lb := newWeightedRRLoadBalancer(nil, hs)
 	total := 1000000
 	runCase := func(subTotal int) {
 		results := map[string]int{}
@@ -154,7 +154,7 @@ func BenchmarkWRRLbSimple(b *testing.B) {
 	}
 	hs := &hostSet{}
 	hs.setFinalHost(hosts)
-	lb := newSmoothWeightedRRLoadBalancer(nil, hs)
+	lb := newWeightedRRLoadBalancer(nil, hs)
 	b.Run("WRRSimple", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			lb.ChooseHost(nil)
@@ -199,7 +199,7 @@ func BenchmarkWRRLbMultiple(b *testing.B) {
 		}
 		hs := &hostSet{}
 		hs.setFinalHost(hosts)
-		lb := newSmoothWeightedRRLoadBalancer(nil, hs)
+		lb := newWeightedRRLoadBalancer(nil, hs)
 		b.Run(tc.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				lb.ChooseHost(nil)
@@ -244,7 +244,7 @@ func BenchmarkWRRLbParallel(b *testing.B) {
 		}
 		hs := &hostSet{}
 		hs.setFinalHost(hosts)
-		lb := newSmoothWeightedRRLoadBalancer(nil, hs)
+		lb := newWeightedRRLoadBalancer(nil, hs)
 		b.Run(tc.name, func(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {

--- a/pkg/upstream/cluster/loadbalancer_test.go
+++ b/pkg/upstream/cluster/loadbalancer_test.go
@@ -105,7 +105,7 @@ func TestWRRLB(t *testing.T) {
 	// 1:2:3:4
 	hs := &hostSet{}
 	hs.setFinalHost(hosts)
-	lb := newWeightedRRLoadBalancer(nil, hs)
+	lb := newWRRLoadBalancer(nil, hs)
 	total := 1000000
 	runCase := func(subTotal int) {
 		results := map[string]int{}
@@ -154,7 +154,7 @@ func BenchmarkWRRLbSimple(b *testing.B) {
 	}
 	hs := &hostSet{}
 	hs.setFinalHost(hosts)
-	lb := newWeightedRRLoadBalancer(nil, hs)
+	lb := newWRRLoadBalancer(nil, hs)
 	b.Run("WRRSimple", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			lb.ChooseHost(nil)
@@ -199,7 +199,7 @@ func BenchmarkWRRLbMultiple(b *testing.B) {
 		}
 		hs := &hostSet{}
 		hs.setFinalHost(hosts)
-		lb := newWeightedRRLoadBalancer(nil, hs)
+		lb := newWRRLoadBalancer(nil, hs)
 		b.Run(tc.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				lb.ChooseHost(nil)
@@ -244,7 +244,7 @@ func BenchmarkWRRLbParallel(b *testing.B) {
 		}
 		hs := &hostSet{}
 		hs.setFinalHost(hosts)
-		lb := newWeightedRRLoadBalancer(nil, hs)
+		lb := newWRRLoadBalancer(nil, hs)
 		b.Run(tc.name, func(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {


### PR DESCRIPTION
the time complexity of edf schedule wrr is O (logn), better than O (n) of smoothWeightedRR LB.
Relate #1161 
