### PR TITLE
optimize proxy extend config parse

### DIFF
--- a/pkg/filter/network/proxy/factory.go
+++ b/pkg/filter/network/proxy/factory.go
@@ -45,7 +45,9 @@ type genericProxyFilterConfigFactory struct {
 }
 
 func (gfcf *genericProxyFilterConfigFactory) CreateFilterChain(ctx context.Context, callbacks api.NetWorkFilterChainFactoryCallbacks) {
-	ctx = mosnctx.WithValue(ctx, types.ContextKeyProxyGeneralConfig, gfcf.extendConfig)
+	if gfcf.extendConfig != nil {
+		ctx = mosnctx.WithValue(ctx, types.ContextKeyProxyGeneralConfig, gfcf.extendConfig)
+	}
 	if gfcf.subProtocols != "" {
 		ctx = mosnctx.WithValue(ctx, types.ContextSubProtocol, gfcf.subProtocols)
 	}

--- a/pkg/protocol/config.go
+++ b/pkg/protocol/config.go
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protocol
+
+import (
+	"sync"
+
+	"mosn.io/api"
+	"mosn.io/mosn/pkg/log"
+)
+
+// ProtocolConfigHandler translate general config into protocol configs
+type ProtocolConfigHandler func(v interface{}) interface{}
+
+var protocolConfigHandlers sync.Map
+
+func RegisterProtocolConfigHandler(prot api.ProtocolName, h ProtocolConfigHandler) {
+	_, loaded := protocolConfigHandlers.LoadOrStore(prot, h)
+	if loaded {
+		log.DefaultLogger.Errorf("protocol %s registered config handler failed, handler is already registered", prot)
+	}
+}
+
+func HandleConfig(prot api.ProtocolName, v interface{}) interface{} {
+	hv, ok := protocolConfigHandlers.Load(prot)
+	if !ok {
+		log.DefaultLogger.Errorf("translate protocol %s config failed, no config handler registered", prot)
+		return nil
+	}
+	handler, _ := hv.(ProtocolConfigHandler)
+	return handler(v)
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -117,22 +117,6 @@ func NewProxy(ctx context.Context, config *v2.Proxy) Proxy {
 	}
 	// proxy level worker pool config end
 
-	if len(proxy.config.ExtendConfig) != 0 {
-		proxy.context = mosnctx.WithValue(proxy.context, types.ContextKeyProxyGeneralConfig, proxy.config.ExtendConfig)
-		if log.DefaultLogger.GetLogLevel() >= log.TRACE {
-			log.DefaultLogger.Tracef("[proxy] extend config proxyGeneralExtendConfig = %v", proxy.config.ExtendConfig)
-		}
-
-		if v, ok := proxy.config.ExtendConfig["sub_protocol"]; ok {
-			if subProtocol, ok := v.(string); ok {
-				proxy.context = mosnctx.WithValue(proxy.context, types.ContextSubProtocol, subProtocol)
-				if log.DefaultLogger.GetLogLevel() >= log.TRACE {
-					log.DefaultLogger.Tracef("[proxy] extend config subprotocol = %v", subProtocol)
-				}
-			}
-		}
-	}
-
 	listenerName := mosnctx.Get(ctx, types.ContextKeyListenerName).(string)
 	proxy.listenerStats = newListenerStats(listenerName)
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -15,7 +15,7 @@ import (
 	"mosn.io/mosn/pkg/protocol"
 	"mosn.io/mosn/pkg/router"
 	"mosn.io/mosn/pkg/stream"
-	_ "mosn.io/mosn/pkg/stream/http"
+	"mosn.io/mosn/pkg/stream/http"
 	"mosn.io/mosn/pkg/streamfilter"
 	"mosn.io/mosn/pkg/trace"
 	"mosn.io/mosn/pkg/types"
@@ -60,14 +60,13 @@ func TestNewProxy(t *testing.T) {
 
 	t.Run("config with subprotocol", func(t *testing.T) {
 		subs := "bolt,boltv2"
-		pv := NewProxy(genctx(), &v2.Proxy{
+		ctx := genctx()
+		ctx = mosnctx.WithValue(ctx, types.ContextSubProtocol, subs)
+		pv := NewProxy(ctx, &v2.Proxy{
 			Name:               "test",
 			DownstreamProtocol: "X",
 			UpstreamProtocol:   "X",
 			RouterConfigName:   "test_router",
-			ExtendConfig: map[string]interface{}{
-				"sub_protocol": subs,
-			},
 		})
 		// verify
 		p := pv.(*proxy)
@@ -79,8 +78,9 @@ func TestNewProxy(t *testing.T) {
 			t.Fatalf("got subprotocol %s, but expected %s", sub, subs)
 		}
 	})
-	t.Run("config with proxy general", func(t *testing.T) {
-		pv := NewProxy(genctx(), &v2.Proxy{
+	t.Run("config with proxy general HTTP1", func(t *testing.T) {
+		ctx := genctx()
+		cfg := &v2.Proxy{
 			Name:               "test",
 			DownstreamProtocol: "Http1",
 			UpstreamProtocol:   "Http1",
@@ -89,15 +89,24 @@ func TestNewProxy(t *testing.T) {
 				"http2_use_stream":      true,
 				"max_request_body_size": 100,
 			},
-		})
+		}
+		// mock create proxy factory
+		extConfig := protocol.HandleConfig(api.ProtocolName(cfg.DownstreamProtocol), cfg.ExtendConfig)
+		ctx = mosnctx.WithValue(ctx, types.ContextKeyProxyGeneralConfig, extConfig)
+		pv := NewProxy(ctx, cfg)
 		// verify
 		p := pv.(*proxy)
-		cfg, ok := mosnctx.Get(p.context, types.ContextKeyProxyGeneralConfig).(map[string]interface{})
-		if !ok {
+		v := mosnctx.Get(p.context, types.ContextKeyProxyGeneralConfig)
+		if v == nil {
 			t.Fatal("no proxy extend config")
 		}
-		assert.True(t, cfg["http2_use_stream"].(bool))
-		assert.Equal(t, cfg["max_request_body_size"].(int), 100)
+		//
+		check := func(t *testing.T, v interface{}) {
+			cfg, ok := v.(http.StreamConfig)
+			assert.True(t, ok)
+			assert.Equal(t, cfg.MaxRequestBodySize, 100)
+		}
+		check(t, v)
 	})
 }
 

--- a/pkg/stream/http/stream.go
+++ b/pkg/stream/http/stream.go
@@ -395,7 +395,7 @@ func streamConfigHandler(v interface{}) interface{} {
 	if err != nil {
 		return defaultStreamConfig
 	}
-	var streamConfig StreamConfig
+	streamConfig := defaultStreamConfig
 	if err := json.Unmarshal(configBytes, &streamConfig); err != nil {
 		return defaultStreamConfig
 	}

--- a/pkg/stream/http/stream_test.go
+++ b/pkg/stream/http/stream_test.go
@@ -21,11 +21,9 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
-	"strconv"
 	"testing"
 	"time"
 
@@ -351,7 +349,7 @@ func Test_serverStream_handleRequest(t *testing.T) {
 		name   string
 		fields fields
 	}{
-		// TODO: Add test cases.
+	// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -406,10 +404,11 @@ func TestHeaderSize(t *testing.T) {
 
 	connection := network.NewServerConnection(context.Background(), rawc, nil)
 
-	var proxyGeneralExtendConfig map[string]interface{}
-	json.Unmarshal([]byte(`{"max_header_size":`+strconv.Itoa(len(requestSmall))+`}`), &proxyGeneralExtendConfig)
+	proxyGeneralExtendConfig := map[string]interface{}{
+		"max_header_size": len(requestSmall),
+	}
+	ctx := mosnctx.WithValue(context.Background(), types.ContextKeyProxyGeneralConfig, streamConfigHandler(proxyGeneralExtendConfig))
 
-	ctx := mosnctx.WithValue(context.Background(), types.ContextKeyProxyGeneralConfig, proxyGeneralExtendConfig)
 	ssc := newServerStreamConnection(ctx, connection, nil)
 	if ssc == nil {
 		t.Errorf("newServerStreamConnection failed!")

--- a/pkg/stream/http/stream_test.go
+++ b/pkg/stream/http/stream_test.go
@@ -384,6 +384,37 @@ func Test_clientStream_CheckReasonError(t *testing.T) {
 
 }
 
+func TestStreamConfigHandler(t *testing.T) {
+	t.Run("test config", func(t *testing.T) {
+		v := map[string]interface{}{
+			"max_header_size":       1024,
+			"max_request_body_size": 1024,
+		}
+		rv := streamConfigHandler(v)
+		cfg, ok := rv.(StreamConfig)
+		if !ok {
+			t.Fatalf("config handler should returns an StreamConfig")
+		}
+		if !(cfg.MaxHeaderSize == 1024 &&
+			cfg.MaxRequestBodySize == 1024) {
+			t.Fatalf("unexpected config: %v", cfg)
+		}
+	})
+	t.Run("test body size", func(t *testing.T) {
+		v := map[string]interface{}{
+			"max_request_body_size": 8192,
+		}
+		rv := streamConfigHandler(v)
+		cfg, ok := rv.(StreamConfig)
+		if !ok {
+			t.Fatalf("config handler should returns an StreamConfig")
+		}
+		if cfg.MaxHeaderSize != defaultMaxHeaderSize {
+			t.Fatalf("no header size configured, should use default header size but not: %d", cfg.MaxHeaderSize)
+		}
+	})
+}
+
 func TestHeaderSize(t *testing.T) {
 	// Only request line, do not add the end of request '\r\n\r\n' identification.
 	requestSmall := []byte("HEAD / HTTP/1.1\r\nHost: test.com\r\nCookie: key=1234")

--- a/pkg/stream/http2/stream.go
+++ b/pkg/stream/http2/stream.go
@@ -169,7 +169,7 @@ func streamConfigHandler(v interface{}) interface{} {
 	if err != nil {
 		return defaultStreamConfig
 	}
-	var streamConfig StreamConfig
+	streamConfig := defaultStreamConfig
 	if err := json.Unmarshal(configBytes, &streamConfig); err != nil {
 		return defaultStreamConfig
 	}

--- a/pkg/stream/http2/stream_test.go
+++ b/pkg/stream/http2/stream_test.go
@@ -117,3 +117,29 @@ func TestDirectResponse(t *testing.T) {
 		t.Errorf("invalid content length got %s , want %s", got, want)
 	}
 }
+
+func TestStreamConfigHandler(t *testing.T) {
+	t.Run("test stream config", func(t *testing.T) {
+		v := map[string]interface{}{
+			"http2_use_stream": true,
+		}
+		rv := streamConfigHandler(v)
+		cfg, ok := rv.(StreamConfig)
+		if !ok {
+			t.Fatalf("should returns StreamConfig but not")
+		}
+		if !cfg.Http2UseStream {
+			t.Fatalf("invalid config: %v", cfg)
+		}
+	})
+	t.Run("test invalid default", func(t *testing.T) {
+		rv := streamConfigHandler(nil)
+		cfg, ok := rv.(StreamConfig)
+		if !ok {
+			t.Fatalf("should returns StreamConfig but not")
+		}
+		if cfg.Http2UseStream {
+			t.Fatalf("invalid config: %v", cfg)
+		}
+	})
+}


### PR DESCRIPTION
### Proxy 配置解析改动
+ Proxy 不识别具体协议，但是依赖Protocol包
+ Stream 层向Protocol 包注册 配置解析的能力
+ Proxy Filter基于Listener提前完成配置解析，通过Ctx传递给Proxy 生成配置

### 验证
+ 配置HTTP1的proxy，header/body都设置成8192，新建连接观察debug日志
```
2021-04-14 20:49:00,175 [DEBUG] [2,-] new http server stream connection, stream config: {8192 8192}
```