### PR TITLE
No provider available occurred after dubbo2.7.3

### DIFF
--- a/pkg/upstream/servicediscovery/dubbod/pub.go
+++ b/pkg/upstream/servicediscovery/dubbod/pub.go
@@ -99,13 +99,18 @@ func doPubUnPub(req pubReq, pub bool) error {
 		"port":      mosnPubPort,
 		"interface": req.Service.Interface,
 	})
+	urlValues := url.Values{
+		dubboconsts.ROLE_KEY:      []string{fmt.Sprint(dubbocommon.PROVIDER)},
+		dubboconsts.INTERFACE_KEY: []string{req.Service.Interface},
+	}
+	if req.Service.Group != "" {
+		urlValues.Set(dubboconsts.GROUP_KEY, req.Service.Group)
+	}
+	if req.Service.Version != "" {
+		urlValues.Set(dubboconsts.VERSION_KEY, req.Service.Version)
+	}
 	dubboURL, _ := dubbocommon.NewURL(dubboPath,
-		dubbocommon.WithParams(url.Values{
-			dubboconsts.ROLE_KEY:      []string{fmt.Sprint(dubbocommon.PROVIDER)},
-			dubboconsts.GROUP_KEY:     []string{req.Service.Group},
-			dubboconsts.INTERFACE_KEY: []string{req.Service.Interface},
-			dubboconsts.VERSION_KEY:   []string{req.Service.Version},
-		}),
+		dubbocommon.WithParams(urlValues),
 		dubbocommon.WithMethods(req.Service.Methods))
 
 	if pub {


### PR DESCRIPTION
### Issues associated with this PR
As the title mentioned. After dubbo2.7.3, 'default.' prefix was removed from URL key. Mosn always pass version and group parameters with empty string by default. But unfortunately consumer set null by default. they won't match when consumer do subscribe. 
See: org.apache.dubbo.common.utils.UrlUtils#isMatch

### Solutions
Don't pass version and group parameter by default when provider register.
