### PR TITLE
Bugfix: prefix variable in access log is not working

### DIFF
--- a/pkg/log/accesslog.go
+++ b/pkg/log/accesslog.go
@@ -66,9 +66,8 @@ type accesslog struct {
 }
 
 type logEntry struct {
-	text     string
-	name     string
-	variable variable.Variable
+	text string
+	name string
 }
 
 func (le *logEntry) log(ctx context.Context, buf buffer.IoBuffer) {
@@ -153,14 +152,11 @@ func parseFormat(format string) ([]*logEntry, error) {
 					}
 
 					// var def ends, add variable
-					varEntry, err := variable.AddVariable(format[lastMark+1 : pos])
+					_, err := variable.AddVariable(format[lastMark+1 : pos])
 					if err != nil {
 						return nil, err
 					}
-					entries = append(entries, &logEntry{
-						variable: varEntry,
-						name:     format[lastMark+1 : pos],
-					})
+					entries = append(entries, &logEntry{name: format[lastMark+1 : pos]})
 				} else {
 					// ignore empty text
 					if pos > lastMark+1 {

--- a/pkg/log/accesslog.go
+++ b/pkg/log/accesslog.go
@@ -67,6 +67,7 @@ type accesslog struct {
 
 type logEntry struct {
 	text     string
+	name     string
 	variable variable.Variable
 }
 
@@ -74,7 +75,7 @@ func (le *logEntry) log(ctx context.Context, buf buffer.IoBuffer) {
 	if le.text != "" {
 		buf.WriteString(le.text)
 	} else {
-		value, err := variable.GetVariableValue(ctx, le.variable.Name())
+		value, err := variable.GetVariableValue(ctx, le.name)
 		if err != nil {
 			buf.WriteString(variable.ValueNotFound)
 		} else {
@@ -156,7 +157,10 @@ func parseFormat(format string) ([]*logEntry, error) {
 					if err != nil {
 						return nil, err
 					}
-					entries = append(entries, &logEntry{variable: varEntry})
+					entries = append(entries, &logEntry{
+						variable: varEntry,
+						name:     format[lastMark+1 : pos],
+					})
 				} else {
 					// ignore empty text
 					if pos > lastMark+1 {

--- a/pkg/log/accesslog_test.go
+++ b/pkg/log/accesslog_test.go
@@ -281,11 +281,15 @@ func prepareLocalIpv4Ctx() context.Context {
 		"service": "test",
 	}
 	ctx = context.WithValue(ctx, requestHeaderMapKey, reqHeaders)
+	reqHeaderMap := newHeaderMap(reqHeaders)
+	ctx = context.WithValue(ctx, requestHeaderMapKey, reqHeaderMap)
 
 	respHeaders := map[string]string{
 		"Server": "MOSN",
 	}
 	ctx = context.WithValue(ctx, responseHeaderMapKey, respHeaders)
+	respHeaderMap := newHeaderMap(respHeaders)
+	ctx = context.WithValue(ctx, responseHeaderMapKey, respHeaderMap)
 
 	requestInfo := newRequestInfo()
 	requestInfo.SetRequestReceivedDuration(time.Now())


### PR DESCRIPTION
### Issues associated with this PR
prefix variables such as request_header_xxx in access log is not parsed correctly, variable names will always only save the prefix

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, details and the changes. At this time, Chinese is allowed to describe these.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
