### PR TITLE
Feature http header size.

### DIFF
--- a/pkg/config/v2/proxy.go
+++ b/pkg/config/v2/proxy.go
@@ -54,4 +54,5 @@ type XProxyExtendConfig struct {
 type ProxyGeneralExtendConfig struct {
 	Http2UseStream     bool `json:"http2_use_stream,omitempty"`
 	MaxRequestBodySize int  `json:"max_request_body_size,omitempty"`
+	MaxHeaderSize      int  `json:"max_header_size,omitempty"`
 }

--- a/pkg/stream/http/stream.go
+++ b/pkg/stream/http/stream.go
@@ -127,7 +127,6 @@ type streamConnection struct {
 	connClosed chan bool
 
 	br *bufio.Reader
-	bw *bufio.Writer
 }
 
 // types.StreamConnection
@@ -231,7 +230,6 @@ func newClientStreamConnection(ctx context.Context, connection types.ClientConne
 	}
 
 	csc.br = bufio.NewReaderSize(csc, maxResponseHeaderSize)
-	csc.bw = bufio.NewWriter(csc)
 
 	utils.GoWithRecover(func() {
 		csc.serve()
@@ -389,7 +387,6 @@ func newServerStreamConnection(ctx context.Context, connection api.Connection,
 	ssc.contextManager.Next()
 
 	ssc.br = bufio.NewReaderSize(ssc, maxRequestHeaderSize)
-	ssc.bw = bufio.NewWriter(ssc)
 
 	// Reset would not be called in server-side scene, so add listener for connection event
 	connection.AddConnectionEventListener(ssc)

--- a/pkg/stream/http/stream_test.go
+++ b/pkg/stream/http/stream_test.go
@@ -272,7 +272,7 @@ func Test_clientStream_CheckReasonError(t *testing.T) {
 
 func TestHeaderSize(t *testing.T) {
 	// Only request line, do not add the end of request '\r\n\r\n' identification.
-	requestSamll := []byte("HEAD / HTTP/1.1\r\nHost: test.com\r\nCookie: key=1234")
+	requestSmall := []byte("HEAD / HTTP/1.1\r\nHost: test.com\r\nCookie: key=1234")
 	requestLarge := []byte("HEAD / HTTP/1.1\r\nHost: test.com\r\nCookie: key=12345")
 	testAddr := "127.0.0.1:11345"
 	l, err := net.Listen("tcp", testAddr)
@@ -290,7 +290,7 @@ func TestHeaderSize(t *testing.T) {
 
 	connection := network.NewServerConnection(context.Background(), rawc, nil)
 	proxyGeneralExtendConfig := v2.ProxyGeneralExtendConfig{
-		MaxHeaderSize: len(requestSamll),
+		MaxHeaderSize: len(requestSmall),
 	}
 
 	ctx := mosnctx.WithValue(context.Background(), types.ContextKeyProxyGeneralConfig, proxyGeneralExtendConfig)
@@ -300,8 +300,8 @@ func TestHeaderSize(t *testing.T) {
 	}
 
 	// test the header size is within the limit
-	buf := buffer.GetIoBuffer(len(requestSamll))
-	buf.Write(requestSamll)
+	buf := buffer.GetIoBuffer(len(requestSmall))
+	buf.Write(requestSmall)
 	ssc.Dispatch(buf)
 	// if it exceeds the limit size of the header, the connection is closed immediately
 	if connection.State() == api.ConnClosed {

--- a/pkg/stream/http/stream_test.go
+++ b/pkg/stream/http/stream_test.go
@@ -18,19 +18,21 @@
 package http
 
 import (
-	"testing"
-
-	"net"
-
 	"bytes"
+	"context"
 	"fmt"
+	"net"
+	"testing"
 
 	"github.com/valyala/fasthttp"
 	"mosn.io/api"
+	v2 "mosn.io/mosn/pkg/config/v2"
+	mosnctx "mosn.io/mosn/pkg/context"
 	"mosn.io/mosn/pkg/network"
 	"mosn.io/mosn/pkg/protocol"
 	"mosn.io/mosn/pkg/protocol/http"
 	"mosn.io/mosn/pkg/types"
+	"mosn.io/pkg/buffer"
 )
 
 func Test_clientStream_AppendHeaders(t *testing.T) {
@@ -266,6 +268,59 @@ func Test_clientStream_CheckReasonError(t *testing.T) {
 		t.Errorf("csc.CheckReasonError(true, types.OnConnect) got %v , want %v", res, types.StreamConnectionSuccessed)
 	}
 
+}
+
+func TestHeaderSize(t *testing.T) {
+	// Only request line, do not add the end of request '\r\n\r\n' identification.
+	requestSamll := []byte("HEAD / HTTP/1.1\r\nHost: test.com\r\nCookie: key=1234")
+	requestLarge := []byte("HEAD / HTTP/1.1\r\nHost: test.com\r\nCookie: key=12345")
+	testAddr := "127.0.0.1:11345"
+	l, err := net.Listen("tcp", testAddr)
+	if err != nil {
+		t.Logf("listen error %v", err)
+		return
+	}
+	defer l.Close()
+
+	rawc, err := net.Dial("tcp", testAddr)
+	if err != nil {
+		t.Logf("net.Dial error %v", err)
+		return
+	}
+
+	connection := network.NewServerConnection(context.Background(), rawc, nil)
+	proxyGeneralExtendConfig := v2.ProxyGeneralExtendConfig{
+		MaxHeaderSize: len(requestSamll),
+	}
+
+	ctx := mosnctx.WithValue(context.Background(), types.ContextKeyProxyGeneralConfig, proxyGeneralExtendConfig)
+	ssc := newServerStreamConnection(ctx, connection, nil)
+	if ssc == nil {
+		t.Errorf("newServerStreamConnection failed!")
+	}
+
+	// test the header size is within the limit
+	buf := buffer.GetIoBuffer(len(requestSamll))
+	buf.Write(requestSamll)
+	ssc.Dispatch(buf)
+	// if it exceeds the limit size of the header, the connection is closed immediately
+	if connection.State() == api.ConnClosed {
+		t.Errorf("requestSmall header size does not exceed limit!")
+	}
+
+	connection = network.NewServerConnection(context.Background(), rawc, nil)
+	ssc = newServerStreamConnection(ctx, connection, nil)
+	if ssc == nil {
+		t.Errorf("newServerStreamConnection failed!")
+	}
+
+	// test the header size exceeds the limit
+	buf = buffer.GetIoBuffer(len(requestLarge))
+	buf.Write(requestLarge)
+	ssc.Dispatch(buf)
+	if connection.State() != api.ConnClosed {
+		t.Errorf("requestLarge header size should exceed limit!")
+	}
 }
 
 func convertHeader(payload protocol.CommonHeader) http.RequestHeader {


### PR DESCRIPTION
### Solutions associated with this PR

* Add header max size configuration option.
* Optimize: delete unnecessary buffio.Writer, single connection can reduce 4K memory waste.
