### PR TITLE
fix: duplicate called filepath.clean method in streamfilter config

### DIFF
--- a/pkg/streamfilter/config.go
+++ b/pkg/streamfilter/config.go
@@ -45,7 +45,7 @@ func LoadAndRegisterStreamFilters(path string) {
 		return
 	}
 
-	content, err := ioutil.ReadFile(filepath.Clean(absPath))
+	content, err := ioutil.ReadFile(absPath)
 	if err != nil {
 		log.DefaultLogger.Errorf("[streamfilter] LoadAndRegisterStreamFilters load config failed, error: %v", err)
 		return


### PR DESCRIPTION
### Solutions
duplicate called filepath.clean method in streamfilter config.
because clean method will be called in filepath.abs, so don't called again.
![image](https://user-images.githubusercontent.com/46013886/109096030-c2439080-7757-11eb-913e-7e6aac41fea5.png)