### PR TITLE
updated dockerfile

### DIFF
--- a/build/contrib/builder/binary/Dockerfile
+++ b/build/contrib/builder/binary/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.7
+FROM golang:1.13.11
 MAINTAINER xiaodong.dxd@alibaba-inc.com,zewen.pzw@alibaba-inc.com,linzhengchun.lzc@alibaba-inc.com
 
 #RUN go get -v github.com/tools/godep

--- a/pkg/module/http2/Dockerfile
+++ b/pkg/module/http2/Dockerfile
@@ -6,7 +6,7 @@
 # Go tests use this curl binary for integration tests.
 #
 
-FROM ubuntu:trusty
+FROM ubuntu:bionc
 
 RUN apt-get update && \
     apt-get upgrade -y && \


### PR DESCRIPTION
### Issues associated with this PR

Updated Ubuntu in dockerfile to bionic (18.04) current trusty (14.04) was end of life April 2019.
Updated golang in dockerfie to 1.13 branch as current 1.12 branch is now eol with release of 1.14
