### PR TITLE
Get proxy global metric in C-friendly format

### DIFF
--- a/pkg/admin/server/apis.go
+++ b/pkg/admin/server/apis.go
@@ -24,8 +24,8 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	gometrics "github.com/rcrowley/go-metrics"
 
+	gometrics "github.com/rcrowley/go-metrics"
 	"mosn.io/mosn/pkg/admin/store"
 	"mosn.io/mosn/pkg/config/v2"
 	"mosn.io/mosn/pkg/featuregate"
@@ -159,7 +159,7 @@ func statsDumpProxyTotal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.DefaultLogger.Infof("[admin api]  [stats dump] stats dump")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	m := metrics.GetProxyTotal()
 	all := ""
 	if m != nil {
@@ -173,8 +173,6 @@ func statsDumpProxyTotal(w http.ResponseWriter, r *http.Request) {
 				h := metric.Snapshot()
 				all += fmt.Sprintf("%s:%s\n", key+"_min", strconv.FormatInt(h.Min(), 10))
 				all += fmt.Sprintf("%s:%s\n", key+"_max", strconv.FormatInt(h.Max(), 10))
-			default:
-				return
 			}
 		})
 	}

--- a/pkg/admin/server/server.go
+++ b/pkg/admin/server/server.go
@@ -43,6 +43,7 @@ func init() {
 	apiHandleFuncStore = map[string]func(http.ResponseWriter, *http.Request){
 		"/api/v1/config_dump":     configDump,
 		"/api/v1/stats":           statsDump,
+		"/api/v1/stats_glob":      statsDumpProxyTotal,
 		"/api/v1/update_loglevel": updateLogLevel,
 		"/api/v1/enable_log":      enableLogger,
 		"/api/v1/disbale_log":     disableLogger,

--- a/pkg/metrics/store.go
+++ b/pkg/metrics/store.go
@@ -198,6 +198,19 @@ func GetAll() (metrics []types.Metrics) {
 	return
 }
 
+// GetProxyTotal returns proxy global metrics data
+func GetProxyTotal() (metrics types.Metrics) {
+	defaultStore.mutex.RLock()
+	defer defaultStore.mutex.RUnlock()
+	for _, m := range defaultStore.metrics {
+		name, _, _ := fullName(m.Type(), m.Labels())
+		if name == "downstream.proxy.global" {
+			return m
+		}
+	}
+	return nil
+}
+
 // ResetAll is only for test and internal usage. DO NOT use this if not sure.
 func ResetAll() {
 	defaultStore.mutex.Lock()


### PR DESCRIPTION
### Issues associated with this PR

Your PR should present related issues you want to solve.

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, details and the changes. At this time, Chinese is allowed to describe these.

Add API /api/v1/stats_glob, which return proxy.global metrics and formatted in a C-friendly way：
```
request_active:0
request_time_total:0
connection_total:0
connection_destroy:0
connection_active:0
bytes_read_total:0
request_total:0
request_failed:0
bytes_write_total:0
request_reset:0
request_time_min:0
request_time_max:0
process_time_min:0
process_time_max:0
process_time_total:0
```
### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
