### PR TITLE
Featuregate/stage

### DIFF
--- a/cmd/mosn/main/control.go
+++ b/cmd/mosn/main/control.go
@@ -124,6 +124,8 @@ var (
 		},
 		Action: func(c *cli.Context) error {
 			stm := mosn.NewStageManager(c, c.String("config"))
+			// if needs featuregate init in parameter stage or init stage
+			// append a new stage and called featuregate.ExecuteInitFunc(keys...)
 			// parameter parsed registered
 			stm.AppendParamsParsedStage(DefaultParamsParsed)
 			// initial registerd
@@ -134,7 +136,7 @@ var (
 				metrics.SetGoVersion(runtime.Version())
 			})
 			// pre-startup
-			stm.AppendPreStartStage(mosn.DefaultPreStartStage)
+			stm.AppendPreStartStage(mosn.DefaultPreStartStage) // called finally stage by default
 			// startup
 			stm.AppendStartStage(mosn.DefaultStartStage)
 			// execute all runs

--- a/pkg/featuregate/default.go
+++ b/pkg/featuregate/default.go
@@ -51,8 +51,12 @@ func KnownFeatures() map[string]bool {
 	return defaultFeatureGate.KnownFeatures()
 }
 
-func StartInit() {
-	defaultFeatureGate.StartInit()
+func ExecuteInitFunc(keys ...Feature) {
+	defaultFeatureGate.ExecuteInitFunc(keys...)
+}
+
+func FinallyInitFunc() {
+	defaultFeatureGate.FinallyInitFunc()
 }
 
 func WaitInitFinsh() error {

--- a/pkg/featuregate/subscribe_dependy_test.go
+++ b/pkg/featuregate/subscribe_dependy_test.go
@@ -80,7 +80,7 @@ func TestSubDependcyReady(t *testing.T) {
 	AddFeatureSpec(_TestFeatureA, fa)
 	AddFeatureSpec(_TestFeatureB, fb)
 	Set("feature A=true, feature B=true")
-	StartInit()
+	FinallyInitFunc()
 	// feature B not ready, feature A sub will timeout
 	if _, err := Subscribe(_TestFeatureA, time.Second); !_IsSubTimeout(err) {
 		t.Errorf("expected sub feature A timeout, but got: %v", err)
@@ -109,7 +109,7 @@ func TestSubDependcyNotReady(t *testing.T) {
 	AddFeatureSpec(_TestFeatureA, fa)
 	AddFeatureSpec(_TestFeatureB, fb)
 	Set("feature A=true, feature B=false")
-	StartInit()
+	FinallyInitFunc()
 	// feature B is not ready, so the feature A is run as 2 mode
 	ready, err := Subscribe(_TestFeatureA, time.Second)
 	if err != nil || !ready {
@@ -133,7 +133,7 @@ func TestSubDependcyNotReady2(t *testing.T) {
 	AddFeatureSpec(_TestFeatureA, fa)
 	AddFeatureSpec(_TestFeatureB, fb)
 	Set("feature A=false, feature B=true")
-	StartInit()
+	FinallyInitFunc()
 	fb.SendNotify() // feature B ready
 	ready, err := Subscribe(_TestFeatureA, time.Second)
 	if err != nil || ready {

--- a/pkg/featuregate/types.go
+++ b/pkg/featuregate/types.go
@@ -41,7 +41,7 @@ type FeatureSpec interface {
 	SetState(enable bool)
 	// State indicates the feature enablement
 	State() bool
-	// InitFunc used to init process when StartInit is invoked
+	// InitFunc used to init process when ExecuteInitFunc or FinallyInitFunc is invoked
 	InitFunc()
 	// PreRelease indicates the maturity level of the feature
 	PreRelease() prerelease
@@ -50,4 +50,5 @@ type FeatureSpec interface {
 var (
 	ErrInited    = errors.New("feature gate is already inited")
 	ErrNotInited = errors.New("feature gate is not inited")
+	ErrSubStage  = errors.New("feature cannot call subscribe because it is not inited in finally stage")
 )

--- a/pkg/mosn/default_stages.go
+++ b/pkg/mosn/default_stages.go
@@ -52,7 +52,7 @@ func DefaultPreStartStage(m *Mosn) {
 	}, syscall.SIGINT, syscall.SIGTERM)
 	// start xds client
 	m.StartXdsClient()
-	featuregate.StartInit()
+	featuregate.FinallyInitFunc()
 	m.HandleExtendConfig()
 }
 

--- a/pkg/mosn/init.go
+++ b/pkg/mosn/init.go
@@ -51,6 +51,7 @@ func InitDebugServe(c *v2.MOSNConfig) {
 	}
 }
 
+// Init Stages Function
 func InitializeTracing(c *v2.MOSNConfig) {
 	initializeTracing(c.Tracing)
 }


### PR DESCRIPTION
1. 新增FeatureGate，修改FeatureGate的Enable状态需要在任意一个初始化（InitFunc）执行之前。之后不再允许修改，限制以后可以去掉保护读写并发用的锁，可以直接使用featuregate.Enabled(key)判断feature状态
2. FeatureGate执行初始化可显示指定顺序，指定顺序的方法需要修改main，作为一个可扩展的能力。顺序执行的InitFunc是同步调用，不支持“订阅”模式