### PR TITLE
convert static resources to servers and clusters

### DIFF
--- a/pkg/xds/conv/convertxds.go
+++ b/pkg/xds/conv/convertxds.go
@@ -35,6 +35,7 @@ import (
 	xdsroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	xdshttpfault "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/fault/v2"
 	xdshttpgzip "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/gzip/v2"
+	xdshttpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type"
 	xdswellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	jsonp "github.com/golang/protobuf/jsonpb"
@@ -87,6 +88,7 @@ func ConvertListenerConfig(xdsListener *xdsapi.Listener) *v2.Listener {
 		return nil
 	}
 
+	address := convertAddress(xdsListener.Address)
 	listenerConfig := &v2.Listener{
 		ListenerConfig: v2.ListenerConfig{
 			Name:           xdsListener.GetName(),
@@ -94,8 +96,9 @@ func ConvertListenerConfig(xdsListener *xdsapi.Listener) *v2.Listener {
 			UseOriginalDst: xdsListener.GetUseOriginalDst().GetValue(),
 			Inspector:      true,
 			AccessLogs:     convertAccessLogs(xdsListener),
+			AddrConfig:     address.String(),
 		},
-		Addr:                    convertAddress(xdsListener.Address),
+		Addr:                    address,
 		PerConnBufferLimitBytes: xdsListener.GetPerConnectionBufferLimitBytes().GetValue(),
 	}
 
@@ -346,7 +349,7 @@ func convertStreamFilters(networkFilter *xdslistener.Filter) []v2.Filter {
 		filterConfig := GetHTTPConnectionManager(networkFilter)
 
 		for _, filter := range filterConfig.GetHttpFilters() {
-			streamFilter := convertStreamFilter(filter.GetName(), filter.GetTypedConfig())
+			streamFilter := convertStreamFilter(filter.GetName(), filter)
 			if streamFilter.Type != "" {
 				log.DefaultLogger.Debugf("add a new stream filter, %v", streamFilter.Type)
 				filters = append(filters, streamFilter)
@@ -364,16 +367,26 @@ func convertStreamFilters(networkFilter *xdslistener.Filter) []v2.Filter {
 	return filters
 }
 
-func convertStreamFilter(name string, s *any.Any) v2.Filter {
+func convertStreamFilter(name string, xdsfilter *xdshttpconnectionmanagerv2.HttpFilter) v2.Filter {
 	filter := v2.Filter{}
 	var err error
+
+	s := xdsfilter.GetTypedConfig()
 
 	switch name {
 	case v2.MIXER:
 		filter.Type = name
-		filter.Config, err = convertMixerConfig(s)
-		if err != nil {
-			log.DefaultLogger.Errorf("convertMixerConfig error: %v", err)
+		if s == nil {
+			// compatible with old configuration, istio may still use the old configuration
+			filter.Config = make(map[string]interface{})
+			for k, v := range xdsfilter.GetConfig().GetFields() {
+				filter.Config[k] = v
+			}
+		} else {
+			filter.Config, err = convertMixerConfig(s)
+			if err != nil {
+				log.DefaultLogger.Errorf("convertMixerConfig error: %v", err)
+			}
 		}
 	case v2.FaultStream, xdswellknown.Fault:
 		filter.Type = v2.FaultStream

--- a/pkg/xds/conv/convertxds_test.go
+++ b/pkg/xds/conv/convertxds_test.go
@@ -35,6 +35,7 @@ import (
 	xdshttpfault "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/fault/v2"
 	xdshttpgzip "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/gzip/v2"
 	xdshttp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	xdshttpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	xdstcp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type"
 	xdswellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
@@ -696,7 +697,12 @@ func Test_convertStreamFilter_IsitoFault(t *testing.T) {
 		},
 	}
 	for i, tc := range testCases {
-		convertFilter := convertStreamFilter(IstioFault, tc.config)
+		filter := &xdshttpconnectionmanagerv2.HttpFilter{
+			ConfigType: &xdshttpconnectionmanagerv2.HttpFilter_TypedConfig{
+				TypedConfig: tc.config,
+			},
+		}
+		convertFilter := convertStreamFilter(IstioFault, filter)
 		if convertFilter.Type != v2.FaultStream {
 			t.Errorf("#%d convert to mosn stream filter not expected, want %s, got %s", i, v2.FaultStream, convertFilter.Type)
 			continue
@@ -929,7 +935,12 @@ func Test_convertStreamFilter_Gzip(t *testing.T) {
 		},
 	}
 	for i, tc := range testCases {
-		convertFilter := convertStreamFilter(xdswellknown.Gzip, tc.config)
+		filter := &xdshttpconnectionmanagerv2.HttpFilter{
+			ConfigType: &xdshttpconnectionmanagerv2.HttpFilter_TypedConfig{
+				TypedConfig: tc.config,
+			},
+		}
+		convertFilter := convertStreamFilter(xdswellknown.Gzip, filter)
 		if convertFilter.Type != v2.Gzip {
 			t.Errorf("#%d convert to mosn stream filter not expected, want %s, got %s", i, v2.Gzip, convertFilter.Type)
 			continue


### PR DESCRIPTION
为了兼容 istio 里的 https://github.com/istio/istio/blob/a736986dd3b7523300a9bc611d991c586266aa11/mixer/test/client/env/envoy_conf.go#L27 这个 envoy 配置，需要把 static_resources 转换成 mosn 的 server 配置和 cluster 配置。

另外，上面提到的这个配置的版本相对较旧，还需要在 `convertStreamFilter` 这个方法里面做一些兼容。 