### PR TITLE
map permission deny code status to bolt server exception

### DIFF
--- a/pkg/protocol/xprotocol/bolt/protocol.go
+++ b/pkg/protocol/xprotocol/bolt/protocol.go
@@ -185,6 +185,10 @@ func (proto *boltProtocol) Mapping(httpStatusCode uint32) uint32 {
 	case api.TimeoutExceptionCode:
 		//Response Timeout
 		return uint32(ResponseStatusTimeout)
+	case api.PermissionDeniedCode:
+		//Response Permission Denied
+		// bolt protocol do not have a permission deny code, use server exception
+		return uint32(ResponseStatusServerException)
 	default:
 		return uint32(ResponseStatusUnknown)
 	}


### PR DESCRIPTION
because of bolt currently not support permission deny code

### Issues associated with this PR

Your PR should present related issues you want to solve.

### Solutions
Mapping permission deny code status to bolt server exception . Because of bolt currently not support permission deny code.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
