### PR TITLE
fix slice clean concur

### DIFF
--- a/pkg/admin/debug/debug_api.go
+++ b/pkg/admin/debug/debug_api.go
@@ -30,6 +30,7 @@ func init() {
 	log.StartLogger.Infof("mosn is builded in debug mosn")
 	admin.RegisterAdminHandleFunc("/debug/update_config", DebugUpdateMosnConfig)
 	admin.RegisterAdminHandleFunc("/debug/disable_tls", DebugUpdateTLSDisable)
+	admin.RegisterAdminHandleFunc("/debug/update_route", DebugUdpateRoute)
 }
 
 // The config types support to be updated
@@ -116,6 +117,7 @@ func DebugUpdateMosnConfig(w http.ResponseWriter, r *http.Request) {
 		log.DefaultLogger.Infof("update extend config success")
 		w.Write(success)
 	default:
+		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, "invalid type, do nothing")
 	}
 }
@@ -141,4 +143,67 @@ func DebugUpdateTLSDisable(w http.ResponseWriter, r *http.Request) {
 		cluster.EnableClientSideTLS()
 	}
 	w.Write(success)
+}
+
+const (
+	AddRoute    = "add"
+	RemoveRoute = "remove"
+)
+
+type RouteConfig struct {
+	RouteName string     `json:"router_config_name"`
+	Domain    string     `json:"domain"`
+	Route     *v2.Router `json:"route"`
+}
+
+func DebugUdpateRoute(w http.ResponseWriter, r *http.Request) {
+	content, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.DefaultLogger.Errorf("api [update mosn config] read body error: %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, "invalid request")
+		return
+	}
+	invalid := func(s string) {
+		log.DefaultLogger.Errorf("api [update mosn config] is not a valid request: %s", s)
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, "invalid request")
+	}
+	req := &UpdateConfigRequest{}
+	if err := json.Unmarshal(content, req); err != nil {
+		invalid(string(content))
+		return
+	}
+	switch req.Type {
+	case AddRoute:
+		rcfg := &RouteConfig{}
+		if err := json.Unmarshal(req.Config, rcfg); err != nil {
+			invalid(string(req.Config))
+			return
+		}
+		mng := router.GetRoutersMangerInstance()
+		if err := mng.AddRoute(rcfg.RouteName, rcfg.Domain, rcfg.Route); err != nil {
+			invalid(err.Error())
+			return
+		}
+		log.DefaultLogger.Infof("update route config success")
+		w.Write(success)
+	case RemoveRoute:
+		rcfg := &RouteConfig{}
+		if err := json.Unmarshal(req.Config, rcfg); err != nil {
+			invalid(string(req.Config))
+			return
+		}
+		mng := router.GetRoutersMangerInstance()
+		if err := mng.RemoveAllRoutes(rcfg.RouteName, rcfg.Domain); err != nil {
+			invalid(err.Error())
+			return
+		}
+		log.DefaultLogger.Infof("remove all route success")
+		w.Write(success)
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, "invalid type, do nothing")
+	}
+
 }

--- a/pkg/config/v2/json_test.go
+++ b/pkg/config/v2/json_test.go
@@ -530,7 +530,7 @@ func TestFilterChainUnmarshal(t *testing.T) {
 
 func TestRouterConfigMarshal(t *testing.T) {
 	router := &RouterConfiguration{
-		VirtualHosts: []*VirtualHost{
+		VirtualHosts: []VirtualHost{
 			{
 				Name:    "test",
 				Domains: []string{"*"},
@@ -717,8 +717,8 @@ func TestRouterMarshalWithSep(t *testing.T) {
 	vhWithSep := "test/vh/with/sep"
 	os.RemoveAll(routerPath)
 	rcfg := &RouterConfiguration{
-		VirtualHosts: []*VirtualHost{
-			&VirtualHost{
+		VirtualHosts: []VirtualHost{
+			VirtualHost{
 				Name:    vhWithSep,
 				Domains: []string{"*"},
 			},
@@ -794,7 +794,7 @@ func TestRouterConfigDynamicModeParse(t *testing.T) {
 		t.Fatalf("virtual host parsed not enough, got: %v", testConfig.VirtualHosts)
 	}
 	// add a new virtualhost
-	testConfig.VirtualHosts = append(testConfig.VirtualHosts, &VirtualHost{
+	testConfig.VirtualHosts = append(testConfig.VirtualHosts, VirtualHost{
 		Domains: []string{"*"},
 	})
 	// dump json

--- a/pkg/config/v2/route.go
+++ b/pkg/config/v2/route.go
@@ -37,7 +37,7 @@ type RouterConfigurationConfig struct {
 	ResponseHeadersToAdd    []*HeaderValueOption `json:"response_headers_to_add,omitempty"`
 	ResponseHeadersToRemove []string             `json:"response_headers_to_remove,omitempty"`
 	RouterConfigPath        string               `json:"router_configs,omitempty"`
-	StaticVirtualHosts      []*VirtualHost       `json:"virtual_hosts,omitempty"`
+	StaticVirtualHosts      []VirtualHost        `json:"virtual_hosts,omitempty"`
 }
 
 type RouterConfig struct {
@@ -197,7 +197,7 @@ type HeaderValue struct {
 
 // RouterConfiguration is a config for routers
 type RouterConfiguration struct {
-	VirtualHosts []*VirtualHost `json:"-"`
+	VirtualHosts []VirtualHost `json:"-"`
 	RouterConfigurationConfig
 }
 
@@ -267,8 +267,8 @@ func (rc *RouterConfiguration) UnmarshalJSON(b []byte) error {
 		}
 		for _, f := range files {
 			fileName := path.Join(cfg.RouterConfigPath, f.Name())
-			vh := &VirtualHost{}
-			e := utils.ReadJsonFile(fileName, vh)
+			vh := VirtualHost{}
+			e := utils.ReadJsonFile(fileName, &vh)
 			switch e {
 			case nil:
 				rc.VirtualHosts = append(rc.VirtualHosts, vh)

--- a/pkg/configmanager/featuregate_test.go
+++ b/pkg/configmanager/featuregate_test.go
@@ -112,8 +112,8 @@ func TestFeatureDump(t *testing.T) {
 			RouterConfigName: "test_router_2",
 			RouterConfigPath: "/tmp/routers/test_router_2/",
 		},
-		VirtualHosts: []*v2.VirtualHost{
-			&v2.VirtualHost{
+		VirtualHosts: []v2.VirtualHost{
+			v2.VirtualHost{
 				Name:    "virtualhost_1",
 				Domains: []string{"*"},
 			},
@@ -124,8 +124,8 @@ func TestFeatureDump(t *testing.T) {
 			RouterConfigName: "test_router",
 			RouterConfigPath: "/tmp/routers/test_router/",
 		},
-		VirtualHosts: []*v2.VirtualHost{
-			&v2.VirtualHost{
+		VirtualHosts: []v2.VirtualHost{
+			v2.VirtualHost{
 				Name:    "virtualhost_0",
 				Domains: []string{"*"},
 			},

--- a/pkg/router/fastindex_test.go
+++ b/pkg/router/fastindex_test.go
@@ -80,7 +80,7 @@ func TestFastIndexRouteFromHeaderKV(t *testing.T) {
 func TestMatchRouteFromHeaderKV(t *testing.T) {
 	routersCnt := 10
 	routersCfg := createRoutersCfg(routersCnt)
-	vhCfg := &v2.VirtualHost{
+	vhCfg := v2.VirtualHost{
 		Domains: []string{"*"},
 		Routers: routersCfg,
 	}
@@ -88,7 +88,7 @@ func TestMatchRouteFromHeaderKV(t *testing.T) {
 		RouterConfigurationConfig: v2.RouterConfigurationConfig{
 			RouterConfigName: "test",
 		},
-		VirtualHosts: []*v2.VirtualHost{
+		VirtualHosts: []v2.VirtualHost{
 			vhCfg,
 		},
 	}

--- a/pkg/router/routers_impl.go
+++ b/pkg/router/routers_impl.go
@@ -217,7 +217,7 @@ func NewRouters(routerConfig *v2.RouterConfiguration) (types.Routers, error) {
 	}
 	configImpl := NewConfigImpl(routerConfig)
 	for index, vhConfig := range routerConfig.VirtualHosts {
-		vh, err := NewVirtualHostImpl(vhConfig)
+		vh, err := NewVirtualHostImpl(&vhConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/router/routers_impl_test.go
+++ b/pkg/router/routers_impl_test.go
@@ -45,17 +45,17 @@ func newTestSimpleRouter(name string) v2.Router {
 	return r
 }
 
-var testVirutalHostConfigs = map[string]*v2.VirtualHost{
-	"all":             &v2.VirtualHost{Name: "all", Domains: []string{"*"}, Routers: []v2.Router{newTestSimpleRouter("test")}},
-	"wildcard-domain": &v2.VirtualHost{Name: "wildcard-domain", Domains: []string{"*.sofa-mosn.test"}, Routers: []v2.Router{newTestSimpleRouter("test")}},
-	"domain":          &v2.VirtualHost{Name: "domain", Domains: []string{"www.sofa-mosn.test"}, Routers: []v2.Router{newTestSimpleRouter("test")}},
+var testVirutalHostConfigs = map[string]v2.VirtualHost{
+	"all":             v2.VirtualHost{Name: "all", Domains: []string{"*"}, Routers: []v2.Router{newTestSimpleRouter("test")}},
+	"wildcard-domain": v2.VirtualHost{Name: "wildcard-domain", Domains: []string{"*.sofa-mosn.test"}, Routers: []v2.Router{newTestSimpleRouter("test")}},
+	"domain":          v2.VirtualHost{Name: "domain", Domains: []string{"www.sofa-mosn.test"}, Routers: []v2.Router{newTestSimpleRouter("test")}},
 }
 
 func TestNewRoutersSingle(t *testing.T) {
 	// Single VirtualHost
 	// Add VirtualHost type verify
 	testCases := []struct {
-		virtualHost *v2.VirtualHost
+		virtualHost v2.VirtualHost
 		Expected    func(*routersImpl) bool
 	}{
 		{
@@ -80,7 +80,7 @@ func TestNewRoutersSingle(t *testing.T) {
 	for _, tc := range testCases {
 
 		cfg := &v2.RouterConfiguration{
-			VirtualHosts: []*v2.VirtualHost{tc.virtualHost},
+			VirtualHosts: []v2.VirtualHost{tc.virtualHost},
 		}
 
 		routers, err := NewRouters(cfg)
@@ -97,7 +97,7 @@ func TestNewRoutersSingle(t *testing.T) {
 
 func TestNewRoutersGroup(t *testing.T) {
 	//A group of VirtualHost
-	var virtualhosts []*v2.VirtualHost
+	var virtualhosts []v2.VirtualHost
 	for _, vhConfig := range testVirutalHostConfigs {
 		virtualhosts = append(virtualhosts, vhConfig)
 	}
@@ -119,19 +119,19 @@ func TestNewRoutersGroup(t *testing.T) {
 func TestNewRoutersDuplicate(t *testing.T) {
 	// two virtualhosts, both domain is "*", expected failed
 	if _, err := NewRouters(&v2.RouterConfiguration{
-		VirtualHosts: []*v2.VirtualHost{testVirutalHostConfigs["all"], testVirutalHostConfigs["all"]},
+		VirtualHosts: []v2.VirtualHost{testVirutalHostConfigs["all"], testVirutalHostConfigs["all"]},
 	}); err == nil {
 		t.Error("expected an error occur, but not")
 	}
 	//two virtualhosts, both domain is "www.sofa-mosn.test", expected failed
 	if _, err := NewRouters(&v2.RouterConfiguration{
-		VirtualHosts: []*v2.VirtualHost{testVirutalHostConfigs["domain"], testVirutalHostConfigs["domain"]},
+		VirtualHosts: []v2.VirtualHost{testVirutalHostConfigs["domain"], testVirutalHostConfigs["domain"]},
 	}); err == nil {
 		t.Error("expected an error occur, but not")
 	}
 	// wildcard domain with same suffix, expected failed
 	if _, err := NewRouters(&v2.RouterConfiguration{
-		VirtualHosts: []*v2.VirtualHost{testVirutalHostConfigs["wildcard-domain"], testVirutalHostConfigs["wildcard-domain"]},
+		VirtualHosts: []v2.VirtualHost{testVirutalHostConfigs["wildcard-domain"], testVirutalHostConfigs["wildcard-domain"]},
 	}); err == nil {
 		t.Error("expected an error occur, but not")
 	}
@@ -139,10 +139,10 @@ func TestNewRoutersDuplicate(t *testing.T) {
 	// *.test.com, *.test.net, *.test.com.cn
 	// expected OK
 	if _, err := NewRouters(&v2.RouterConfiguration{
-		VirtualHosts: []*v2.VirtualHost{
-			&v2.VirtualHost{Domains: []string{"*.test.com"}, Routers: []v2.Router{newTestSimpleRouter("test")}},
-			&v2.VirtualHost{Domains: []string{"*.test.net"}, Routers: []v2.Router{newTestSimpleRouter("test")}},
-			&v2.VirtualHost{Domains: []string{"*.test.com.cn"}, Routers: []v2.Router{newTestSimpleRouter("test")}},
+		VirtualHosts: []v2.VirtualHost{
+			v2.VirtualHost{Domains: []string{"*.test.com"}, Routers: []v2.Router{newTestSimpleRouter("test")}},
+			v2.VirtualHost{Domains: []string{"*.test.net"}, Routers: []v2.Router{newTestSimpleRouter("test")}},
+			v2.VirtualHost{Domains: []string{"*.test.com.cn"}, Routers: []v2.Router{newTestSimpleRouter("test")}},
 		},
 	}); err != nil {
 		t.Error("NewRouters with different wildcard domain failed")
@@ -153,7 +153,7 @@ func TestNewRoutersDuplicate(t *testing.T) {
 // match all
 func TestDefaultMatch(t *testing.T) {
 	cfg := &v2.RouterConfiguration{
-		VirtualHosts: []*v2.VirtualHost{
+		VirtualHosts: []v2.VirtualHost{
 			testVirutalHostConfigs["all"],
 		},
 	}
@@ -184,7 +184,7 @@ func TestDefaultMatch(t *testing.T) {
 }
 func TestDomainMatch(t *testing.T) {
 	cfg := &v2.RouterConfiguration{
-		VirtualHosts: []*v2.VirtualHost{
+		VirtualHosts: []v2.VirtualHost{
 			testVirutalHostConfigs["domain"],
 		},
 	}
@@ -257,12 +257,12 @@ func TestWildcardMatch(t *testing.T) {
 	ctx := variable.NewVariableContext(context.Background())
 
 	for i, tc := range testCases {
-		vh := &v2.VirtualHost{
+		vh := v2.VirtualHost{
 			Domains: []string{tc.wildcardDomain},
 			Routers: []v2.Router{simpleRouter},
 		}
 		cfg := &v2.RouterConfiguration{
-			VirtualHosts: []*v2.VirtualHost{vh},
+			VirtualHosts: []v2.VirtualHost{vh},
 		}
 		routers, err := NewRouters(cfg)
 		if err != nil {
@@ -298,11 +298,11 @@ func TestWildcardMatch(t *testing.T) {
 }
 
 func TestWildcardLongestSuffixMatch(t *testing.T) {
-	virtualHosts := []*v2.VirtualHost{
-		&v2.VirtualHost{Domains: []string{"f-bar.baz.com"}, Routers: []v2.Router{newTestSimpleRouter("domain")}},
-		&v2.VirtualHost{Domains: []string{"*.baz.com"}, Routers: []v2.Router{newTestSimpleRouter("short")}},
-		&v2.VirtualHost{Domains: []string{"*-bar.baz.com"}, Routers: []v2.Router{newTestSimpleRouter("long")}},
-		&v2.VirtualHost{Domains: []string{"*.foo.com"}, Routers: []v2.Router{newTestSimpleRouter("foo")}},
+	virtualHosts := []v2.VirtualHost{
+		v2.VirtualHost{Domains: []string{"f-bar.baz.com"}, Routers: []v2.Router{newTestSimpleRouter("domain")}},
+		v2.VirtualHost{Domains: []string{"*.baz.com"}, Routers: []v2.Router{newTestSimpleRouter("short")}},
+		v2.VirtualHost{Domains: []string{"*-bar.baz.com"}, Routers: []v2.Router{newTestSimpleRouter("long")}},
+		v2.VirtualHost{Domains: []string{"*.foo.com"}, Routers: []v2.Router{newTestSimpleRouter("foo")}},
 	}
 	cfg := &v2.RouterConfiguration{
 		VirtualHosts: virtualHosts,
@@ -340,11 +340,11 @@ func TestWildcardLongestSuffixMatch(t *testing.T) {
 func TestAddRouter(t *testing.T) {
 	// 1. no routes
 	cfg := &v2.RouterConfiguration{
-		VirtualHosts: []*v2.VirtualHost{
-			&v2.VirtualHost{
+		VirtualHosts: []v2.VirtualHost{
+			v2.VirtualHost{
 				Domains: []string{"www.test.com"},
 			},
-			&v2.VirtualHost{
+			v2.VirtualHost{
 				Domains: []string{"*"},
 			},
 		},
@@ -378,8 +378,8 @@ func TestAddRouter(t *testing.T) {
 func TestRemoveAllRoutes(t *testing.T) {
 	// init
 	cfg := &v2.RouterConfiguration{
-		VirtualHosts: []*v2.VirtualHost{
-			&v2.VirtualHost{
+		VirtualHosts: []v2.VirtualHost{
+			v2.VirtualHost{
 				Domains: []string{"www.test.com"},
 				Routers: []v2.Router{
 					{
@@ -396,7 +396,7 @@ func TestRemoveAllRoutes(t *testing.T) {
 					},
 				},
 			},
-			&v2.VirtualHost{
+			v2.VirtualHost{
 				Domains: []string{"*"},
 				Routers: []v2.Router{
 					{
@@ -451,7 +451,7 @@ func TestInvalidConfig(t *testing.T) {
 		t.Errorf("config should have at least one virtual host")
 	}
 	// duplicate virtual host
-	cfg.VirtualHosts = []*v2.VirtualHost{
+	cfg.VirtualHosts = []v2.VirtualHost{
 		{
 			Domains: []string{"*"},
 		},

--- a/pkg/router/routers_manager.go
+++ b/pkg/router/routers_manager.go
@@ -133,8 +133,10 @@ func (rm *routersManagerImpl) AddRoute(routerConfigName, domain string, route *v
 			return errors.New(errMsg)
 		}
 		// modify config
-		routersCfg := cfg.VirtualHosts[index].Routers
-		routersCfg = append(routersCfg, *route)
+		// make a new one to avoid the slice is referenced outside the lock
+		routersCfg := make([]v2.Router, len(cfg.VirtualHosts[index].Routers)+1)
+		copy(routersCfg, cfg.VirtualHosts[index].Routers)
+		routersCfg[len(cfg.VirtualHosts[index].Routers)] = *route
 		cfg.VirtualHosts[index].Routers = routersCfg
 		rw.routersConfig = cfg
 		configmanager.SetRouter(*cfg)
@@ -166,8 +168,8 @@ func (rm *routersManagerImpl) RemoveAllRoutes(routerConfigName, domain string) e
 			return errors.New(errMsg)
 		}
 		// modify config
-		routersCfg := cfg.VirtualHosts[index].Routers
-		cfg.VirtualHosts[index].Routers = routersCfg[:0]
+		// make a new one to avoid the slice is referenced outside the lock
+		cfg.VirtualHosts[index].Routers = []v2.Router{}
 		rw.routersConfig = cfg
 		configmanager.SetRouter(*cfg)
 	}

--- a/pkg/router/routers_manager_test.go
+++ b/pkg/router/routers_manager_test.go
@@ -357,6 +357,9 @@ func Test_routersManager_AddRouter(t *testing.T) {
 	if len(cfgChanged.VirtualHosts[0].Routers) != 1 || len(cfgChanged.VirtualHosts[1].Routers) != 1 {
 		t.Fatal("default route config is not changed")
 	}
+	if len(cfgChanged.VirtualHosts[0].Routers[0].Match.Headers) != 1 {
+		t.Fatal("virtual host config routers is not expected")
+	}
 	routersChanged := rw.GetRouters()
 	// the wrapper can get the new router
 	if r := routersChanged.MatchRouteFromHeaderKV(ctx, nil, "service", "test"); r == nil {

--- a/pkg/router/routers_manager_test.go
+++ b/pkg/router/routers_manager_test.go
@@ -27,10 +27,9 @@ import (
 	"context"
 	"testing"
 
-	"mosn.io/mosn/pkg/variable"
-
 	v2 "mosn.io/mosn/pkg/config/v2"
 	"mosn.io/mosn/pkg/types"
+	"mosn.io/mosn/pkg/variable"
 )
 
 var routerConfig = `{
@@ -296,7 +295,7 @@ func Test_routersManager_AddRouter(t *testing.T) {
 		RouterConfigurationConfig: v2.RouterConfigurationConfig{
 			RouterConfigName: "test_addrouter",
 		},
-		VirtualHosts: []*v2.VirtualHost{
+		VirtualHosts: []v2.VirtualHost{
 			{
 				Name:    "test_addrouter_vh",
 				Domains: []string{"www.test.com"},
@@ -374,7 +373,7 @@ func Test_routersManager_RemoveAllRouter(t *testing.T) {
 		RouterConfigurationConfig: v2.RouterConfigurationConfig{
 			RouterConfigName: "test_remove_all_router",
 		},
-		VirtualHosts: []*v2.VirtualHost{
+		VirtualHosts: []v2.VirtualHost{
 			{
 				Name:    "test_addrouter_vh",
 				Domains: []string{"www.test.com"},

--- a/pkg/upstream/servicediscovery/dubbod/bootstrap.go
+++ b/pkg/upstream/servicediscovery/dubbod/bootstrap.go
@@ -125,7 +125,7 @@ func initRouterManager() {
 		RouterConfigurationConfig: v2.RouterConfigurationConfig{
 			RouterConfigName: dubboRouterConfigName,
 		},
-		VirtualHosts: []*v2.VirtualHost{
+		VirtualHosts: []v2.VirtualHost{
 			{
 				Name:    dubboRouterConfigName,
 				Domains: []string{"*"},

--- a/pkg/xds/conv/convertxds.go
+++ b/pkg/xds/conv/convertxds.go
@@ -838,10 +838,10 @@ func ConvertRouterConf(routeConfigName string, xdsRouteConfig *xdsapi.RouteConfi
 		return nil, false
 	}
 
-	virtualHosts := make([]*v2.VirtualHost, 0)
+	virtualHosts := make([]v2.VirtualHost, 0)
 
 	for _, xdsVirtualHost := range xdsRouteConfig.GetVirtualHosts() {
-		virtualHost := &v2.VirtualHost{
+		virtualHost := v2.VirtualHost{
 			Name:    xdsVirtualHost.GetName(),
 			Domains: xdsVirtualHost.GetDomains(),
 			Routers: convertRoutes(xdsVirtualHost.GetRoutes()),

--- a/test/cases/autoconfig/router_test.go
+++ b/test/cases/autoconfig/router_test.go
@@ -78,6 +78,48 @@ func TestUpdateRouter(t *testing.T) {
 			Verify(route, NotNil)
 			Verify(len(route.VirtualHosts[0].Routers), Equal, 2)
 		})
+		Case("add route rule", func() {
+			config := `{
+				"router_config_name": "test_router",
+				"domain": "",
+				"route": {
+					"match":{"path":"/new"},
+					"route":{"cluster_name":"testnew"}
+				}
+			}`
+			err := m.UpdateRoute(34901, "add", config)
+			Verify(err, Equal, nil)
+			// wait auto config dump
+			time.Sleep(4 * time.Second)
+			mcfg := m.LoadMosnConfig() // read config from files
+			var route *v2.RouterConfiguration
+			for _, r := range mcfg.Servers[0].Routers {
+				if r.RouterConfigName == "test_router" {
+					route = r
+				}
+			}
+			Verify(route, NotNil)
+			Verify(len(route.VirtualHosts[0].Routers), Equal, 3)
+		})
+		Case("remove route rule", func() {
+			config := `{
+				"router_config_name": "test_router",
+				"domain": ""
+			}`
+			err := m.UpdateRoute(34901, "remove", config)
+			Verify(err, Equal, nil)
+			// wait auto config dump
+			time.Sleep(4 * time.Second)
+			mcfg := m.LoadMosnConfig() // read config from files
+			var route *v2.RouterConfiguration
+			for _, r := range mcfg.Servers[0].Routers {
+				if r.RouterConfigName == "test_router" {
+					route = r
+				}
+			}
+			Verify(route, NotNil)
+			Verify(len(route.VirtualHosts[0].Routers), Equal, 0)
+		})
 		TearDown(func() {
 			m.Stop()
 		})

--- a/test/integrate/filter/perfilterconfig_test.go
+++ b/test/integrate/filter/perfilterconfig_test.go
@@ -125,8 +125,8 @@ func createConfigFilterProxyMesh(addr string, hosts []string, proto types.Protoc
 		RouterConfigurationConfig: v2.RouterConfigurationConfig{
 			RouterConfigName: routerCfgName,
 		},
-		VirtualHosts: []*v2.VirtualHost{
-			&v2.VirtualHost{
+		VirtualHosts: []v2.VirtualHost{
+			v2.VirtualHost{
 				Name:    "test1",
 				Domains: []string{"domain1.example"},
 				Routers: []v2.Router{
@@ -166,7 +166,7 @@ func createConfigFilterProxyMesh(addr string, hosts []string, proto types.Protoc
 					},
 				},
 			},
-			&v2.VirtualHost{
+			v2.VirtualHost{
 				Name:    "test2",
 				Domains: []string{"*"},
 				Routers: []v2.Router{

--- a/test/lib/mosn/mosn.go
+++ b/test/lib/mosn/mosn.go
@@ -73,6 +73,24 @@ func (op *MosnOperator) UpdateConfig(port int, typ string, config string) error 
 	return nil
 }
 
+func (op *MosnOperator) UpdateRoute(port int, typ string, config string) error {
+	// test case, do not care about performance
+	body := fmt.Sprintf(`{
+		"type": "%s",
+		"config": %s
+	}`, typ, config)
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/debug/update_route", port), strings.NewReader(body))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("request failed")
+	}
+	return nil
+}
+
 func (op *MosnOperator) GetMosnConfig(port int, params string) ([]byte, error) {
 	if len(params) > 0 {
 		params = "?" + params

--- a/test/util/genconfig.go
+++ b/test/util/genconfig.go
@@ -32,8 +32,8 @@ func makeFilterChain(proxy *v2.Proxy, routers []v2.Router, cfgName string) v2.Fi
 		RouterConfigurationConfig: v2.RouterConfigurationConfig{
 			RouterConfigName: cfgName,
 		},
-		VirtualHosts: []*v2.VirtualHost{
-			&v2.VirtualHost{
+		VirtualHosts: []v2.VirtualHost{
+			v2.VirtualHost{
 				Name:    "test",
 				Domains: []string{"*"},
 				Routers: routers,


### PR DESCRIPTION
在configmanager中做配置持久化时，通过configmanager.SetRouter进行路由配置的设置

```
func SetRouter(router v2.RouterConfiguration) {
}
```
这里是通过struct 值传递的方式，进行了一次拷贝，但是struct里包含的切片(slice) 依然是引用
虽然在router中处理配置时有锁、在configmanager中处理配置也有锁，但是各自只能锁到自己的struct，而其中切片(slice)仍然是共通的，可能存在并发冲突。