### PR TITLE
api.HeaderMap empty key

### DIFF
--- a/pkg/filter/stream/transcoder/http2bolt/http2bolt_simple.go
+++ b/pkg/filter/stream/transcoder/http2bolt/http2bolt_simple.go
@@ -35,7 +35,7 @@ func init() {
 type http2bolt struct{}
 
 func (t *http2bolt) Accept(ctx context.Context, headers types.HeaderMap, buf types.IoBuffer, trailers types.HeaderMap) bool {
-	_, ok := headers.(http.RequestHeader)
+	_, ok := headers.(*http.RequestHeader)
 	return ok
 }
 
@@ -62,5 +62,5 @@ func (t *http2bolt) TranscodingResponse(ctx context.Context, headers types.Heade
 		targetResponse.SetStatusCode(http.InternalServerError)
 	}
 
-	return http.ResponseHeader{ResponseHeader: &targetResponse.Header}, buf, trailers, nil
+	return &http.ResponseHeader{ResponseHeader: &targetResponse.Header}, buf, trailers, nil
 }

--- a/pkg/filter/stream/transcoder/http2bolt/http2bolt_simple_test.go
+++ b/pkg/filter/stream/transcoder/http2bolt/http2bolt_simple_test.go
@@ -46,7 +46,7 @@ func Test_http2bolt_Accept(t1 *testing.T) {
 			name: "http header",
 			args: args{
 				ctx:      context.Background(),
-				headers:  http.RequestHeader{RequestHeader: &fasthttp.RequestHeader{}},
+				headers:  &http.RequestHeader{RequestHeader: &fasthttp.RequestHeader{}},
 				buf:      buffer.NewIoBufferString("Test_http2bolt_Accept"),
 				trailers: nil,
 			},
@@ -202,7 +202,7 @@ func buildHttpRequestHeaders(args map[string]string) http.RequestHeader {
 	return http.RequestHeader{RequestHeader: header}
 }
 
-func buildHttpResponseHeaders(status int, args map[string]string) http.ResponseHeader {
+func buildHttpResponseHeaders(status int, args map[string]string) *http.ResponseHeader {
 	header := &fasthttp.ResponseHeader{}
 
 	for key, value := range args {
@@ -211,7 +211,7 @@ func buildHttpResponseHeaders(status int, args map[string]string) http.ResponseH
 
 	header.SetStatusCode(status)
 
-	return http.ResponseHeader{ResponseHeader: header}
+	return &http.ResponseHeader{ResponseHeader: header}
 }
 
 func checkHeadersEqual(left, right types.HeaderMap) bool {
@@ -232,9 +232,9 @@ func checkHeadersEqual(left, right types.HeaderMap) bool {
 	statusEqual := true
 
 	switch left.(type) {
-	case http.ResponseHeader:
-		leftHttpResp := left.(http.ResponseHeader)
-		rightHttpResp := right.(http.ResponseHeader)
+	case *http.ResponseHeader:
+		leftHttpResp := left.(*http.ResponseHeader)
+		rightHttpResp := right.(*http.ResponseHeader)
 
 		statusEqual = leftHttpResp.StatusCode() == rightHttpResp.StatusCode()
 	}

--- a/pkg/protocol/http/conv/http1.go
+++ b/pkg/protocol/http/conv/http1.go
@@ -46,14 +46,14 @@ func (c *common2http) ConvHeader(ctx context.Context, headerMap types.HeaderMap)
 
 		switch direction {
 		case protocol.Request:
-			headerImpl := http.RequestHeader{&fasthttp.RequestHeader{}, nil}
+			headerImpl := &http.RequestHeader{&fasthttp.RequestHeader{}, nil}
 			// copy headers
 			for k, v := range header {
 				headerImpl.Set(k, v)
 			}
 			return headerImpl, nil
 		case protocol.Response:
-			headerImpl := http.ResponseHeader{&fasthttp.ResponseHeader{}, nil}
+			headerImpl := &http.ResponseHeader{&fasthttp.ResponseHeader{}, nil}
 			// copy headers
 			for k, v := range header {
 				headerImpl.Set(k, v)
@@ -77,7 +77,7 @@ type http2common struct{}
 
 func (c *http2common) ConvHeader(ctx context.Context, headerMap types.HeaderMap) (types.HeaderMap, error) {
 	switch header := headerMap.(type) {
-	case http.RequestHeader:
+	case *http.RequestHeader:
 		cheader := make(map[string]string, header.Len())
 
 		// copy headers
@@ -88,7 +88,7 @@ func (c *http2common) ConvHeader(ctx context.Context, headerMap types.HeaderMap)
 		cheader[protocol.MosnHeaderDirection] = protocol.Request
 
 		return protocol.CommonHeader(cheader), nil
-	case http.ResponseHeader:
+	case *http.ResponseHeader:
 		cheader := make(map[string]string, header.Len())
 
 		// copy headers

--- a/pkg/protocol/http/header_test.go
+++ b/pkg/protocol/http/header_test.go
@@ -21,7 +21,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
+	"mosn.io/api"
 )
 
 func TestRequestHeader_Add(t *testing.T) {
@@ -57,5 +59,37 @@ func TestResponseHeader_Add(t *testing.T) {
 	output := header.String()
 	if !strings.Contains(output, "value-one") || !strings.Contains(output, "value-two") {
 		t.Errorf("ResponseHeader.String not contains all header values")
+	}
+}
+
+func TestHeaderSetEmptyKey(t *testing.T) {
+	tests := []struct {
+		name   string
+		header api.HeaderMap
+	}{
+		{
+			name:   "request header",
+			header: &ResponseHeader{&fasthttp.ResponseHeader{}, nil},
+		},
+		{
+			name:   "response header",
+			header: &RequestHeader{&fasthttp.RequestHeader{}, nil},
+		},
+	}
+
+	key := "foobar"
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.header.Set(key, "")
+
+			// value is "", key exists
+			value, exists := tc.header.Get(key)
+			assert.True(t, exists)
+			assert.Equal(t, "", value)
+
+			tc.header.Del(key)
+			_, exists = tc.header.Get(key)
+			assert.False(t, exists)
+		})
 	}
 }

--- a/pkg/protocol/http/types.go
+++ b/pkg/protocol/http/types.go
@@ -112,7 +112,7 @@ func (h RequestHeader) Get(key string) (string, bool) {
 }
 
 // Set key-value pair in header map, the previous pair will be replaced if exists
-func (h RequestHeader) Set(key string, value string) {
+func (h *RequestHeader) Set(key string, value string) {
 	h.RequestHeader.Set(key, value)
 	if value == "" {
 		if h.EmptyValueHeaders == nil {
@@ -158,7 +158,7 @@ func (h RequestHeader) Clone() types.HeaderMap {
 			copyEmptyMap[k] = v
 		}
 	}
-	return RequestHeader{copy, copyEmptyMap}
+	return &RequestHeader{copy, copyEmptyMap}
 }
 
 func (h RequestHeader) ByteSize() (size uint64) {
@@ -193,7 +193,7 @@ func (h ResponseHeader) Get(key string) (string, bool) {
 }
 
 // Set key-value pair in header map, the previous pair will be replaced if exists
-func (h ResponseHeader) Set(key string, value string) {
+func (h *ResponseHeader) Set(key string, value string) {
 	h.ResponseHeader.Set(key, value)
 	if value == "" {
 		if h.EmptyValueHeaders == nil {
@@ -239,7 +239,7 @@ func (h ResponseHeader) Clone() types.HeaderMap {
 			copyEmptyMap[k] = v
 		}
 	}
-	return ResponseHeader{copy, copyEmptyMap}
+	return &ResponseHeader{copy, copyEmptyMap}
 }
 
 func (h ResponseHeader) ByteSize() (size uint64) {

--- a/pkg/router/base_rule_test.go
+++ b/pkg/router/base_rule_test.go
@@ -182,7 +182,7 @@ func Test_RouteRuleImplBase_matchRoute_matchMethod(t *testing.T) {
 		t.FailNow()
 	}
 
-	headers := http.RequestHeader{
+	headers := &http.RequestHeader{
 		RequestHeader: &fasthttp.RequestHeader{},
 	}
 	headers.Set(protocol.MosnHeaderMethod, "POST")


### PR DESCRIPTION
### Bug Detail

A key with an empty value set to api.HeaderMap. But header.Get(key) thinks that the key does not exist. The reason is that the receiver of the Set method is a value, not a pointer, so the modification of EmptyValueHeaders can only be effective in the Set method.

### Solutions

Use a pointer receiver instead of a value receiver.
