### PR TITLE
ignore the protocol not registered error

### DIFF
--- a/pkg/protocol/config.go
+++ b/pkg/protocol/config.go
@@ -39,7 +39,7 @@ func RegisterProtocolConfigHandler(prot api.ProtocolName, h ProtocolConfigHandle
 func HandleConfig(prot api.ProtocolName, v interface{}) interface{} {
 	hv, ok := protocolConfigHandlers.Load(prot)
 	if !ok {
-		log.DefaultLogger.Errorf("translate protocol %s config failed, no config handler registered", prot)
+		// log.DefaultLogger.Errorf("translate protocol %s config failed, no config handler registered", prot)
 		return nil
 	}
 	handler, _ := hv.(ProtocolConfigHandler)


### PR DESCRIPTION
部分协议（如XProtocol ）或者其他扩展的 没有特别的extend config处理需求，没有进行注册。不应该输出Error日志