### PR TITLE
修复 msgconnpool 

### DIFF
--- a/pkg/trace/api.go
+++ b/pkg/trace/api.go
@@ -64,6 +64,9 @@ func Init(typ string, config map[string]interface{}) error {
 }
 
 func Enable() {
+	if global.driver == nil {
+		return
+	}
 	global.enable = true
 }
 


### PR DESCRIPTION
1. 修复 msgconnpool 中 ConnectionEventListener 收不到 Connected 事件的问题
2. trace/api.go 的Enable方法判断 global.driver 是否nil

### Issues associated with this PR

msgconpool中，用户自定义 ConnectionEventListener 的注册落后于Connect 调用，因此用户的 activeClient 永远收不到 Connected 的事件。


### Solutions
将用户自定义ConnectionEventListener的注册逻辑提前到Connect之前。

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

All passed.

### Code Style

