### PR TITLE
fix bug 'getAPISourceEndpoint' when initializing adsclient

### DIFF
--- a/pkg/xds/v2/xdsconfig.go
+++ b/pkg/xds/v2/xdsconfig.go
@@ -94,7 +94,7 @@ func (c *XDSConfig) getAPISourceEndpoint(source *core.ApiConfigSource) (*ADSConf
 		t := service.TargetSpecifier
 		if target, ok := t.(*core.GrpcService_EnvoyGrpc_); ok {
 			serviceConfig := ServiceConfig{}
-			if service.Timeout == nil || (serviceConfig.Timeout.Seconds() <= 0 && serviceConfig.Timeout.Nanoseconds() <= 0) {
+			if service.Timeout == nil || (service.Timeout.Seconds <= 0 && service.Timeout.Nanos <= 0) {
 				duration := time.Duration(time.Second) // default connection timeout
 				serviceConfig.Timeout = &duration
 			} else {


### PR DESCRIPTION
I will describe this PR in Chinese

1. `serviceConfig`被初始化，`serviceConfig.Timeout`是一个time.Duration的指针，如果直接拿`Seconds ()`和`Nanoseconds()`会空指针报错

2. 原意应该是判断`service.Timeout.Seconds` 和 `service.Timeout.Nanos`吧