### PR TITLE
add cluster manager tls config

### DIFF
--- a/pkg/config/v2/upstream.go
+++ b/pkg/config/v2/upstream.go
@@ -94,6 +94,7 @@ type Cluster struct {
 	Spec                 ClusterSpecInfo     `json:"spec,omitempty"`
 	LBSubSetConfig       LBSubsetConfig      `json:"lb_subset_config,omitempty"`
 	LBOriDstConfig       LBOriDstConfig      `json:"original_dst_lb_config,omitempty"`
+	ClusterManagerTLS    bool                `json:"cluster_manager_tls,omitempty"`
 	TLS                  TLSConfig           `json:"tls_context,omitempty"`
 	Hosts                []Host              `json:"hosts,omitempty"`
 	ConnectTimeout       *api.DurationConfig `json:"connect_timeout,omitempty"`
@@ -214,12 +215,9 @@ type ClusterManagerConfig struct {
 }
 
 type ClusterManagerConfigJson struct {
-	// Note: consider to use standard configure
-	AutoDiscovery bool `json:"auto_discovery,omitempty"`
-	// Note: this is a hack method to realize cluster's  health check which push by registry
-	RegistryUseHealthCheck bool      `json:"registry_use_health_check,omitempty"`
-	ClusterConfigPath      string    `json:"clusters_configs,omitempty"`
-	ClustersJson           []Cluster `json:"clusters,omitempty"`
+	TLSContext        TLSConfig `json:"tls_context,omitempty"`
+	ClusterConfigPath string    `json:"clusters_configs,omitempty"`
+	ClustersJson      []Cluster `json:"clusters,omitempty"`
 }
 
 func (cc *ClusterManagerConfig) UnmarshalJSON(b []byte) error {

--- a/pkg/configmanager/configmanager.go
+++ b/pkg/configmanager/configmanager.go
@@ -132,6 +132,13 @@ FoundCluster:
 	dump(true)
 }
 
+func UpdateClusterManagerTLS(tls v2.TLSConfig) {
+	configLock.Lock()
+	defer configLock.Unlock()
+	config.ClusterManager.TLSContext = tls
+	dump(true)
+}
+
 // AddPubInfo
 // called when add pub info received
 func AddPubInfo(pubInfoAdded map[string]string) {

--- a/pkg/configmanager/configmanager_test.go
+++ b/pkg/configmanager/configmanager_test.go
@@ -305,6 +305,20 @@ func TestUpdateFullConfig(t *testing.T) {
 
 }
 
+func TestUpdateClusterManager(t *testing.T) {
+	cfg := []byte(`{
+		"cluster_managers":{}
+	}`)
+	mockInitConfig(t, cfg)
+	UpdateClusterManagerTLS(v2.TLSConfig{
+		Status: true,
+	})
+	// verify
+	if !config.ClusterManager.TLSContext.Status {
+		t.Fatalf("Cluster Manager TLS Context update failed")
+	}
+}
+
 func TestUpdateMqClientKey(t *testing.T) {
 	UpdateMqClientKey("hello", "ck", false)
 	if len(config.ServiceRegistry.MqClientKey) != 1 {

--- a/pkg/configmanager/configmanager_test.go
+++ b/pkg/configmanager/configmanager_test.go
@@ -386,6 +386,9 @@ func TestUpdateConfigConcurrency(t *testing.T) {
 			AddOrUpdateListener(&v2.Listener{})
 		},
 		func() {
+			UpdateClusterManagerTLS(v2.TLSConfig{})
+		},
+		func() {
 			AddMsgMeta("data", "group")
 		},
 		func() {

--- a/pkg/mosn/starter.go
+++ b/pkg/mosn/starter.go
@@ -102,10 +102,6 @@ func NewMosn(c *v2.MOSNConfig) *Mosn {
 				DefaultLogLevel: "INFO",
 			},
 		}
-	} else {
-		if len(c.ClusterManager.Clusters) == 0 && !c.ClusterManager.AutoDiscovery {
-			log.StartLogger.Fatalf("[mosn] [NewMosn] no cluster found and cluster manager doesn't support auto discovery")
-		}
 	}
 
 	srvNum := len(c.Servers)
@@ -123,9 +119,9 @@ func NewMosn(c *v2.MOSNConfig) *Mosn {
 	clusters, clusterMap := configmanager.ParseClusterConfig(c.ClusterManager.Clusters)
 	// create cluster manager
 	if mode == v2.Xds {
-		m.clustermanager = cluster.NewClusterManagerSingleton(nil, nil)
+		m.clustermanager = cluster.NewClusterManagerSingleton(nil, nil, &c.ClusterManager.TLSContext)
 	} else {
-		m.clustermanager = cluster.NewClusterManagerSingleton(clusters, clusterMap)
+		m.clustermanager = cluster.NewClusterManagerSingleton(clusters, clusterMap, &c.ClusterManager.TLSContext)
 	}
 
 	// initialize the routerManager

--- a/pkg/mtls/tls_context_manager.go
+++ b/pkg/mtls/tls_context_manager.go
@@ -172,12 +172,12 @@ func (mng *clientContextManager) Conn(c net.Conn) (net.Conn, error) {
 }
 
 func (mng *clientContextManager) Enabled() bool {
-	return mng.provider != nil && mng.provider.Ready()
+	return mng != nil && mng.provider != nil && mng.provider.Ready()
 }
 
 // if the provider is not ready, the hash value returns nil.
 func (mng *clientContextManager) HashValue() *types.HashValue {
-	if mng.provider == nil {
+	if mng == nil || mng.provider == nil {
 		return nil
 	}
 	return mng.provider.GetTLSConfigContext(true).HashValue()

--- a/pkg/trace/sofa/xprotocol/types.go
+++ b/pkg/trace/sofa/xprotocol/types.go
@@ -58,6 +58,7 @@ const (
 const (
 	MOSN_PROCESS_TIME = 60 + iota
 	MOSN_TLS_STATE
+	TLSCipherSuite
 )
 
 type SubProtocolDelegate func(ctx context.Context, frame xprotocol.XFrame, span types.Span)

--- a/pkg/types/upstream.go
+++ b/pkg/types/upstream.go
@@ -69,6 +69,11 @@ type ClusterManager interface {
 	// RemoveClusterHosts, remove the host by address string
 	RemoveClusterHosts(clusterName string, hosts []string) error
 
+	// TLSManager is used to cluster tls config
+	GetTLSManager() TLSContextManager
+	// UpdateTLSManager updates the tls manager which is used to cluster tls config
+	UpdateTLSManager(*v2.TLSConfig)
+
 	// Destroy the cluster manager
 	Destroy()
 }

--- a/pkg/upstream/cluster/cluster_adapter_test.go
+++ b/pkg/upstream/cluster/cluster_adapter_test.go
@@ -61,7 +61,7 @@ func _createClusterManager() types.ClusterManager {
 	clusterManagerInstance.Destroy() // Destroy for test
 	return NewClusterManagerSingleton([]v2.Cluster{clusterConfig}, map[string][]v2.Host{
 		"test1": []v2.Host{host1, host2},
-	})
+	}, nil)
 }
 
 func TestClusterManagerFromConfig(t *testing.T) {
@@ -392,7 +392,7 @@ func TestConnPoolUpdateTLS(t *testing.T) {
 	clusterManagerInstance.Destroy() // Destroy for test
 	NewClusterManagerSingleton([]v2.Cluster{clusterConfig}, map[string][]v2.Host{
 		"test1": []v2.Host{host},
-	})
+	}, nil)
 	snap1 := GetClusterMngAdapterInstance().GetClusterSnapshot(nil, "test1")
 	connPool1 := GetClusterMngAdapterInstance().ConnPoolForCluster(newMockLbContext(nil), snap1, mockProtocol)
 	// hash value equals nil means not support tls

--- a/pkg/upstream/cluster/cluster_adapter_test.go
+++ b/pkg/upstream/cluster/cluster_adapter_test.go
@@ -425,3 +425,55 @@ func TestConnPoolUpdateTLS(t *testing.T) {
 	}
 
 }
+
+func TestClusterManagerTLSUpdateTLS(t *testing.T) {
+	testStateReset()
+	defer testStateReset()
+	clusterConfig := v2.Cluster{
+		Name:              "test1",
+		LbType:            v2.LB_RANDOM,
+		ClusterManagerTLS: true,
+	}
+	host := v2.Host{
+		HostConfig: v2.HostConfig{
+			Address: "127.0.0.1:10000",
+		},
+	}
+	clusterManagerInstance.Destroy() // Destroy for test
+	NewClusterManagerSingleton([]v2.Cluster{clusterConfig}, map[string][]v2.Host{
+		"test1": []v2.Host{host},
+	}, nil)
+	snap1 := GetClusterMngAdapterInstance().GetClusterSnapshot(nil, "test1")
+	connPool1 := GetClusterMngAdapterInstance().ConnPoolForCluster(newMockLbContext(nil), snap1, mockProtocol)
+	// hash value equals nil means not support tls
+	if !connPool1.TLSHashValue().Equal(nil) {
+		t.Fatal("conn pool support tls")
+	}
+	// Update to support TLS
+	GetClusterMngAdapterInstance().UpdateTLSManager(&v2.TLSConfig{
+		Status:       true,
+		InsecureSkip: true,
+	})
+	connPool2 := GetClusterMngAdapterInstance().ConnPoolForCluster(newMockLbContext(nil), snap1, mockProtocol)
+	if !connPool1.TLSHashValue().Equal(nil) {
+		t.Fatal("old conn pool support tls")
+	}
+	if connPool2.TLSHashValue().Equal(nil) {
+		t.Fatal("conn pool does not support tls")
+	}
+	// Update Same Config, no effects
+	GetClusterMngAdapterInstance().UpdateTLSManager(&v2.TLSConfig{
+		Status:       true,
+		InsecureSkip: true,
+	})
+	connPool3 := GetClusterMngAdapterInstance().ConnPoolForCluster(newMockLbContext(nil), snap1, mockProtocol)
+	if !connPool2.TLSHashValue().Equal(connPool3.TLSHashValue()) {
+		t.Fatal("Hash Value changed")
+	}
+	// disbale tls, connpool should will be changed
+	DisableClientSideTLS()
+	connPool4 := GetClusterMngAdapterInstance().ConnPoolForCluster(newMockLbContext(nil), snap1, mockProtocol)
+	if !connPool4.TLSHashValue().Equal(nil) {
+		t.Fatal("conn pool support tls")
+	}
+}

--- a/pkg/upstream/cluster/cluster_manager.go
+++ b/pkg/upstream/cluster/cluster_manager.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"mosn.io/mosn/pkg/admin/store"
@@ -61,6 +62,7 @@ type clusterManager struct {
 	clustersMap      sync.Map
 	protocolConnPool sync.Map
 	tlsMetrics       *mtls.TLSStats
+	tlsMng           atomic.Value // store types.TLSContextManager
 	mux              sync.Mutex
 }
 
@@ -77,15 +79,19 @@ func (singleton *clusterManagerSingleton) Destroy() {
 
 var clusterManagerInstance = &clusterManagerSingleton{}
 
-func NewClusterManagerSingleton(clusters []v2.Cluster, clusterMap map[string][]v2.Host) types.ClusterManager {
+func NewClusterManagerSingleton(clusters []v2.Cluster, clusterMap map[string][]v2.Host, tls *v2.TLSConfig) types.ClusterManager {
 	clusterManagerInstance.instanceMutex.Lock()
 	defer clusterManagerInstance.instanceMutex.Unlock()
 	if clusterManagerInstance.clusterManager != nil {
 		return clusterManagerInstance
 	}
+
 	clusterManagerInstance.clusterManager = &clusterManager{
 		tlsMetrics: mtls.NewStats(globalTLSMetrics),
 	}
+	// set global tls
+	clusterManagerInstance.clusterManager.UpdateTLSManager(tls)
+	// add conn pool
 	for k := range types.ConnPoolFactories {
 		clusterManagerInstance.protocolConnPool.Store(k, &sync.Map{})
 	}
@@ -290,6 +296,23 @@ func (cm *clusterManager) ConnPoolForCluster(balancerContext types.LoadBalancerC
 		log.DefaultLogger.Errorf("[upstream] [cluster manager] ConnPoolForCluster Failed; %v", err)
 	}
 	return pool
+}
+
+func (cm *clusterManager) GetTLSManager() types.TLSContextManager {
+	v := cm.tlsMng.Load()
+	tlsmng, _ := v.(types.TLSContextManager)
+	return tlsmng
+}
+
+func (cm *clusterManager) UpdateTLSManager(tls *v2.TLSConfig) {
+	if tls == nil {
+		tls = &v2.TLSConfig{} // use a disabled config instead
+	}
+	mng, err := mtls.NewTLSClientContextManager(tls)
+	if err != nil {
+		log.DefaultLogger.Alertf("cluster.config", "[upstream] [cluster manager] NewClusterManager: Add TLS Manager failed, error: %v", err)
+	}
+	cm.tlsMng.Store(mng)
 }
 
 const (

--- a/pkg/upstream/cluster/cluster_test.go
+++ b/pkg/upstream/cluster/cluster_test.go
@@ -164,3 +164,36 @@ func TestUpdateHostLabels(t *testing.T) {
 		}
 	}
 }
+
+func TestClusterUseClusterManagerTLS(t *testing.T) {
+	clusterManagerInstance.Destroy()
+	NewClusterManagerSingleton(nil, nil, nil)
+	clusterConfig := v2.Cluster{
+		Name:              "test_cluster",
+		LbType:            v2.LB_RANDOM,
+		ClusterManagerTLS: true,
+	}
+	c := NewCluster(clusterConfig)
+	snap := c.Snapshot()
+	if mng := snap.ClusterInfo().TLSMng(); mng.Enabled() {
+		t.Fatal("tls should not enabled")
+	}
+	// update tls mananger
+	clusterManagerInstance.UpdateTLSManager(&v2.TLSConfig{
+		Status:       true,
+		InsecureSkip: true,
+	})
+	if mng := snap.ClusterInfo().TLSMng(); !mng.Enabled() {
+		t.Fatal("tls should enabled")
+	}
+	// config without manager tls
+	clusterConfig2 := v2.Cluster{
+		Name:   "test_cluster",
+		LbType: v2.LB_RANDOM,
+	}
+	c2 := NewCluster(clusterConfig2)
+	if mng := c2.Snapshot().ClusterInfo().TLSMng(); mng.Enabled() {
+		t.Fatal("tls should not enabled")
+	}
+
+}

--- a/pkg/upstream/servicediscovery/dubbod/dubbo_test.go
+++ b/pkg/upstream/servicediscovery/dubbod/dubbo_test.go
@@ -37,7 +37,7 @@ func init() {
 		return nil
 	})
 
-	cluster.NewClusterManagerSingleton(nil, nil)
+	cluster.NewClusterManagerSingleton(nil, nil, nil)
 
 }
 

--- a/pkg/xds/conv/convertxds_test.go
+++ b/pkg/xds/conv/convertxds_test.go
@@ -59,7 +59,7 @@ import (
 func TestMain(m *testing.M) {
 	// init
 	router.NewRouterManager()
-	cm := cluster.NewClusterManagerSingleton(nil, nil)
+	cm := cluster.NewClusterManagerSingleton(nil, nil, nil)
 	sc := server.NewConfig(&v2.ServerConfig{
 		ServerName:      "test_xds_server",
 		DefaultLogPath:  "stdout",
@@ -408,14 +408,14 @@ func Test_convertListenerConfig(t *testing.T) {
 							TypedConfig: accessLogFilterConfig,
 						},
 					}},
-					UseRemoteAddress:            NewBoolValue(false),
-					XffNumTrustedHops:           0,
-					SkipXffAppend:               false,
-					Via:                         "",
-					GenerateRequestId:           NewBoolValue(true),
-					ForwardClientCertDetails:    xdshttp.HttpConnectionManager_SANITIZE,
-					SetCurrentClientCertDetails: nil,
-					Proxy_100Continue:           false,
+					UseRemoteAddress:                           NewBoolValue(false),
+					XffNumTrustedHops:                          0,
+					SkipXffAppend:                              false,
+					Via:                                        "",
+					GenerateRequestId:                          NewBoolValue(true),
+					ForwardClientCertDetails:                   xdshttp.HttpConnectionManager_SANITIZE,
+					SetCurrentClientCertDetails:                nil,
+					Proxy_100Continue:                          false,
 					RepresentIpv4RemoteAddressAsIpv4MappedIpv6: false,
 				},
 				filterName: "envoy.http_connection_manager",


### PR DESCRIPTION
1. config `ClusterManager` Add `TLSContext` Field, which will create a tls context manager if configured.
2. config `Cluster` Add `ClusterManagerTLS` Filed. If this field is configured, use the ClusterManager's TLSContext instead of `Cluster.TLSContext`
3. Update `ClusterManager.TLSContext` will take effect on all clusters(and their snapshot) without update the cluster.
4. Delete some useless config fields in `ClusterManager`, and Add `UpdateTLSManager` for update the config