### PR TITLE
bugfix: UDP session read buffer size should not be reset on read timeout

### DIFF
--- a/pkg/filter/network/streamproxy/streamproxy.go
+++ b/pkg/filter/network/streamproxy/streamproxy.go
@@ -396,7 +396,7 @@ func NewProxyConfig(config *v2.StreamProxy) ProxyConfig {
 }
 
 func (pc *proxyConfig) GetIdleTimeout(network string) time.Duration {
-	if pc.idleTimeout != nil {
+	if pc.idleTimeout != nil && *pc.idleTimeout > 0 {
 		return *pc.idleTimeout
 	}
 	if network == "udp" {

--- a/pkg/mosn/starter.go
+++ b/pkg/mosn/starter.go
@@ -225,6 +225,13 @@ func (m *Mosn) beforeStart() {
 			ln.Close()
 		}
 	}
+	for _, ln := range m.inheritPacketConn {
+		if ln != nil {
+			log.StartLogger.Infof("[mosn] [NewMosn] close useless legacy listener: %s", ln.LocalAddr().String())
+			ln.Close()
+		}
+	}
+
 
 	// start dump config process
 	utils.GoWithRecover(func() {

--- a/pkg/mosn/starter.go
+++ b/pkg/mosn/starter.go
@@ -232,7 +232,6 @@ func (m *Mosn) beforeStart() {
 		}
 	}
 
-
 	// start dump config process
 	utils.GoWithRecover(func() {
 		configmanager.DumpConfigHandler()

--- a/pkg/mosn/starter.go
+++ b/pkg/mosn/starter.go
@@ -225,6 +225,7 @@ func (m *Mosn) beforeStart() {
 			ln.Close()
 		}
 	}
+	//close legacy UDP listeners
 	for _, ln := range m.inheritPacketConn {
 		if ln != nil {
 			log.StartLogger.Infof("[mosn] [NewMosn] close useless legacy listener: %s", ln.LocalAddr().String())

--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -208,7 +208,7 @@ func (c *connection) attachEventLoop(lctx context.Context) {
 
 				if err != nil {
 					if te, ok := err.(net.Error); ok && te.Timeout() {
-						if c.readBuffer != nil && c.readBuffer.Len() == 0 {
+						if c.network == "tcp" && c.readBuffer != nil && c.readBuffer.Len() == 0 {
 							c.readBuffer.Free()
 							c.readBuffer.Alloc(DefaultBufferReadCapacity)
 						}
@@ -386,7 +386,7 @@ func (c *connection) startReadLoop() {
 				err := c.doRead()
 				if err != nil {
 					if te, ok := err.(net.Error); ok && te.Timeout() {
-						if c.readBuffer != nil && c.readBuffer.Len() == 0 && c.readBuffer.Cap() > DefaultBufferReadCapacity {
+						if c.network == "tcp" && c.readBuffer != nil && c.readBuffer.Len() == 0 && c.readBuffer.Cap() > DefaultBufferReadCapacity {
 							c.readBuffer.Free()
 							c.readBuffer.Alloc(DefaultBufferReadCapacity)
 						}

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -496,7 +496,7 @@ func (al *activeListener) OnNewConnection(ctx context.Context, conn api.Connecti
 		log.DefaultLogger.Debugf("[server] [listener] accept connection from %s, condId= %d, remote addr:%s", al.listener.Addr().String(), conn.ID(), conn.RemoteAddr().String())
 	}
 
-	if conn.LocalAddr().Network() == "udp" {
+	if conn.LocalAddr().Network() == "udp" && conn.State() != api.ConnClosed {
 		network.SetUDPProxyMap(network.GetProxyMapKey(conn.LocalAddr().String(), conn.RemoteAddr().String()), conn)
 	}
 


### PR DESCRIPTION
### Issues associated with this PR

c.readBuffer will be reset on read timeout,  which will resize UDP recv buffer to 128. Data in a UDP packet exceeding the buffer size will be discarded.

### Solutions
c.readBuffer of a UDP session should not be reset.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
