### PR TITLE
Fixes gh-1751: catch h2 connection termination event

### DIFF
--- a/pkg/stream/http2/connpool.go
+++ b/pkg/stream/http2/connpool.go
@@ -205,19 +205,19 @@ func newActiveClient(ctx context.Context, pool *connPool) *activeClient {
 	host := pool.Host()
 	data := host.CreateConnection(ctx)
 	data.Connection.AddConnectionEventListener(ac)
-	if err := data.Connection.Connect(); err != nil {
-		if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
-			log.DefaultLogger.Debugf("http2 underlying connection error: %v", err)
-		}
-		return nil
-	}
-
 	connCtx := mosnctx.WithValue(ctx, types.ContextKeyConnectionID, data.Connection.ID())
 	codecClient := pool.createStreamClient(connCtx, data)
 	codecClient.SetStreamConnectionEventListener(ac)
 
 	ac.client = codecClient
 	ac.host = data
+
+	if err := data.Connection.Connect(); err != nil {
+		if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
+			log.DefaultLogger.Debugf("http2 underlying connection error: %v", err)
+		}
+		return nil
+	}
 
 	host.HostStats().UpstreamConnectionTotal.Inc(1)
 	host.HostStats().UpstreamConnectionActive.Inc(1)

--- a/pkg/stream/http2/stream.go
+++ b/pkg/stream/http2/stream.go
@@ -650,6 +650,9 @@ var errClosedClientConn = errors.New("http2: client conn is closed")
 func (conn *clientStreamConnection) OnEvent(event api.ConnectionEvent) {
 	conn.mutex.Lock()
 	defer conn.mutex.Unlock()
+	if event == api.Connected {
+		conn.mClientConn.WriteInitFrame()
+	}
 	if event.IsClose() || event.ConnectFailure() {
 		for _, stream := range conn.streams {
 			if buf := stream.recData; buf != nil {
@@ -1041,10 +1044,6 @@ func (s *clientStream) ResetStream(reason types.StreamResetReason) {
 		if log.DefaultLogger.GetLogLevel() >= log.WARN {
 			log.DefaultLogger.Warnf("http2 client reset by goaway, retry it, lastStream = %d, streamId = %d", s.sc.lastStream, s.id)
 		}
-		reason = types.StreamConnectionFailed
-	}
-	switch reason {
-	case types.StreamConnectionTermination:
 		reason = types.StreamConnectionFailed
 	}
 


### PR DESCRIPTION
### Issues associated with this PR

https://github.com/mosn/mosn/issues/1751

### Solutions
Add clientStreamConnection to eventListeners before connecting. After connected, write setting frame.

### UT result
See actions / Test.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
