### PR TITLE
mtls support hash and update

### DIFF
--- a/pkg/mtls/ciphers.go
+++ b/pkg/mtls/ciphers.go
@@ -1,0 +1,58 @@
+// +build !BabaSSL
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mtls
+
+import (
+	"mosn.io/mosn/pkg/mtls/crypto/tls"
+)
+
+// Ciphers
+var (
+	defaultCiphers = []uint16{
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+	}
+	ciphersMap = map[string]uint16{
+		"ECDHE-ECDSA-AES256-GCM-SHA384":      tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-RSA-AES256-GCM-SHA384":        tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-ECDSA-AES128-GCM-SHA256":      tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-RSA-AES128-GCM-SHA256":        tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-ECDSA-WITH-CHACHA20-POLY1305": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+		"ECDHE-RSA-WITH-CHACHA20-POLY1305":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		"ECDHE-RSA-AES256-CBC-SHA":           tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"ECDHE-RSA-AES128-CBC-SHA":           tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-ECDSA-AES256-CBC-SHA":         tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		"ECDHE-ECDSA-AES128-CBC-SHA":         tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"RSA-AES256-CBC-SHA":                 tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"RSA-AES128-CBC-SHA":                 tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-RSA-3DES-EDE-CBC-SHA":         tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		"RSA-3DES-EDE-CBC-SHA":               tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	}
+)

--- a/pkg/mtls/ciphers_cgo.go
+++ b/pkg/mtls/ciphers_cgo.go
@@ -20,47 +20,8 @@
 package mtls
 
 import (
-	"crypto/x509"
-	"errors"
-
 	"mosn.io/mosn/pkg/mtls/crypto/tls"
 )
-
-// Support Protocols version
-const (
-	minProtocols uint16 = tls.VersionTLS10
-	maxProtocols uint16 = tls.VersionTLS13
-)
-
-// version string map
-var version = map[string]uint16{
-	"tls_auto": 0,
-	"tlsv1_0":  tls.VersionTLS10,
-	"tlsv1_1":  tls.VersionTLS11,
-	"tlsv1_2":  tls.VersionTLS12,
-	"tlsv1_3":  tls.VersionTLS13,
-}
-
-// Curves
-var (
-	defaultCurves = []tls.CurveID{
-		tls.X25519,
-		tls.CurveP256,
-	}
-	allCurves = map[string]tls.CurveID{
-		"x25519": tls.X25519,
-		"p256":   tls.CurveP256,
-		"p384":   tls.CurveP384,
-		"p521":   tls.CurveP521,
-	}
-)
-
-// ALPN
-var alpn = map[string]bool{
-	"h2":       true,
-	"http/1.1": true,
-	"sofa":     true,
-}
 
 // Ciphers
 var (
@@ -97,33 +58,3 @@ var (
 		"TLS_SM4_GCM_SM3":                    tls.TLS_SM4_GCM_SM3,
 	}
 )
-
-// ConfigHooks is a  set of functions used to make a tls config
-type ConfigHooks interface {
-	// GetCertificate returns the tls.Certificate by index.
-	// By default the index is the cert/key file path or cert/key pem string
-	GetCertificate(certIndex, keyIndex string) (tls.Certificate, error)
-	// GetX509Pool returns the x509.CertPool, which is a set of certificates.
-	// By default the index is the ca certificate file path or certificate pem string
-	GetX509Pool(caIndex string) (*x509.CertPool, error)
-	// ServerHandshakeVerify returns a function that used to set "VerifyPeerCertificate" defined in tls.Config.
-	// If it is returns nil, the normal certificate verification will be used.
-	// Notice that we set tls.Config.InsecureSkipVerify to make sure the "VerifyPeerCertificate" is called,
-	// so the ServerHandshakeVerify should verify the trusted ca if necessary.
-	// If the TLSConfig.RequireClientCert is false, the ServerHandshakeVerify will be ignored
-	ServerHandshakeVerify(cfg *tls.Config) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error
-	// ClientHandshakeVerify returns a function that used to set "VerifyPeerCertificate" defined in tls.Config.
-	// If it is returns nil, the normal certificate verification will be used.
-	// Notice that we set tls.Config.InsecureSkipVerify to make sure the "VerifyPeerCertificate" is called,
-	// so the ClientHandshakeVerify should verify the trusted ca if necessary.
-	// If TLSConfig.InsecureSkip is true, the ClientHandshakeVerify will be ignored.
-	ClientHandshakeVerify(cfg *tls.Config) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error
-}
-
-// ConfigHooksFactory creates ConfigHooks by config
-type ConfigHooksFactory interface {
-	CreateConfigHooks(config map[string]interface{}) ConfigHooks
-}
-
-// ErrorNoCertConfigure represents config has no certificate
-var ErrorNoCertConfigure = errors.New("no certificate config")

--- a/pkg/mtls/provider.go
+++ b/pkg/mtls/provider.go
@@ -31,6 +31,7 @@ type staticProvider struct {
 func (p *staticProvider) Ready() bool {
 	return true
 }
+
 func (p *staticProvider) Empty() bool {
 	return p.tlsContext.server == nil
 }

--- a/pkg/mtls/sds/subscriber.go
+++ b/pkg/mtls/sds/subscriber.go
@@ -1,13 +1,13 @@
 package sds
 
 import (
-	"github.com/golang/protobuf/ptypes"
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	v2 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/juju/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -60,13 +60,13 @@ func (subscribe *SdsSubscriber) Start() {
 	for {
 		sdsStreamConfig, err := subscribe.convertSdsConfig(subscribe.sdsConfig)
 		if err != nil {
-			log.DefaultLogger.Alertf("sds.subscribe", "[sds][subscribe] convert sds config fail %v", err)
+			log.DefaultLogger.Alertf("sds.subscribe.config", "[sds][subscribe] convert sds config fail %v", err)
 			time.Sleep(SubscriberRetryPeriod)
 			continue
 		}
 		streamClient, err := subscribe.getSdsStreamClient(sdsStreamConfig)
 		if err != nil {
-			log.DefaultLogger.Alertf("sds.subscribe", "[sds][subscribe] get sds stream client fail %v", err)
+			log.DefaultLogger.Alertf("sds.subscribe.stream", "[sds][subscribe] get sds stream client fail %v", err)
 			time.Sleep(SubscriberRetryPeriod)
 			continue
 		}
@@ -97,7 +97,7 @@ func (subscribe *SdsSubscriber) convertSdsConfig(sdsConfig *core.ConfigSource) (
 		if apiConfig.ApiConfigSource.GetApiType() == core.ApiConfigSource_GRPC {
 			grpcService := apiConfig.ApiConfigSource.GetGrpcServices()
 			if len(grpcService) != 1 {
-				log.DefaultLogger.Alertf("sds.subscribe", "[xds] [sds subscriber] only support one grpc service,but get %v", len(grpcService))
+				log.DefaultLogger.Alertf("sds.subscribe.grpc", "[xds] [sds subscriber] only support one grpc service,but get %v", len(grpcService))
 				return nil, errors.New("unsupport sds config")
 			}
 			if grpcConfig, ok := grpcService[0].TargetSpecifier.(*core.GrpcService_GoogleGrpc_); ok {
@@ -126,7 +126,7 @@ func (subscribe *SdsSubscriber) sendRequestLoop(sdsStreamClient *SdsStreamClient
 			for {
 				err := subscribe.sendRequest(discoveryReq)
 				if err != nil {
-					log.DefaultLogger.Alertf("sds.subscribe", "[xds] [sds subscriber] send sds request fail , resource name = %v", name)
+					log.DefaultLogger.Alertf("sds.subscribe.request", "[xds] [sds subscriber] send sds request fail , resource name = %v", name)
 					time.Sleep(1 * time.Second)
 					subscribe.reconnect()
 					continue
@@ -216,7 +216,7 @@ func (subscribe *SdsSubscriber) reconnect() {
 	for {
 		sdsStreamConfig, err := subscribe.convertSdsConfig(subscribe.sdsConfig)
 		if err != nil {
-			log.DefaultLogger.Alertf("sds.subscribe", "[xds][sds subscriber] convert sds config fail %v", err)
+			log.DefaultLogger.Alertf("sds.subscribe.config", "[xds][sds subscriber] convert sds config fail %v", err)
 			time.Sleep(SubscriberRetryPeriod)
 			continue
 		}

--- a/pkg/mtls/tls_context.go
+++ b/pkg/mtls/tls_context.go
@@ -44,16 +44,16 @@ type tlsContext struct {
 	serverName string
 	ticket     string
 	matches    map[string]struct{}
-	client     *tls.Config
-	server     *tls.Config
+	client     *types.TLSConfigContext
+	server     *types.TLSConfigContext
 }
 
-func (ctx *tlsContext) buildMatch() {
-	if ctx.server == nil {
+func (ctx *tlsContext) buildMatch(tlsConfig *tls.Config) {
+	if tlsConfig == nil {
 		return
 	}
 	matches := make(map[string]struct{})
-	certs := ctx.server.Certificates
+	certs := tlsConfig.Certificates
 	for i := range certs {
 		cert := certs[i]
 		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
@@ -67,7 +67,7 @@ func (ctx *tlsContext) buildMatch() {
 			matches[san] = struct{}{}
 		}
 	}
-	for _, protocol := range ctx.server.NextProtos {
+	for _, protocol := range tlsConfig.NextProtos {
 		matches[protocol] = struct{}{}
 	}
 	matches[ctx.serverName] = struct{}{}
@@ -80,19 +80,12 @@ func (ctx *tlsContext) setServerConfig(tmpl *tls.Config, cfg *v2.TLSConfig, hook
 	if len(tlsConfig.Certificates) == 0 {
 		return
 	}
-	if !cfg.RequireClientCert {
-		tlsConfig.ClientAuth = tls.NoClientCert
-	} else {
-		if cfg.VerifyClient {
-			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-		} else {
-			tlsConfig.ClientAuth = tls.VerifyClientCertIfGiven
-		}
-	}
+	tlsConfig.ClientAuth = hooks.GetClientAuth(cfg)
 	tlsConfig.VerifyPeerCertificate = hooks.ServerHandshakeVerify(tlsConfig)
-	ctx.server = tlsConfig
+
+	ctx.server = types.NewTLSConfigContext(tlsConfig, hooks.GenerateHashValue)
 	// build matches
-	ctx.buildMatch()
+	ctx.buildMatch(tlsConfig)
 }
 
 func (ctx *tlsContext) setClientConfig(tmpl *tls.Config, cfg *v2.TLSConfig, hooks ConfigHooks) {
@@ -107,7 +100,7 @@ func (ctx *tlsContext) setClientConfig(tmpl *tls.Config, cfg *v2.TLSConfig, hook
 		tlsConfig.InsecureSkipVerify = true
 		tlsConfig.VerifyPeerCertificate = nil
 	}
-	ctx.client = tlsConfig
+	ctx.client = types.NewTLSConfigContext(tlsConfig, hooks.GenerateHashValue)
 }
 
 func (ctx *tlsContext) MatchedServerName(sn string) bool {
@@ -140,14 +133,14 @@ func (ctx *tlsContext) MatchedALPN(protos []string) bool {
 	return false
 }
 
-func (ctx *tlsContext) GetTLSConfig(client bool) *tls.Config {
+func (ctx *tlsContext) GetTLSConfigContext(client bool) *types.TLSConfigContext {
 	if client {
-		return ctx.client.Clone()
+		return ctx.client
 	} else {
 		if ctx.server == nil {
 			return nil
 		}
-		return ctx.server.Clone()
+		return ctx.server
 	}
 }
 

--- a/pkg/mtls/tls_context_test.go
+++ b/pkg/mtls/tls_context_test.go
@@ -22,6 +22,7 @@ import (
 
 	"mosn.io/mosn/pkg/config/v2"
 	"mosn.io/mosn/pkg/mtls/crypto/tls"
+	"mosn.io/mosn/pkg/types"
 )
 
 func TestTLSContext(t *testing.T) {
@@ -57,11 +58,11 @@ func TestTLSContext(t *testing.T) {
 			t.Errorf("%s not in context", m)
 		}
 	}
-	if ctx.client.InsecureSkipVerify {
+	if ctx.client.Config().InsecureSkipVerify {
 		t.Errorf("client certificate should verify the server")
 	}
-	if ctx.server.ClientAuth != tls.VerifyClientCertIfGiven {
-		t.Errorf("server client auth is %v", ctx.server.ClientAuth)
+	if ctx.server.Config().ClientAuth != tls.RequestClientCert {
+		t.Errorf("server client auth is %v", ctx.server.Config().ClientAuth)
 	}
 }
 
@@ -75,10 +76,10 @@ func TestTLSContextNoCert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create tls context failed, %v", err)
 	}
-	if ctx.GetTLSConfig(false) != nil {
+	if ctx.GetTLSConfigContext(false) != nil {
 		t.Error("context should not contains a server side config")
 	}
-	if ctx.GetTLSConfig(true) == nil {
+	if ctx.GetTLSConfigContext(true) == nil {
 		t.Error("context contains a client side config")
 	}
 }
@@ -120,4 +121,68 @@ func TestTLSContextMatch(t *testing.T) {
 		t.Error("protos matched failed")
 	}
 
+}
+
+func TestTLSContextHash(t *testing.T) {
+	info := &certInfo{
+		CommonName: "test",
+		Curve:      "RSA",
+	}
+	secret, _ := info.CreateSecret()
+	cfg := &v2.TLSConfig{
+		Status:            true,
+		CipherSuites:      "ECDHE-ECDSA-AES256-GCM-SHA384:RSA-3DES-EDE-CBC-SHA",
+		RequireClientCert: true,
+	}
+	createHash := func(cfg *v2.TLSConfig) (*types.HashValue, *types.HashValue) {
+		ctx, err := newTLSContext(cfg, secret)
+		if err != nil {
+			t.Fatalf("create tls context failed, %v", err)
+		}
+		return ctx.GetTLSConfigContext(true).HashValue(),
+			ctx.GetTLSConfigContext(false).HashValue()
+	}
+	c1, s1 := createHash(cfg)
+	c2, s2 := createHash(cfg)
+	if !(!c1.Equal(s1) &&
+		c1.Equal(c2) &&
+		s1.Equal(s2)) {
+		t.Fatalf("config no changed, but hash value changed %s : %s, %s : %s \n", c1, c2, s1, s2)
+	}
+	// ClientAuth changed, client hash do not changed, server hash changed
+	cfg2 := &v2.TLSConfig{
+		Status:            true,
+		CipherSuites:      "ECDHE-ECDSA-AES256-GCM-SHA384:RSA-3DES-EDE-CBC-SHA",
+		RequireClientCert: true,
+		VerifyClient:      true,
+	}
+	c3, s3 := createHash(cfg2)
+	if !c3.Equal(c1) ||
+		s3.Equal(s1) {
+		t.Fatalf("hash value is not expected, %s : %s, %s : %s\n", c3, c1, s3, s1)
+	}
+	// CipherSuites changed, hash should be changed
+	cfg3 := &v2.TLSConfig{
+		Status:            true,
+		CipherSuites:      "RSA-3DES-EDE-CBC-SHA:ECDHE-ECDSA-AES256-GCM-SHA384",
+		RequireClientCert: true,
+	}
+	c4, s4 := createHash(cfg3)
+	if c4.Equal(c1) || s4.Equal(s1) {
+		t.Fatalf("hash value is not expected, %s : %s, %s : %s\n", c4, c1, s4, s1)
+	}
+}
+
+func TestTLSContextHashNil(t *testing.T) {
+	cfg := &v2.TLSConfig{
+		Status: false,
+	}
+	cltMng, err := NewTLSClientContextManager(cfg)
+	if err != nil {
+		t.Fatalf("new client manager failed: %v", err)
+	}
+	hash := cltMng.HashValue()
+	if !hash.Equal(nil) {
+		t.Fatalf("disabled client manager cannot returns a hash value")
+	}
 }

--- a/pkg/mtls/types.go
+++ b/pkg/mtls/types.go
@@ -23,7 +23,9 @@ import (
 	"crypto/x509"
 	"errors"
 
+	"mosn.io/mosn/pkg/config/v2"
 	"mosn.io/mosn/pkg/mtls/crypto/tls"
+	"mosn.io/mosn/pkg/types"
 )
 
 // Support Protocols version
@@ -62,42 +64,10 @@ var alpn = map[string]bool{
 	"sofa":     true,
 }
 
-// Ciphers
-var (
-	defaultCiphers = []uint16{
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-	}
-	ciphersMap = map[string]uint16{
-		"ECDHE-ECDSA-AES256-GCM-SHA384":      tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		"ECDHE-RSA-AES256-GCM-SHA384":        tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		"ECDHE-ECDSA-AES128-GCM-SHA256":      tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		"ECDHE-RSA-AES128-GCM-SHA256":        tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		"ECDHE-ECDSA-WITH-CHACHA20-POLY1305": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-		"ECDHE-RSA-WITH-CHACHA20-POLY1305":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-		"ECDHE-RSA-AES256-CBC-SHA":           tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-		"ECDHE-RSA-AES128-CBC-SHA":           tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-		"ECDHE-ECDSA-AES256-CBC-SHA":         tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-		"ECDHE-ECDSA-AES128-CBC-SHA":         tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-		"RSA-AES256-CBC-SHA":                 tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-		"RSA-AES128-CBC-SHA":                 tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-		"ECDHE-RSA-3DES-EDE-CBC-SHA":         tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
-		"RSA-3DES-EDE-CBC-SHA":               tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
-	}
-)
-
 // ConfigHooks is a  set of functions used to make a tls config
 type ConfigHooks interface {
+	// GetClientAuth sets the tls.Config's ClientAuth fields
+	GetClientAuth(cfg *v2.TLSConfig) tls.ClientAuthType
 	// GetCertificate returns the tls.Certificate by index.
 	// By default the index is the cert/key file path or cert/key pem string
 	GetCertificate(certIndex, keyIndex string) (tls.Certificate, error)
@@ -116,6 +86,8 @@ type ConfigHooks interface {
 	// so the ClientHandshakeVerify should verify the trusted ca if necessary.
 	// If TLSConfig.InsecureSkip is true, the ClientHandshakeVerify will be ignored.
 	ClientHandshakeVerify(cfg *tls.Config) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error
+	// GenerateHashValue creates a hash value based on the tls.Config
+	GenerateHashValue(cfg *tls.Config) *types.HashValue
 }
 
 // ConfigHooksFactory creates ConfigHooks by config

--- a/pkg/stream/http/connpool.go
+++ b/pkg/stream/http/connpool.go
@@ -44,6 +44,7 @@ type connPool struct {
 	MaxConn int
 
 	host       atomic.Value
+	tlsHash    *types.HashValue
 	supportTLS bool
 
 	statReport bool
@@ -55,7 +56,7 @@ type connPool struct {
 
 func NewConnPool(host types.Host) types.ConnectionPool {
 	pool := &connPool{
-		supportTLS: host.SupportTLS(),
+		tlsHash: host.TLSHashValue(),
 	}
 	pool.host.Store(host)
 
@@ -66,8 +67,8 @@ func NewConnPool(host types.Host) types.ConnectionPool {
 	return pool
 }
 
-func (p *connPool) SupportTLS() bool {
-	return p.supportTLS
+func (p *connPool) TLSHashValue() *types.HashValue {
+	return p.tlsHash
 }
 
 func (p *connPool) Protocol() types.ProtocolName {

--- a/pkg/stream/http2/connpool.go
+++ b/pkg/stream/http2/connpool.go
@@ -42,7 +42,7 @@ func init() {
 type connPool struct {
 	activeClient *activeClient
 	host         atomic.Value
-	supportTLS   bool
+	tlsHash      *types.HashValue
 
 	mux sync.Mutex
 }
@@ -50,14 +50,14 @@ type connPool struct {
 // NewConnPool
 func NewConnPool(host types.Host) types.ConnectionPool {
 	pool := &connPool{
-		supportTLS: host.SupportTLS(),
+		tlsHash: host.TLSHashValue(),
 	}
 	pool.host.Store(host)
 	return pool
 }
 
-func (p *connPool) SupportTLS() bool {
-	return p.supportTLS
+func (p *connPool) TLSHashValue() *types.HashValue {
+	return p.tlsHash
 }
 
 func (p *connPool) Protocol() types.ProtocolName {

--- a/pkg/stream/xprotocol/connpool.go
+++ b/pkg/stream/xprotocol/connpool.go
@@ -53,20 +53,20 @@ type connPool struct {
 	activeClients sync.Map //sub protocol -> activeClient
 	host          atomic.Value
 	mux           sync.Mutex
-	supportTLS    bool
+	tlsHash       *types.HashValue
 }
 
 // NewConnPool
 func NewConnPool(host types.Host) types.ConnectionPool {
 	p := &connPool{
-		supportTLS: host.SupportTLS(),
+		tlsHash: host.TLSHashValue(),
 	}
 	p.host.Store(host)
 	return p
 }
 
-func (p *connPool) SupportTLS() bool {
-	return p.supportTLS
+func (p *connPool) TLSHashValue() *types.HashValue {
+	return p.tlsHash
 }
 
 func (p *connPool) init(client *activeClient, sub types.ProtocolName) {

--- a/pkg/types/stream.go
+++ b/pkg/types/stream.go
@@ -240,8 +240,9 @@ type ConnectionPool interface {
 	// check host health and init host
 	CheckAndInit(ctx context.Context) bool
 
-	// SupportTLS represents the connection support tls or not
-	SupportTLS() bool
+	// TLSHashValue returns the TLS Config's HashValue.
+	// If HashValue is changed, the connection pool will changed.
+	TLSHashValue() *HashValue
 
 	// Shutdown gracefully shuts down the connection pool without interrupting any active requests
 	Shutdown()

--- a/pkg/types/tls_test.go
+++ b/pkg/types/tls_test.go
@@ -51,13 +51,13 @@ func BenchmarkHashValue(b *testing.B) {
 	hash2 := NewHashValue(sha256.Sum256(data))
 	b.Run("hash_equal", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			hash1.Equal(hash2)
+			_ = hash1.Equal(hash2)
 		}
 	})
 	// bench string
 	b.Run("hash_string", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			hash1.String()
+			_ = hash1.String()
 		}
 	})
 }

--- a/pkg/types/tls_test.go
+++ b/pkg/types/tls_test.go
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+import (
+	"crypto/sha256"
+	"testing"
+)
+
+func TestHashValue(t *testing.T) {
+	data := []byte("123456")
+	hash1 := NewHashValue(sha256.Sum256(data))
+	hash2 := NewHashValue(sha256.Sum256(data))
+	// same hash value compare
+	if !hash1.Equal(hash2) {
+		t.Fatalf("same data got different hash value %s: %s\n", hash1, hash2)
+	}
+	hash3 := NewHashValue(sha256.Sum256([]byte("1234567")))
+	// different hash value compare
+	if hash1.Equal(hash3) {
+		t.Fatalf("different data got same hash value %s: %s", hash1, hash3)
+	}
+	// empty hash value compare
+	var empty *HashValue
+	if !empty.Equal(nil) {
+		t.Fatal("empty hash compare failed")
+	}
+	if hash1.Equal(empty) {
+		t.Fatal("hash value equals to nil")
+	}
+}
+
+func BenchmarkHashValue(b *testing.B) {
+	data := []byte("123456")
+	hash1 := NewHashValue(sha256.Sum256(data))
+	hash2 := NewHashValue(sha256.Sum256(data))
+	b.Run("hash_equal", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			hash1.Equal(hash2)
+		}
+	})
+	// bench string
+	b.Run("hash_string", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			hash1.String()
+		}
+	})
+}

--- a/pkg/types/upstream.go
+++ b/pkg/types/upstream.go
@@ -41,6 +41,9 @@ type ClusterManager interface {
 	// Add Cluster health check callbacks
 	AddClusterHealthCheckCallbacks(name string, cb HealthCheckCb) error
 
+	// GetAllClusters returns all cluster name in the cluster manager
+	GetAllClusters() []string
+
 	// Get, use to get the snapshot of a cluster
 	GetClusterSnapshot(context context.Context, cluster string) ClusterSnapshot
 
@@ -124,7 +127,11 @@ type Host interface {
 
 	// ClusterInfo returns the cluster info
 	ClusterInfo() ClusterInfo
+	// SetClusterInfo updates the host's cluster info
+	SetClusterInfo(info ClusterInfo)
 
+	// TLS HashValue effects the host support tls state
+	TLSHashValue() *HashValue
 	// Create a connection for this host.
 	CreateConnection(context context.Context) CreateConnectionData
 

--- a/pkg/upstream/cluster/cluster_manager.go
+++ b/pkg/upstream/cluster/cluster_manager.go
@@ -106,7 +106,7 @@ func NewClusterManagerSingleton(clusters []v2.Cluster, clusterMap map[string][]v
 }
 
 // AddOrUpdatePrimaryCluster will always create a new cluster without the hosts config
-// if the same name cluster is already exists, we will keep the exists hosts, and use rcu to update it.
+// if the same name cluster is already exists, we will keep the exists hosts.
 func (cm *clusterManager) AddOrUpdatePrimaryCluster(cluster v2.Cluster) error {
 	// new cluster
 	newCluster := NewCluster(cluster)
@@ -134,6 +134,9 @@ func (cm *clusterManager) AddOrUpdatePrimaryCluster(cluster v2.Cluster) error {
 
 		// sync newResourceManager value to oldResourceManager value
 		updateResourceValue(oldResourceManager, newResourceManager)
+		for _, host := range hosts {
+			host.SetClusterInfo(newSnap.ClusterInfo()) // update host cluster info
+		}
 
 		// update hosts, refresh
 		newCluster.UpdateHosts(hosts)
@@ -254,8 +257,17 @@ func (cm *clusterManager) RemoveClusterHosts(clusterName string, addrs []string)
 	return nil
 }
 
+func (cm *clusterManager) GetAllClusters() []string {
+	var names []string
+	cm.clustersMap.Range(func(key, value interface{}) bool {
+		name, _ := key.(string)
+		names = append(names, name)
+		return true
+	})
+	return names
+}
+
 // GetClusterSnapshot returns cluster snap
-// do not needs PutClusterSnapshot any more
 func (cm *clusterManager) GetClusterSnapshot(ctx context.Context, clusterName string) types.ClusterSnapshot {
 	ci, ok := cm.clustersMap.Load(clusterName)
 	if !ok {
@@ -351,7 +363,7 @@ func (cm *clusterManager) getActiveConnectionPool(balancerContext types.LoadBala
 		}
 		pool, loaded := loadOrStoreConnPool()
 		if loaded {
-			if pool.SupportTLS() != host.SupportTLS() {
+			if !pool.TLSHashValue().Equal(host.TLSHashValue()) {
 				if log.DefaultLogger.GetLogLevel() >= log.INFO {
 					log.DefaultLogger.Infof("[upstream] [cluster manager] %s tls state changed", addr)
 				}
@@ -363,7 +375,7 @@ func (cm *clusterManager) getActiveConnectionPool(balancerContext types.LoadBala
 					// recheck whether the pool is changed
 					if connPool, ok := connectionPool.Load(addr); ok {
 						pool = connPool.(types.ConnectionPool)
-						if pool.SupportTLS() == host.SupportTLS() {
+						if pool.TLSHashValue().Equal(host.TLSHashValue()) {
 							return
 						}
 						connectionPool.Delete(addr)

--- a/pkg/upstream/cluster/mock_test.go
+++ b/pkg/upstream/cluster/mock_test.go
@@ -155,8 +155,8 @@ func makePool(size int) *ipPool {
 }
 
 type mockConnPool struct {
-	host       atomic.Value
-	supportTLS bool
+	host      atomic.Value
+	hashvalue *types.HashValue
 	types.ConnectionPool
 }
 
@@ -170,8 +170,8 @@ func (p *mockConnPool) CheckAndInit(ctx context.Context) bool {
 	return true
 }
 
-func (p *mockConnPool) SupportTLS() bool {
-	return p.supportTLS
+func (p *mockConnPool) TLSHashValue() *types.HashValue {
+	return p.hashvalue
 }
 
 func (p *mockConnPool) Shutdown() {
@@ -199,7 +199,7 @@ func (p *mockConnPool) UpdateHost(h types.Host) {
 func init() {
 	network.RegisterNewPoolFactory(mockProtocol, func(h types.Host) types.ConnectionPool {
 		pool := &mockConnPool{
-			supportTLS: h.SupportTLS(),
+			hashvalue: h.TLSHashValue(),
 		}
 		pool.host.Store(h)
 		return pool

--- a/pkg/upstream/cluster/strict_dns_cluster.go
+++ b/pkg/upstream/cluster/strict_dns_cluster.go
@@ -310,13 +310,13 @@ func (rt *ResolveTarget) OnResolve() {
 		host := &simpleHost{
 			hostname:      rt.config.Hostname,
 			addressString: newAddr,
-			clusterInfo:   sdc.info,
 			stats:         stat,
 			metaData:      rt.config.MetaData,
 			tlsDisable:    rt.config.TLSDisable,
 			weight:        rt.config.Weight,
 			healthFlags:   GetHealthFlagPointer(newAddr),
 		}
+		host.clusterInfo.Store(sdc.info)
 		hosts = append(hosts, host)
 		if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
 			log.DefaultLogger.Debugf("[upstream] [strict dns cluster] resolve dns result, address:%s, addr:%s, ttl:%.3f", rt.dnsAddress, newAddr, rsp.Ttl.Seconds())


### PR DESCRIPTION
## tls context
+ Add a new type `HashValue`  to represent tls config in tls context.
   + How to generate HashValue can be extended in `confighook`
+ Update tls config is valid  for sds mode
+ Parse client auth in tls config can be extended in `confighook`

## connection pool
+ connpool changed when tls hash value changed

## cluster manager
+ Add a new api `GetAllClusters`
+ Update cluster config will update the hosts' cluster info 

## benchmark
+ Add update cluster info 
```
BenchmarkAddOrUpdateCluster/update_count:100-4              10000      181294 ns/op     30344 B/op       115 allocs/op
BenchmarkAddOrUpdateCluster/update_count:500-4               5000      409458 ns/op    100307 B/op       127 allocs/op
BenchmarkAddOrUpdateCluster/update_count:1000-4              2000      703845 ns/op    184069 B/op       141 allocs/op
BenchmarkAddOrUpdateCluster/update_count:5000-4               500     2797682 ns/op    768478 B/op       219 allocs/op
BenchmarkAddOrUpdateCluster/update_count:20000-4              100    12816462 ns/op   2974942 B/op       582 allocs/op
```
+ Before

```
BenchmarkAddOrUpdateCluster/update_count:100-4         	   10000	    210924 ns/op	   30343 B/op	     115 allocs/op
BenchmarkAddOrUpdateCluster/update_count:500-4         	    3000	    415557 ns/op	  100287 B/op	     127 allocs/op
BenchmarkAddOrUpdateCluster/update_count:1000-4        	    3000	    663567 ns/op	  184042 B/op	     140 allocs/op
BenchmarkAddOrUpdateCluster/update_count:5000-4        	     500	   2711602 ns/op	  768509 B/op	     219 allocs/op
BenchmarkAddOrUpdateCluster/update_count:20000-4       	     100	  12564153 ns/op	 2974319 B/op	     577 allocs/op
```