### PR TITLE
feature: support '-d' start param

### DIFF
--- a/cmd/mosn/main/control.go
+++ b/cmd/mosn/main/control.go
@@ -55,6 +55,10 @@ var (
 				EnvVar: "MOSN_CONFIG",
 				Value:  "configs/mosn_config.json",
 			}, cli.StringFlag{
+				Name:   "dynamic-config, d",
+				Usage:  "Load dynamic configuration from `FILE`",
+				EnvVar: "MOSN_DYNAMIC CONFIG",
+			}, cli.StringFlag{
 				Name:   "service-cluster, s",
 				Usage:  "sidecar service cluster",
 				EnvVar: "SERVICE_CLUSTER",
@@ -126,6 +130,7 @@ var (
 		},
 		Action: func(c *cli.Context) error {
 			configPath := c.String("config")
+			dyconfigPath := c.String("dynamic-config")
 			serviceCluster := c.String("service-cluster")
 			serviceNode := c.String("service-node")
 			serviceType := c.String("service-type")
@@ -138,6 +143,9 @@ var (
 
 			flagLogLevel := c.String("log-level")
 
+			if dyconfigPath != "" {
+				configmanager.SetDynamicConfigPath(dyconfigPath)
+			}
 			conf := configmanager.Load(configPath)
 			if mosnLogLevel, ok := flagToMosnLogLevel[flagLogLevel]; ok {
 				if mosnLogLevel == "OFF" {

--- a/pkg/configmanager/dump_action.go
+++ b/pkg/configmanager/dump_action.go
@@ -88,7 +88,12 @@ func DumpConfig() {
 			return
 		}
 	}
-	err = utils.WriteFileSafety(configPath, content, 0644)
+
+	confPath := configPath
+	if dyconfigPath != "" {
+		confPath = dyconfigPath
+	}
+	err = utils.WriteFileSafety(confPath, content, 0644)
 	if err != nil {
 		log.DefaultLogger.Alertf(types.ErrorKeyConfigDump, "dump config failed, caused by: %v", err.Error())
 		// add retry if write file  failed

--- a/pkg/configmanager/load_config.go
+++ b/pkg/configmanager/load_config.go
@@ -118,11 +118,12 @@ func checkUpdateFromDyconfig(conf *v2.MOSNConfig) {
 				conf.ClusterManager.Clusters = append(conf.ClusterManager.Clusters, cluster)
 			}
 		}
+		// server config should not be empty in dynamic config
 		if len(cfg.Servers) == 0 {
 			log.StartLogger.Fatalf("[config] no server found in config file %s", dyconfigPath)
 		}
-		// update listeners
 		if len(conf.Servers) > 0 {
+			// update listeners
 			for _, listener := range cfg.Servers[0].Listeners {
 				found := false
 				for i := 0; i < len(conf.Servers[0].Listeners); i++ {
@@ -138,12 +139,7 @@ func checkUpdateFromDyconfig(conf *v2.MOSNConfig) {
 					conf.Servers[0].Listeners = append(conf.Servers[0].Listeners, listener)
 				}
 			}
-		} else {
-			conf.Servers[0].Listeners = cfg.Servers[0].Listeners
-		}
-
-		//update routers
-		if len(cfg.Servers) > 0 {
+			// update routers
 			for _, router := range cfg.Servers[0].Routers {
 				found := false
 				for i := 0; i < len(conf.Servers[0].Routers); i++ {
@@ -160,7 +156,7 @@ func checkUpdateFromDyconfig(conf *v2.MOSNConfig) {
 				}
 			}
 		} else {
-			conf.Servers[0].Routers = cfg.Servers[0].Routers
+			conf.Servers = append(conf.Servers, cfg.Servers[0])
 		}
 	}
 }

--- a/pkg/configmanager/load_config_test.go
+++ b/pkg/configmanager/load_config_test.go
@@ -18,9 +18,11 @@
 package configmanager
 
 import (
+	"os"
 	"testing"
 
 	"mosn.io/mosn/pkg/config/v2"
+	"mosn.io/pkg/utils"
 )
 
 // Test Yaml Config Load
@@ -51,5 +53,148 @@ func TestRegisterConfigLoadFunc(t *testing.T) {
 	cfg := Load("test")
 	if cfg.Pid != "test" {
 		t.Fatalf("register config load func failed")
+	}
+}
+
+func TestLoadDynamicConfig(t *testing.T) {
+	config1 := `
+	{
+	  "servers": [
+	    {
+	      "listeners": [
+	        {
+	          "name": "testListener",
+	          "address": "0.0.0.0:28089",
+	          "bind_port": true,
+	          "inspector": true,
+	          "filter_chains": [
+	            {
+	              "filters": [
+	                {
+	                  "config": {
+	                    "downstream_protocol": "Auto",
+	                    "router_config_name": "http.19002",
+	                    "upstream_protocol": "Auto"
+	                  },
+	                  "type": "proxy"
+	                }
+	              ]
+	            }
+	          ]
+	        }
+	      ]
+	    }
+	  ]
+	}
+	`
+	config2 := `
+    {
+      "servers": [
+        {
+          "listeners": [
+            {
+              "name": "testListener1",
+              "address": "0.0.0.0:19002",
+              "bind_port": true,
+              "inspector": true,
+              "filter_chains": [
+                {
+                  "filters": [
+                    {
+                      "config": {
+                        "downstream_protocol": "Auto",
+                        "router_config_name": "http.28089",
+                        "upstream_protocol": "Auto"
+                      },
+                      "type": "proxy"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "testListener",
+              "address": "0.0.0.0:28089",
+              "bind_port": true,
+              "inspector": true,
+              "filter_chains": [
+                {
+                  "filters": [
+                    {
+                      "config": {
+                        "downstream_protocol": "Auto",
+                        "router_config_name": "http.28089",
+                        "upstream_protocol": "Auto"
+                      },
+                      "type": "proxy"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "routers": [
+            {
+              "router_config_name": "http.19002",
+              "virtual_hosts": [
+                {
+                  "name": "*:19002",
+                  "domains": [
+                    "*"
+                  ],
+                  "routers": [
+                    {
+                      "match": {
+                        "prefix": "/"
+                      },
+                      "route": {
+                        "cluster_name": "testCluster"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+	 "cluster_manager": {
+	     "clusters": [
+	       {
+	         "name": "cmagentCluster",
+	         "type": "STRICT_DNS",
+	         "lb_type": "LB_ROUNDROBIN",
+	         "max_request_per_conn": 1024,
+	         "conn_buffer_limit_bytes": 32768,
+	         "circuit_breakers": null,
+	         "health_check": {
+	           "timeout": "0s",
+	           "interval": "0s",
+	           "interval_jitter": "0s"
+	         }
+	       }
+	     ]
+	   }
+   }`
+	f1 := "/tmp/config1.json"
+	f2 := "/tmp/config2.json"
+	utils.WriteFileSafety(f1, []byte(config1), os.ModePerm)
+	utils.WriteFileSafety(f2, []byte(config2), os.ModePerm)
+	SetDynamicConfigPath(f2)
+	conf := Load(f1)
+	if conf == nil {
+		t.Fatalf("load config and update from dyconfig file failed")
+	}
+	if len(conf.Servers) != 1 {
+		t.Fatalf("load config and update from dyconfig file failed")
+	}
+	if len(conf.Servers[0].Routers) != 1 {
+		t.Fatalf("load config and update router from dyconfig file failed")
+	}
+	if len(conf.Servers[0].Listeners) != 2 {
+		t.Fatalf("load config and update listener from dyconfig file failed")
+	}
+	if len(conf.ClusterManager.Clusters) != 1 {
+		t.Fatalf("load config and update cluster from dyconfig file failed")
 	}
 }


### PR DESCRIPTION
### Issues associated with this PR
When upgrade mosn in xDS mode, new mosn only inherit fd when loading static config. New mosn will fail to listen on port in LDS due to port conflict.

### Solutions
We  support '-d' start parameter, you can use it along with feature "auto_config" to  implement configuration persistence.
Example:
```
 ./build/bundles/v0.17.0/binary/mosn start -c mosn.json -d ./dy.json -f "auto_config=true" -n 'xxx'
```
Use "-d" along with auto_config, config will be dumped to the path specified by "-d" parameter instead of "-c" parameter.
And if dy.json is not empty, config in dy.json will be loaded. Only clusters, listeners, routers in dy.json will be loaded.
You can still update other configs in mosn.json.
