### PR TITLE
set timeout for local write buffer send, avoid goroutine leak

### DIFF
--- a/pkg/types/network.go
+++ b/pkg/types/network.go
@@ -235,6 +235,7 @@ type FilterChainFactory interface {
 }
 
 var (
-	ErrConnectionHasClosed = errors.New("connection has closed")
-	ErrWriteTryLockTimeout = errors.New("write trylock has timeout")
+	ErrConnectionHasClosed    = errors.New("connection has closed")
+	ErrWriteTryLockTimeout    = errors.New("write trylock has timeout")
+	ErrWriteBufferChanTimeout = errors.New("writeBufferChan has timeout")
 )


### PR DESCRIPTION
local write hang cause goroutine to accumulate, the following data can show that from the hang start to mosn OOM, about 5-6 minutes passed, 60s is a proper value

Fixes https://github.com/mosn/mosn/issues/1435