### PR TITLE
Bug Fix: nil pointer ref

### DIFF
--- a/pkg/filter/stream/mixer/mixer.go
+++ b/pkg/filter/stream/mixer/mixer.go
@@ -173,5 +173,12 @@ func ParseMixerFilter(cfg map[string]interface{}) (*v2.Mixer, error) {
 		return nil, err
 	}
 
+	// default configuration
+	if mixerFilter.Transport == nil {
+		mixerFilter.Transport = &client.TransportConfig{
+			ReportCluster: "mixer_server",
+		}
+	}
+
 	return mixerFilter, nil
 }

--- a/pkg/istio/control/http/request_handler.go
+++ b/pkg/istio/control/http/request_handler.go
@@ -47,7 +47,7 @@ func NewRequestHandler(serviceContext *ServiceContext) RequestHandler {
 // * extract more report attributes
 // * make a Report call.
 func (h *requestHandler) Report(checkData CheckData, reportData ReportData) {
-	if h.serviceContext != nil && h.serviceContext.serviceConfig.DisableReportCalls {
+	if h.serviceContext != nil && h.serviceContext.serviceConfig != nil && h.serviceContext.serviceConfig.DisableReportCalls {
 		return
 	}
 	h.addForwardAttributes(checkData)


### PR DESCRIPTION
### Bug detail

The configuration of the mixer filter may look like this:
```
{
  "forward_attributes":
    {
      "attributes":
        {
          "source.namespace": { "string_value": "XYZ11" },
          "source.uid": { "string_value": "POD11" },
        },
    },
}
```

No Transport specified will result in a nil pointer reference.

In addition, when `h.serviceContext.serviceConfig` is nil, it will also cause nil pointer reference.

### Solutions

1. Create a default Transport for mixer filter.
2. Maker sure `serviceConfig` is not nil before `serviceConfig.DisableReportCalls`.
