### PR TITLE
Bug Fix: unsupported processor type: float64

### DIFF
--- a/pkg/configmanager/parser.go
+++ b/pkg/configmanager/parser.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -374,8 +375,10 @@ func setMaxProcsWithProcessor(procs interface{}) {
 		strfunc(processor)
 	case int:
 		intfunc(processor)
+	case float64:
+		intfunc(int(processor))
 	default:
-		log.StartLogger.Fatalf("unsupport serverconfig processor type, must be int or string.")
+		log.StartLogger.Fatalf("unsupport serverconfig processor type %v, must be int or string.", reflect.TypeOf(procs))
 	}
 }
 


### PR DESCRIPTION
```
{
    "servers": [
        {
            "default_log_path": "/tmp/logs/mosn/default.log",
            "default_log_level": "DEBUG",
            "processor": 4,
            "listeners": [
                {
```

[Processor interface{} `json:"processor,omitempty"`](https://github.com/mosn/mosn/blob/86223f67e2fe5254aa826a0c1c01a597427c0c0d/pkg/config/v2/server.go#L44) 

After `json.Unmarshal` parses JSON-encoded data into `MOSNConfig`, the type of processor is float64, not int.

### Solutions

Extend float64 type for processor