### PR TITLE
fix(conn): change the read err log from info to debug

### DIFF
--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -483,7 +483,9 @@ func (c *connection) doRead() (err error) {
 	bytesRead, err = c.readBuffer.ReadOnce(c.rawConnection)
 
 	if err != nil {
-		log.DefaultLogger.Infof("[network] [read loop] do read err: %v", err)
+		if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
+			log.DefaultLogger.Debugf("[network] [read loop] do read err: %v", err)
+		}
 		if atomic.LoadUint32(&c.closed) == 1 {
 			return err
 		}


### PR DESCRIPTION
### Issues associated with this PR

KeepAlive connections without data transfer will frequently print timeout logs and eventually fill the disk， like:

![image](https://user-images.githubusercontent.com/28730939/101484140-22fed080-3994-11eb-9922-598c8e6ce593.png)


so, need change the read err log from info to debug.

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, details and the changes. At this time, Chinese is allowed to describe these.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
