### PR TITLE
Fixes gh-1750: retry hangs if empty hosts.

### DIFF
--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -1648,6 +1648,9 @@ func (s *downStream) processError(id uint32) (phase types.Phase, err error) {
 	}
 
 	if s.upstreamRequest != nil && s.upstreamRequest.setupRetry {
+		// https://github.com/mosn/mosn/issues/1750
+		s.upstreamRequest.setupRetry = false
+
 		phase = types.Retry
 		err = types.ErrExit
 		return


### PR DESCRIPTION
### Issues associated with this PR

https://github.com/mosn/mosn/issues/1750

### Solutions
set upstreamRequest = nil before initializeUpstreamConnectionPool in function doRetry().

### UT result

> /usr/local/go/bin/go test -c -o /private/var/folders/_f/6yxxg9md6dv5c6pv78g151cc0000gn/T/___TestRetryEmptyUpstreamHosts_in_mosn_io_mosn_pkg_proxy -gcflags "all=-N -l" mosn.io/mosn/pkg/proxy #gosetup
/usr/local/go/bin/go tool test2json -t /Applications/GoLand.app/Contents/plugins/go/lib/dlv/mac/dlv --listen=localhost:59157 --headless=true --api-version=2 --check-go-version=false --only-same-user=false exec /private/var/folders/_f/6yxxg9md6dv5c6pv78g151cc0000gn/T/___TestRetryEmptyUpstreamHosts_in_mosn_io_mosn_pkg_proxy -- -test.v -test.run ^TestRetryEmptyUpstreamHosts$ #gosetup
API server listening at: 127.0.0.1:59157
2021-08-24 14:12:12,63 [INFO] register a new handler maker, name is default, is default: true
2021-08-24 14:12:12,695 [INFO] [network] [ register pool factory] register protocol: Http1 factory
2021-08-24 14:12:12,695 [INFO] [config] processor added to configParsedCBMaps
=== RUN   TestRetryEmptyUpstreamHosts
2021-08-24 14:12:12,706 [ERROR] [mosn.proxy.upstream_conn_failed]  retry choose conn pool failed, error = [proxy] [downstream] no healthy upstream in cluster 
2021-08-24 14:12:12,706 [WARN]  [proxy] [downstream] set hijack reply, proxyId = 1, code = 502, with headers = true
2021-08-24 14:12:12,706 [WARN] [-,-] [proxy] [downstream] convert header from HTTP2 to  failed, no convert function found for given protocol pair
--- PASS: TestRetryEmptyUpstreamHosts (0.01s)
PASS 

### Benchmark

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result

>  xzy@xzydeMacBook-Pro  ~/Desktop/projects/gopath/src/github.com/XIEZHENGYAO/mosn   bugfix/gh_1750 ●  golint pkg/proxy/downstream.go 
pkg/proxy/downstream.go:447:37: method parameter phaseId should be phaseID
pkg/proxy/downstream.go:447:58: method parameter proxyId should be proxyID
pkg/proxy/downstream.go:1130:10: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
pkg/proxy/downstream.go:1162:10: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
pkg/proxy/downstream.go:1189:10: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)