### PR TITLE
add connection pool shutdown from host address

### DIFF
--- a/pkg/mock/upstream.go
+++ b/pkg/mock/upstream.go
@@ -910,6 +910,20 @@ func (mr *MockClusterInfoMockRecorder) LbConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LbConfig", reflect.TypeOf((*MockClusterInfo)(nil).LbConfig))
 }
 
+// SubType mocks base method.
+func (m *MockClusterInfo) SubType() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubType")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// SubType indicates an expected call of SubType.
+func (mr *MockClusterInfoMockRecorder) SubType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubType", reflect.TypeOf((*MockClusterInfo)(nil).SubType))
+}
+
 // MockResourceManager is a mock of ResourceManager interface.
 type MockResourceManager struct {
 	ctrl     *gomock.Controller

--- a/pkg/types/upstream.go
+++ b/pkg/types/upstream.go
@@ -186,6 +186,9 @@ type ClusterInfo interface {
 
 	// Optional configuration for the load balancing algorithm selected by
 	LbConfig() v2.IsCluster_LbConfig
+
+	//  Optional configuration for some cluster description
+	SubType() string
 }
 
 // ResourceManager manages different types of Resource

--- a/pkg/upstream/cluster/cluster.go
+++ b/pkg/upstream/cluster/cluster.go
@@ -70,6 +70,7 @@ func newSimpleCluster(clusterConfig v2.Cluster) types.Cluster {
 	info := &clusterInfo{
 		name:                 clusterConfig.Name,
 		clusterType:          clusterConfig.ClusterType,
+		subType:              clusterConfig.SubType,
 		maxRequestsPerConn:   clusterConfig.MaxRequestPerConn,
 		connBufferLimitBytes: clusterConfig.ConnBufferLimitBytes,
 		stats:                newClusterStats(clusterConfig.Name),
@@ -167,6 +168,7 @@ func (sc *simpleCluster) StopHealthChecking() {
 type clusterInfo struct {
 	name                 string
 	clusterType          v2.ClusterType
+	subType              string
 	lbType               types.LoadBalancerType // if use subset lb , lbType is used as inner LB algorithm for choosing subset's host
 	connBufferLimitBytes uint32
 	maxRequestsPerConn   uint32
@@ -235,6 +237,10 @@ func (ci *clusterInfo) LbOriDstInfo() types.LBOriDstInfo {
 
 func (ci *clusterInfo) LbConfig() v2.IsCluster_LbConfig {
 	return ci.lbConfig
+}
+
+func (ci *clusterInfo) SubType() string {
+	return ci.subType
 }
 
 type clusterSnapshot struct {


### PR DESCRIPTION
ClusterManager 新增一个接口，用于基于Host的地址 优雅的断开连接。
基于协议+地址找到连接池实行优雅断开，对于部分场景没有办法获取协议信息的，支持传空对所有协议进行遍历