### PR TITLE
Code improvements: range over append, redundant nil checks etc.

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,15 @@
+version = 1
+
+test_patterns = [
+    "test/**/*.go",
+    "*_test.go",
+    "test_*.go"
+]
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_paths = ["github.com/chsatyap/mosn"]
+  dependencies_vendored = true

--- a/pkg/istio/mixerclient/attribute_compressor.go
+++ b/pkg/istio/mixerclient/attribute_compressor.go
@@ -81,9 +81,7 @@ func (a *AttributeCompressor) Compress(attributes *v1.Attributes, pb *v1.Compres
 	dict := newMessageDictionary(a.globalDict)
 	compressByDict(attributes, dict, pb)
 
-	for _, word := range dict.getWords() {
-		pb.Words = append(pb.Words, word)
-	}
+	pb.Words = append(pb.Words, dict.getWords()...)
 }
 
 // NewBatchCompressor return BatchCompressor
@@ -110,9 +108,7 @@ func (b *batchCompressor) Add(attributes *v1.Attributes) {
 // Finish the batch and create the batched report request
 func (b *batchCompressor) Finish() *v1.ReportRequest {
 	words := b.dict.getWords()
-	for _, word := range words {
-		b.report.DefaultWords = append(b.report.DefaultWords, word)
-	}
+	b.report.DefaultWords = append(b.report.DefaultWords, words...)
 	b.report.GlobalWordCount = uint32(len(b.globalDict.globalDict))
 
 	return &b.report

--- a/pkg/module/http2/mhttp2.go
+++ b/pkg/module/http2/mhttp2.go
@@ -175,14 +175,12 @@ func (ms *MStream) WriteTrailers() error {
 		tramap = *ms.Trailer
 	}
 	var trailers []string
-	if tramap != nil {
-		for k, _ := range tramap {
-			k = http.CanonicalHeaderKey(k)
-			if !httpguts.ValidTrailerHeader(k) {
-				tramap.Del(k)
-			} else {
-				trailers = append(trailers, k)
-			}
+	for k, _ := range tramap {
+		k = http.CanonicalHeaderKey(k)
+		if !httpguts.ValidTrailerHeader(k) {
+			tramap.Del(k)
+		} else {
+			trailers = append(trailers, k)
 		}
 	}
 

--- a/pkg/protocol/xprotocol/dubbo/decoder.go
+++ b/pkg/protocol/xprotocol/dubbo/decoder.go
@@ -106,7 +106,7 @@ func getServiceAwareMeta(ctx context.Context, frame *Frame) (map[string]string, 
 	}
 
 	decoder := decodePool.Get().(*hessian.Decoder)
-	decoder.Reset(frame.payload[:])
+	decoder.Reset(frame.payload)
 
 	// Recycle decode
 	defer decodePool.Put(decoder)

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -426,9 +426,7 @@ func (al *activeListener) OnAccept(rawc net.Conn, useOriginalDst bool, oriRemote
 	arc := newActiveRawConn(rawc, al)
 
 	// listener filter chain.
-	for _, lfcf := range al.listenerFiltersFactories {
-		arc.acceptedFilters = append(arc.acceptedFilters, lfcf)
-	}
+	arc.acceptedFilters = append(arc.acceptedFilters, al.listenerFiltersFactories...)
 
 	if useOriginalDst {
 		arc.useOriginalDst = true

--- a/pkg/upstream/cluster/strict_dns_cluster.go
+++ b/pkg/upstream/cluster/strict_dns_cluster.go
@@ -212,9 +212,7 @@ func (sdc *strictDnsCluster) updateDynamicHosts(newHosts []types.Host, rt *Resol
 	var allHosts []types.Host
 	// collect all hosts in resolve targets
 	for _, r := range sdc.resolveTargets {
-		for _, h := range r.hosts {
-			allHosts = append(allHosts, h)
-		}
+		allHosts = append(allHosts, r.hosts...)
 	}
 
 	// compare current hosts with allHosts

--- a/pkg/xds/conv/convertxds.go
+++ b/pkg/xds/conv/convertxds.go
@@ -1185,7 +1185,7 @@ func convertSubsetSelectors(xdsSubsetSelectors []*xdsapi.Cluster_LbSubsetConfig_
 }
 
 func convertHealthChecks(xdsHealthChecks []*xdscore.HealthCheck) v2.HealthCheck {
-	if xdsHealthChecks == nil || len(xdsHealthChecks) == 0 || xdsHealthChecks[0] == nil {
+	if len(xdsHealthChecks) == 0 || xdsHealthChecks[0] == nil {
 		return v2.HealthCheck{}
 	}
 
@@ -1302,7 +1302,7 @@ func convertTLS(xdsTLSContext interface{}) v2.TLSConfig {
 				config.PrivateKey = cert.GetPrivateKey().GetFilename()
 			}
 		}
-	} else if tlsCertSdsConfig := common.GetTlsCertificateSdsSecretConfigs(); tlsCertSdsConfig != nil && len(tlsCertSdsConfig) > 0 {
+	} else if tlsCertSdsConfig := common.GetTlsCertificateSdsSecretConfigs(); len(tlsCertSdsConfig) > 0 {
 		isSdsMode = true
 		if validationContext, ok := common.GetValidationContextType().(*xdsauth.CommonTlsContext_CombinedValidationContext); ok {
 			config.SdsConfig.CertificateConfig = &v2.SecretConfigWrapper{Config: tlsCertSdsConfig[0]}


### PR DESCRIPTION
This commit introduces general code quality improvements such as -

1. `append()` inside `range` - elements can be added by calling `append()` only once.
2. controller does not enter `range` if the slice is `nil`.
3. `foo` is same as `foo[:]` (in this context)
4. `nil` check is redundant when called with `len` for a slice as `len()` returns 0 for slices that are `nil`.

---
Find the other issues found here - [https://deepsource.io/gh/chsatyap/mosn/issues/?category=all](https://deepsource.io/gh/chsatyap/mosn/issues/?category=all)

This PR also adds `.deepsource.toml` configuration file to run DeepSource analysis on the repo with. Upon enabling DeepSource, the analysis will run on every PR and commit to detect 560+ types of issues in the changes — including bug risks, anti-patterns, security vulnerabilities, etc.

To enable DeepSource analysis after merging this PR, please follow these steps:
1. [Signup](https://deepsource.io/signup/) on DeepSource with your GitHub account and grant access to this repo.
2. Activate analysis on this repo [here](https://deepsource.io/gh/chsatyap/mosn/).
You can also look at the [docs](https://deepsource.io/docs/guides/quickstart.html) for more details. 

Do let me know if I can be of any help!