### PR TITLE
feat: wasm manager support reload

### DIFF
--- a/pkg/config/v2/wasm.go
+++ b/pkg/config/v2/wasm.go
@@ -27,6 +27,7 @@ type WasmVmConfig struct {
 	Engine string `json:"engine,omitempty"`
 	Path   string `json:"path,omitempty"`
 	Url    string `json:"url,omitempty"`
+	Md5    string `json:"md5,omitempty"`
 	Cpu    int    `json:"cpu,omitempty"`
 	Mem    int    `json:"mem,omitempty"`
 }

--- a/pkg/types/wasm.go
+++ b/pkg/types/wasm.go
@@ -36,9 +36,6 @@ type WasmManager interface {
 
 	// UninstallWasmPluginByName remove wasm plugin by name
 	UninstallWasmPluginByName(pluginName string) error
-
-	// ReloadWasmByName reload wasm plugin by name without modify config
-	ReloadWasmByName(pluginName string) error
 }
 
 // WasmPluginWrapper wraps wasm plugin with its config and plugin handler

--- a/pkg/types/wasm.go
+++ b/pkg/types/wasm.go
@@ -36,6 +36,9 @@ type WasmManager interface {
 
 	// UninstallWasmPluginByName remove wasm plugin by name
 	UninstallWasmPluginByName(pluginName string) error
+
+	// ReloadWasmByName reload wasm plugin by name without modify config
+	ReloadWasmByName(pluginName string) error
 }
 
 // WasmPluginWrapper wraps wasm plugin with its config and plugin handler

--- a/pkg/wasm/manager.go
+++ b/pkg/wasm/manager.go
@@ -55,7 +55,9 @@ func (w *wasmManagerImpl) shouldCreateNewPlugin(newConfig v2.WasmPluginConfig, o
 
 	if newConfig.VmConfig.Engine != oldConfig.VmConfig.Engine ||
 		newConfig.VmConfig.Path != oldConfig.VmConfig.Path ||
-		newConfig.VmConfig.Url != oldConfig.VmConfig.Url {
+		newConfig.VmConfig.Url != oldConfig.VmConfig.Url ||
+		newConfig.VmConfig.Md5 == "" ||
+		newConfig.VmConfig.Md5 != oldConfig.VmConfig.Md5 {
 		return true
 	}
 
@@ -96,18 +98,6 @@ func (w *wasmManagerImpl) updateWasm(pluginWrapper types.WasmPluginWrapper, newC
 
 	log.DefaultLogger.Infof("[wasm][manager] AddOrUpdateWasm update wasm plugin: %v, config: %v", newConfig.PluginName, newConfig)
 
-	return nil
-}
-
-func (w *wasmManagerImpl) forceUpdateWasm(pluginWrapper types.WasmPluginWrapper, newConfig v2.WasmPluginConfig) error {
-	plugin, err := NewWasmPlugin(newConfig)
-	if err != nil {
-		log.DefaultLogger.Errorf("[wasm][manager] forceUpdateWasm fail to create wasm plugin: %v, err: %v", newConfig.PluginName, err)
-		return err
-	}
-
-	pluginWrapper.Update(newConfig, plugin)
-	log.DefaultLogger.Infof("[wasm][manager] forceUpdateWasm update wasm plugin: %v, config: %v", newConfig.PluginName, newConfig)
 	return nil
 }
 
@@ -181,27 +171,5 @@ func (w *wasmManagerImpl) UninstallWasmPluginByName(pluginName string) error {
 
 	log.DefaultLogger.Infof("[wasm][manager] UninstallWasmPluginByName uninstall wasm plugin: %v", pluginName)
 
-	return nil
-}
-
-func (w *wasmManagerImpl) ReloadWasmByName(pluginName string) error {
-	v, ok := w.pluginMap.Load(pluginName)
-	if !ok {
-		log.DefaultLogger.Errorf("[wasm][manager] ReloadWasmByName plugin not found, name: %v", pluginName)
-		return ErrPluginNotFound
-	}
-
-	pw, ok := v.(*pluginWrapper)
-	if !ok {
-		log.DefaultLogger.Errorf("[wasm][manager] ReloadWasmByName unexpected type in map")
-		return ErrUnexpectedType
-	}
-
-	if err := w.forceUpdateWasm(pw, pw.GetConfig()); err != nil {
-		log.DefaultLogger.Errorf("[wasm][manager] ReloadWasmByName force update wasm plugin error, err: %v", err)
-		return err
-	}
-
-	log.DefaultLogger.Infof("[wasm][manager] ReloadWasmByName reload wasm plugin success: %v", pluginName)
 	return nil
 }

--- a/pkg/wasm/manager_test.go
+++ b/pkg/wasm/manager_test.go
@@ -153,7 +153,7 @@ func TestWasmManagerReloadWasmByName(t *testing.T) {
 	}
 
 	assert.Nil(t, GetWasmManager().AddOrUpdateWasm(config))
-	assert.Nil(t, GetWasmManager().ReloadWasmByName("testPluginDiffWasm"))
+	assert.Nil(t, GetWasmManager().AddOrUpdateWasm(config))
 }
 
 func TestWasmManagerInstanceNum(t *testing.T) {

--- a/pkg/wasm/manager_test.go
+++ b/pkg/wasm/manager_test.go
@@ -121,7 +121,7 @@ func TestWasmManagerDiffVmConfig(t *testing.T) {
 	assert.Equal(t, newInstanceCount, 2*config.InstanceNum)
 }
 
-func TestWasmManagerReloadWasmByName(t *testing.T) {
+func TestWasmManagerReloadWasm(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -153,7 +153,20 @@ func TestWasmManagerReloadWasmByName(t *testing.T) {
 	}
 
 	assert.Nil(t, GetWasmManager().AddOrUpdateWasm(config))
-	assert.Nil(t, GetWasmManager().AddOrUpdateWasm(config))
+
+	config2 := v2.WasmPluginConfig{
+		PluginName: "testPluginDiffWasm",
+		VmConfig: &v2.WasmVmConfig{
+			Engine: "testWasmEngine",
+			Path:   "/tmp/foo.wasm",
+		},
+		InstanceNum: 4,
+	}
+
+	assert.Nil(t, GetWasmManager().AddOrUpdateWasm(config2))
+
+	assert.Equal(t, newModuleCount, 2)
+	assert.Equal(t, newInstanceCount, 2*config.InstanceNum)
 }
 
 func TestWasmManagerInstanceNum(t *testing.T) {

--- a/pkg/wasm/manager_test.go
+++ b/pkg/wasm/manager_test.go
@@ -121,6 +121,41 @@ func TestWasmManagerDiffVmConfig(t *testing.T) {
 	assert.Equal(t, newInstanceCount, 2*config.InstanceNum)
 }
 
+func TestWasmManagerReloadWasmByName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	newModuleCount, newInstanceCount := 0, 0
+	module := mock.NewMockWasmModule(ctrl)
+	module.EXPECT().NewInstance().AnyTimes().DoAndReturn(func() types.WasmInstance {
+		newInstanceCount++
+		instance := mock.NewMockWasmInstance(ctrl)
+		instance.EXPECT().Start().AnyTimes().Return(nil)
+		return instance
+	})
+	engine := mock.NewMockWasmVM(ctrl)
+	engine.EXPECT().NewModule(gomock.Any()).AnyTimes().DoAndReturn(func([]byte) types.WasmModule {
+		newModuleCount++
+		return module
+	})
+
+	RegisterWasmEngine("testWasmEngine", engine)
+
+	_ = ioutil.WriteFile("/tmp/foo.wasm", []byte("some bytes"), 0644)
+
+	config := v2.WasmPluginConfig{
+		PluginName: "testPluginDiffWasm",
+		VmConfig: &v2.WasmVmConfig{
+			Engine: "testWasmEngine",
+			Path:   "/tmp/foo.wasm",
+		},
+		InstanceNum: 4,
+	}
+
+	assert.Nil(t, GetWasmManager().AddOrUpdateWasm(config))
+	assert.Nil(t, GetWasmManager().ReloadWasmByName("testPluginDiffWasm"))
+}
+
 func TestWasmManagerInstanceNum(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
### Issues associated with this PR

https://github.com/mosn/layotto/issues/165

### Solutions

Add func `ReloadWasmByName` for wasm manager to provide the ability to reload a wasm plugin without modify the config.

This func will be used by `layotto` to achieve wasm hot reload for developer.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.


### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result

