### PR TITLE
fix data race bug

### DIFF
--- a/pkg/router/base_rule.go
+++ b/pkg/router/base_rule.go
@@ -229,8 +229,8 @@ func (rri *RouteRuleImplBase) ClusterName(ctx context.Context) string {
 	if rri.randInstance == nil {
 		rri.randInstance = rand.New(rand.NewSource(time.Now().UnixNano()))
 	}
-	rri.lock.Unlock()
 	selectedValue := rri.randInstance.Intn(int(rri.totalClusterWeight))
+	rri.lock.Unlock()
 	for _, weightCluster := range rri.weightedClusters {
 		selectedValue = selectedValue - int(weightCluster.clusterWeight)
 		if selectedValue <= 0 {


### PR DESCRIPTION
### Issues associated with this PR

#1715 

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, details and the changes. At this time, Chinese is allowed to describe these.

### UT result

```log
=== RUN   TestWeightedClusterSelect
    base_rule_test.go:156: defalut =  0 w1 =  7366 w2 = 715
    base_rule_test.go:156: defalut =  0 w1 =  3982 w2 = 3905
--- PASS: TestWeightedClusterSelect (0.01s)
PASS
```

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
