### PR TITLE
bugfix: when new mosn start failed pid file won't be recovered

### DIFF
--- a/pkg/server/keeper/serverkeeper.go
+++ b/pkg/server/keeper/serverkeeper.go
@@ -60,10 +60,10 @@ func SetPid(pid string) {
 			pidFile = pid
 		}
 	}
-	writePidFile()
+	WritePidFile()
 }
 
-func writePidFile() (err error) {
+func WritePidFile() (err error) {
 	pid := []byte(strconv.Itoa(os.Getpid()) + "\n")
 
 	if err = ioutil.WriteFile(pidFile, pid, 0644); err != nil {

--- a/pkg/server/reconfigure.go
+++ b/pkg/server/reconfigure.go
@@ -88,6 +88,8 @@ func reconfigure(start bool) {
 	n, err = listenSockConn.Read(buf[:])
 	if n != 1 {
 		log.DefaultLogger.Alertf(types.ErrorKeyReconfigure, "new mosn start failed")
+		// Restore PID
+		keeper.WritePidFile()
 		return
 	}
 


### PR DESCRIPTION
### Issues associated with this PR

When a new mosn starts, its pid was written to pidfile. But even if new mosn start failed, the pidfile won't be recovered

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, details and the changes. At this time, Chinese is allowed to describe these.

Old mosn find that new mosn start failed, then write it's own pid to pidfile again.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
