### PR TITLE
fix rrLB bug, issues1663

### DIFF
--- a/pkg/upstream/cluster/loadbalancer.go
+++ b/pkg/upstream/cluster/loadbalancer.go
@@ -165,18 +165,16 @@ func (lb *roundRobinLoadBalancer) ChooseHost(context types.LoadBalancerContext) 
 		}
 	}
 
-	next := int(atomic.AddUint32(&lb.rrIndex, 1) % uint32(total))
-	l := total + next
-	for i := next; i < l; i++ {
-		idx := i % total
-		host := targets[idx]
+	// Reference https://github.com/mosn/mosn/issues/1663
+	secondStartIndex := int(atomic.AddUint32(&lb.rrIndex, 1) % uint32(total))
+	for i := 0; i < total; i++ {
+		index := (i + secondStartIndex) % total
+		host := targets[index]
 		if host.Health() {
-			if i != next {
-				atomic.StoreUint32(&lb.rrIndex, uint32(idx))
-			}
 			return host
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/upstream/cluster/loadbalancer.go
+++ b/pkg/upstream/cluster/loadbalancer.go
@@ -164,6 +164,19 @@ func (lb *roundRobinLoadBalancer) ChooseHost(context types.LoadBalancerContext) 
 			return host
 		}
 	}
+
+	next := int(atomic.AddUint32(&lb.rrIndex, 1) % uint32(total))
+	l := total + next
+	for i := next; i < l; i++ {
+		idx := i % total
+		host := targets[idx]
+		if host.Health() {
+			if i != next {
+				atomic.StoreUint32(&lb.rrIndex, uint32(idx))
+			}
+			return host
+		}
+	}
 	return nil
 }
 

--- a/pkg/upstream/cluster/loadbalancer_test.go
+++ b/pkg/upstream/cluster/loadbalancer_test.go
@@ -458,7 +458,7 @@ func Test_roundRobinLoadBalancer_ChooseHost(t *testing.T) {
 				"address3": 0,
 				"address4": 500000,
 			},
-			wantUniformity: 0.00005,
+			wantUniformity: 0.0001,
 			resultChan:     make(chan types.Host, 1000000),
 		},
 	}
@@ -586,7 +586,7 @@ func Test_roundRobinLoadBalancer_ChooseHost(t *testing.T) {
 			"address--8": 0,
 			"address--9": 0,
 		},
-		wantUniformity: 0.00005,
+		wantUniformity: 0.0001,
 		resultChan:     make(chan types.Host, 1500000),
 	})
 	// testcase4

--- a/pkg/upstream/cluster/loadbalancer_test.go
+++ b/pkg/upstream/cluster/loadbalancer_test.go
@@ -458,7 +458,7 @@ func Test_roundRobinLoadBalancer_ChooseHost(t *testing.T) {
 				"address3": 0,
 				"address4": 500000,
 			},
-			wantUniformity: 0.0001,
+			wantUniformity: 0.00005,
 			resultChan:     make(chan types.Host, 1000000),
 		},
 	}
@@ -506,7 +506,7 @@ func Test_roundRobinLoadBalancer_ChooseHost(t *testing.T) {
 			"address-3": 0,
 			"address-4": 1000000,
 		},
-		wantUniformity: 0.0001,
+		wantUniformity: 0.0,
 		resultChan:     make(chan types.Host, 1000000),
 	})
 	// testcase3
@@ -586,7 +586,7 @@ func Test_roundRobinLoadBalancer_ChooseHost(t *testing.T) {
 			"address--8": 0,
 			"address--9": 0,
 		},
-		wantUniformity: 0.0001,
+		wantUniformity: 0.00005,
 		resultChan:     make(chan types.Host, 1500000),
 	})
 	// testcase4
@@ -661,7 +661,7 @@ func Test_roundRobinLoadBalancer_ChooseHost(t *testing.T) {
 			"address--8": 100000,
 			"address--9": 100000,
 		},
-		wantUniformity: 0.0001,
+		wantUniformity: 0.0,
 		resultChan:     make(chan types.Host, 900000),
 	})
 

--- a/pkg/upstream/cluster/loadbalancer_test.go
+++ b/pkg/upstream/cluster/loadbalancer_test.go
@@ -506,6 +506,160 @@ func Test_roundRobinLoadBalancer_ChooseHost(t *testing.T) {
 		},
 		resultChan: make(chan types.Host, 1000000),
 	})
+	// testcase3
+	mockHosts_testcase3 := []types.Host{
+		&mockHost{
+			name:       "host--1",
+			addr:       "address--1",
+			healthFlag: GetHealthFlagPointer("address--1"),
+		},
+		&mockHost{
+			name:       "host--2",
+			addr:       "address--2",
+			healthFlag: GetHealthFlagPointer("address--2"),
+		},
+		&mockHost{
+			name:       "host--3",
+			addr:       "address--3",
+			healthFlag: GetHealthFlagPointer("address--3"),
+		},
+		&mockHost{
+			name:       "host--4",
+			addr:       "address--4",
+			healthFlag: GetHealthFlagPointer("address--4"),
+		},
+		&mockHost{
+			name:       "host--5",
+			addr:       "address--5",
+			healthFlag: GetHealthFlagPointer("address--5"),
+		},
+		&mockHost{
+			name:       "host--6",
+			addr:       "address--6",
+			healthFlag: GetHealthFlagPointer("address--6"),
+		},
+		&mockHost{
+			name:       "host--7",
+			addr:       "address--7",
+			healthFlag: GetHealthFlagPointer("address--7"),
+		},
+		&mockHost{
+			name:       "host--8",
+			addr:       "address--8",
+			healthFlag: GetHealthFlagPointer("address--8"),
+		},
+		&mockHost{
+			name:       "host--9",
+			addr:       "address--9",
+			healthFlag: GetHealthFlagPointer("address--9"),
+		},
+	}
+	mockHosts_testcase3[8].SetHealthFlag(api.FAILED_ACTIVE_HC)
+	mockHosts_testcase3[7].SetHealthFlag(api.FAILED_ACTIVE_HC)
+	mockHosts_testcase3[5].SetHealthFlag(api.FAILED_ACTIVE_HC)
+	mockHosts_testcase3[4].SetHealthFlag(api.FAILED_ACTIVE_HC)
+	mockHosts_testcase3[2].SetHealthFlag(api.FAILED_ACTIVE_HC)
+	mockHosts_testcase3[1].SetHealthFlag(api.FAILED_ACTIVE_HC)
+	hostSet1_testCase3 := &hostSet{}
+	hostSet1_testCase3.setFinalHost(mockHosts_testcase3)
+	tests = append(tests, testCase{
+		name: "LB-From9Hosts-3-healthy-6-unhealthy",
+		fields: fields{
+			info:  nil,
+			hosts: hostSet1_testCase3,
+		},
+		args: args{
+			context:  nil,
+			runCount: 1500000,
+		},
+		want: map[string]int{
+			"address--1": 500000,
+			"address--2": 0,
+			"address--3": 0,
+			"address--4": 500000,
+			"address--5": 0,
+			"address--6": 0,
+			"address--7": 500000,
+			"address--8": 0,
+			"address--9": 0,
+		},
+		resultChan: make(chan types.Host, 1500000),
+	})
+	// testcase4
+	mockHosts_testcase4 := []types.Host{
+		&mockHost{
+			name:       "host--1",
+			addr:       "address--1",
+			healthFlag: GetHealthFlagPointer("address--1"),
+		},
+		&mockHost{
+			name:       "host--2",
+			addr:       "address--2",
+			healthFlag: GetHealthFlagPointer("address--2"),
+		},
+		&mockHost{
+			name:       "host--3",
+			addr:       "address--3",
+			healthFlag: GetHealthFlagPointer("address--3"),
+		},
+		&mockHost{
+			name:       "host--4",
+			addr:       "address--4",
+			healthFlag: GetHealthFlagPointer("address--4"),
+		},
+		&mockHost{
+			name:       "host--5",
+			addr:       "address--5",
+			healthFlag: GetHealthFlagPointer("address--5"),
+		},
+		&mockHost{
+			name:       "host--6",
+			addr:       "address--6",
+			healthFlag: GetHealthFlagPointer("address--6"),
+		},
+		&mockHost{
+			name:       "host--7",
+			addr:       "address--7",
+			healthFlag: GetHealthFlagPointer("address--7"),
+		},
+		&mockHost{
+			name:       "host--8",
+			addr:       "address--8",
+			healthFlag: GetHealthFlagPointer("address--8"),
+		},
+		&mockHost{
+			name:       "host--9",
+			addr:       "address--9",
+			healthFlag: GetHealthFlagPointer("address--9"),
+		},
+	}
+
+	hostSet1_testCase4 := &hostSet{}
+	hostSet1_testCase4.setFinalHost(mockHosts_testcase4)
+	tests = append(tests, testCase{
+		name: "LB-From9Hosts-9-healthy-0-unhealthy",
+		fields: fields{
+			info:  nil,
+			hosts: hostSet1_testCase4,
+		},
+		args: args{
+			context:  nil,
+			runCount: 900000,
+		},
+		want: map[string]int{
+			"address--1": 100000,
+			"address--2": 100000,
+			"address--3": 100000,
+			"address--4": 100000,
+			"address--5": 100000,
+			"address--6": 100000,
+			"address--7": 100000,
+			"address--8": 100000,
+			"address--9": 100000,
+		},
+		resultChan: make(chan types.Host, 900000),
+	})
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			factory := lbFactories[types.RoundRobin]


### PR DESCRIPTION
### Issues associated with this PR

Your PR should present related issues you want to solve.

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, details and the changes. At this time, Chinese is allowed to describe these.

### UT result

```log
2021-06-09 10:22:35,193 [INFO] [network] [ register pool factory] register protocol: mock factory
=== RUN   Test_roundRobinLoadBalancer_ChooseHost
--- PASS: Test_roundRobinLoadBalancer_ChooseHost (0.55s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address4, count: -4
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address2, count: 4
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address3, count: 0
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy (0.26s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address2, count: -1
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address4, count: 1
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy (0.27s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address2, count: -3
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address4, count: 3
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy (0.27s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address2, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address4, count: 0
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy (0.25s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address2, count: 2
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address4, count: -2
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy (0.29s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address2, count: -4
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address4, count: 4
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy (0.30s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address2, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address4, count: 0
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy (0.30s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address4, count: 2
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address2, count: -2
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy (0.30s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address2, count: 1
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address4, count: -1
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address1, count: 0
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy (0.31s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address2, count: 1
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address4, count: -1
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-2-healthy-2-unhealthy (0.24s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-2, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-4, count: 0
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy (0.28s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-2, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-4, count: 0
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy (0.30s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-2, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-4, count: 0
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy (0.30s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-2, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-4, count: 0
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy (0.31s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-2, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-4, count: 0
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy (0.30s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-2, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-4, count: 0
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy (0.29s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-2, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-4, count: 0
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy (0.28s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-2, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-4, count: 0
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy (0.28s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-2, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-4, count: 0
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy (0.27s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-1, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-2, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-3, count: 0
    loadbalancer_test.go:537: roundRobinLoadBalancer choose host count err, address: address-4, count: 0
    --- PASS: Test_roundRobinLoadBalancer_ChooseHost/LB-From4Hosts-1-healthy-3-unhealthy (0.30s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost
--- PASS: Test_roundRobinLoadBalancer_ChooseHost (0.57s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost
--- PASS: Test_roundRobinLoadBalancer_ChooseHost (0.58s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost
--- PASS: Test_roundRobinLoadBalancer_ChooseHost (0.56s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost
--- PASS: Test_roundRobinLoadBalancer_ChooseHost (0.59s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost
--- PASS: Test_roundRobinLoadBalancer_ChooseHost (0.59s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost
--- PASS: Test_roundRobinLoadBalancer_ChooseHost (0.58s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost
--- PASS: Test_roundRobinLoadBalancer_ChooseHost (0.58s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost
--- PASS: Test_roundRobinLoadBalancer_ChooseHost (0.59s)
=== RUN   Test_roundRobinLoadBalancer_ChooseHost
--- PASS: Test_roundRobinLoadBalancer_ChooseHost (0.55s)
PASS

Process finished with the exit code 0

```

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
