### PR TITLE
fix invalid empty value cause by nil EmptyValueHeaders

### DIFF
--- a/pkg/protocol/http/conv/http1.go
+++ b/pkg/protocol/http/conv/http1.go
@@ -46,14 +46,14 @@ func (c *common2http) ConvHeader(ctx context.Context, headerMap types.HeaderMap)
 
 		switch direction {
 		case protocol.Request:
-			headerImpl := http.RequestHeader{&fasthttp.RequestHeader{}, nil}
+			headerImpl := http.RequestHeader{&fasthttp.RequestHeader{}}
 			// copy headers
 			for k, v := range header {
 				headerImpl.Set(k, v)
 			}
 			return headerImpl, nil
 		case protocol.Response:
-			headerImpl := http.ResponseHeader{&fasthttp.ResponseHeader{}, nil}
+			headerImpl := http.ResponseHeader{&fasthttp.ResponseHeader{}}
 			// copy headers
 			for k, v := range header {
 				headerImpl.Set(k, v)

--- a/pkg/protocol/http/header_test.go
+++ b/pkg/protocol/http/header_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestRequestHeader_Add(t *testing.T) {
-	header := RequestHeader{&fasthttp.RequestHeader{}, nil}
+	header := RequestHeader{&fasthttp.RequestHeader{}}
 	header.Add("test-multiple", "value-one")
 	header.Add("test-multiple", "value-two")
 
@@ -43,7 +43,7 @@ func TestRequestHeader_Add(t *testing.T) {
 }
 
 func TestResponseHeader_Add(t *testing.T) {
-	header := ResponseHeader{&fasthttp.ResponseHeader{}, nil}
+	header := ResponseHeader{&fasthttp.ResponseHeader{}}
 	header.Add("test-multiple", "value-one")
 	header.Add("test-multiple", "value-two")
 

--- a/pkg/protocol/http/types_test.go
+++ b/pkg/protocol/http/types_test.go
@@ -33,7 +33,7 @@ func TestRequestHeader(t *testing.T) {
 		}
 	}()
 
-	header := RequestHeader{&fasthttp.RequestHeader{}, nil}
+	header := RequestHeader{&fasthttp.RequestHeader{}}
 
 	header.Set(MosnHeaderHostKey, "test")
 	if v, ok := header.Get(MosnHeaderHostKey); !ok || v != "test" {
@@ -69,12 +69,20 @@ func TestRequestHeader(t *testing.T) {
 		return true
 	})
 
-	// test set empty header
-	h2.Set(MosnHeaderEmptyKey, "")
-	if v, ok := header.Get(MosnHeaderEmptyKey); ok || v != "" {
+}
+
+func TestEmptyValueForRequestHeader(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("TestCommonHeader error: %v", r)
+		}
+	}()
+	header := RequestHeader{&fasthttp.RequestHeader{}}
+
+	header.Set(MosnHeaderEmptyKey, "")
+	if v, ok := header.Get(MosnHeaderEmptyKey); !ok || v != "" {
 		t.Errorf("Set empty header failed: %v %v", v, ok)
 	}
-
 }
 
 func TestResponseHeader(t *testing.T) {
@@ -84,7 +92,7 @@ func TestResponseHeader(t *testing.T) {
 		}
 	}()
 
-	header := ResponseHeader{&fasthttp.ResponseHeader{}, nil}
+	header := ResponseHeader{&fasthttp.ResponseHeader{}}
 
 	header.Set(MosnHeaderContentTypeKey, "test")
 	if v, ok := header.Get(MosnHeaderContentTypeKey); !ok || v != "test" {
@@ -119,5 +127,19 @@ func TestResponseHeader(t *testing.T) {
 	h2.Set(MosnHeaderHostKey, "")
 	if _, ok := header.Get(MosnHeaderHostKey); ok {
 		t.Error("Set empty header failed.")
+	}
+}
+
+func TestEmptyValueForResponseHeader(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("TestCommonHeader error: %v", r)
+		}
+	}()
+	header := ResponseHeader{&fasthttp.ResponseHeader{}}
+
+	header.Set(MosnHeaderEmptyKey, "")
+	if v, ok := header.Get(MosnHeaderEmptyKey); !ok || v != "" {
+		t.Errorf("Set empty header failed: %v %v", v, ok)
 	}
 }

--- a/pkg/stream/http/stream.go
+++ b/pkg/stream/http/stream.go
@@ -473,7 +473,7 @@ func (conn *serverStreamConnection) serve() {
 		}
 		s.connection = conn
 		s.responseDoneChan = make(chan bool, 1)
-		s.header = mosnhttp.RequestHeader{&s.request.Header, nil}
+		s.header = mosnhttp.RequestHeader{&s.request.Header}
 
 		var span types.Span
 		if trace.IsEnabled() {
@@ -654,7 +654,7 @@ func (s *clientStream) doSend() (err error) {
 
 func (s *clientStream) handleResponse() {
 	if s.response != nil {
-		header := mosnhttp.ResponseHeader{&s.response.Header, nil}
+		header := mosnhttp.ResponseHeader{&s.response.Header}
 
 		statusCode := header.StatusCode()
 		status := strconv.Itoa(statusCode)

--- a/pkg/stream/http/stream_test.go
+++ b/pkg/stream/http/stream_test.go
@@ -102,7 +102,7 @@ func Test_header_capitalization(t *testing.T) {
 		{
 			protocol.MosnHeaderQueryStringKey: queryString,
 			protocol.MosnHeaderPathKey:        path,
-			"Args": "Hello, world!",
+			"Args":                            "Hello, world!",
 		},
 	}
 
@@ -170,7 +170,7 @@ func Test_header_conflict(t *testing.T) {
 
 func Test_internal_header(t *testing.T) {
 	remoteAddr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:12200")
-	header := http.RequestHeader{&fasthttp.RequestHeader{}, nil}
+	header := http.RequestHeader{&fasthttp.RequestHeader{}}
 	uri := fasthttp.AcquireURI()
 
 	// headers.Get return
@@ -237,7 +237,7 @@ func Test_serverStream_handleRequest(t *testing.T) {
 		name   string
 		fields fields
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -354,7 +354,7 @@ func TestAppendData(t *testing.T) {
 }
 
 func convertHeader(payload protocol.CommonHeader) http.RequestHeader {
-	header := http.RequestHeader{&fasthttp.RequestHeader{}, nil}
+	header := http.RequestHeader{&fasthttp.RequestHeader{}}
 
 	for k, v := range payload {
 		header.Set(k, v)

--- a/pkg/trace/skywalking/http/tracer_test.go
+++ b/pkg/trace/skywalking/http/tracer_test.go
@@ -65,7 +65,7 @@ func Test_httpSkyTraceStartAndFinish(t *testing.T) {
 			args: args{
 				requestFunc: func() interface{} {
 					re := http.RequestHeader{
-						&fasthttp.RequestHeader{}, nil,
+						&fasthttp.RequestHeader{},
 					}
 					re.SetRequestURI("/test")
 					re.SetHost("127.0.0.1:80")
@@ -89,7 +89,7 @@ func Test_httpSkyTraceStartAndFinish(t *testing.T) {
 			args: args{
 				requestFunc: func() interface{} {
 					re := http.RequestHeader{
-						&fasthttp.RequestHeader{}, nil,
+						&fasthttp.RequestHeader{},
 					}
 					re.SetRequestURI("/test")
 					re.SetHost("127.0.0.1:80")
@@ -127,7 +127,7 @@ func Test_httpSkyTraceStartAndFinish(t *testing.T) {
 			args: args{
 				requestFunc: func() interface{} {
 					re := http.RequestHeader{
-						&fasthttp.RequestHeader{}, nil,
+						&fasthttp.RequestHeader{},
 					}
 					re.SetRequestURI("/test")
 					re.SetHost("127.0.0.1:80")
@@ -154,7 +154,7 @@ func Test_httpSkyTraceStartAndFinish(t *testing.T) {
 			s := tracer.Start(tt.args.context, downStreamRequest, time.Now())
 
 			upStreamRequest := http.RequestHeader{
-				&fasthttp.RequestHeader{}, nil,
+				&fasthttp.RequestHeader{},
 			}
 			requestInfo := tt.args.requestInfoFunc()
 			s.InjectContext(upStreamRequest, requestInfo)


### PR DESCRIPTION
### Issues associated with this PR

#1518 

### Solutions

function `Set` has no pointer reciever, so  `make EmptyValueHeaders` in `Set` does not take effect. So, add a New function to create struct which with a alread maked map to fix it.

### UT result

add test to pkg/protocol/http/types_test.go

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
