### PR TITLE
opt edf performance

### DIFF
--- a/pkg/upstream/cluster/edf.go
+++ b/pkg/upstream/cluster/edf.go
@@ -54,14 +54,14 @@ func (edf *edfSchduler) NextAndPush(weightFunc func(item WeightItem) float64) in
 	if len(edf.items) == 0 {
 		return nil
 	}
-	entry := heap.Pop(&edf.items).(*edfEntry)
+	entry := edf.items[0]
 	edf.currentTime = entry.deadline
 	weight := weightFunc(entry.item)
 	// update the index、deadline and put into priorityQueue again
 	entry.deadline = entry.deadline + 1.0/weight
 	entry.weight = weight
 	entry.queuedTime = time.Now()
-	heap.Push(&edf.items, entry)
+	heap.Fix(&edf.items, 0)
 	return entry.item
 }
 

--- a/pkg/upstream/cluster/edf_test.go
+++ b/pkg/upstream/cluster/edf_test.go
@@ -1,9 +1,11 @@
 package cluster
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"mosn.io/mosn/pkg/types"
 )
 
 func Test(t *testing.T) {
@@ -29,4 +31,82 @@ func Test(t *testing.T) {
 	ele = edfScheduler.NextAndPush(weightFunc)
 	assert.Equal(t, A, ele)
 
+}
+
+func mockHostList(count int, name string) []types.Host {
+	hosts := make([]types.Host, 0, count)
+	for i := 0; i < count; i++ {
+		hosts = append(hosts, &mockHost{
+			name: "A" + strconv.Itoa(i),
+			w:    uint32(i + 1),
+		})
+	}
+	return hosts
+}
+
+func Benchmark_edfSchduler_NextAndPush(b *testing.B) {
+	type fields struct {
+		hostCount int
+		hostName  string
+	}
+	type args struct {
+		weightFunc func(item WeightItem) float64
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   interface{}
+	}{
+		{
+			name: "10-hosts",
+			fields: fields{
+				hostCount: 10,
+				hostName:  "bench-host",
+			},
+			args: args{
+				weightFunc: func(item WeightItem) float64 {
+					return float64(item.Weight())
+				},
+			},
+		},
+		{
+			name: "100-hosts",
+			fields: fields{
+				hostCount: 100,
+				hostName:  "bench-host",
+			},
+			args: args{
+				weightFunc: func(item WeightItem) float64 {
+					return float64(item.Weight())
+				},
+			},
+		},
+		{
+			name: "1000-hosts",
+			fields: fields{
+				hostCount: 1000,
+				hostName:  "bench-host",
+			},
+			args: args{
+				weightFunc: func(item WeightItem) float64 {
+					return float64(item.Weight())
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			edf := newEdfScheduler(tt.fields.hostCount)
+			hosts := mockHostList(tt.fields.hostCount, tt.fields.hostName)
+			for _, h := range hosts {
+				edf.Add(h, float64(h.Weight()))
+			}
+			b.StartTimer()
+			for i := 0; i < b.N; i++ {
+				edf.NextAndPush(tt.args.weightFunc)
+			}
+			b.StopTimer()
+		})
+	}
 }


### PR DESCRIPTION
### Issues associated with this PR

#1760 

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, details and the changes. At this time, Chinese is allowed to describe these.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark

```bash
$ benchstat old.txt new.txt 
name                                    old time/op    new time/op    delta
_edfSchduler_NextAndPush/10-hosts-12       214ns ±14%     157ns ± 5%  -26.35%  (p=0.000 n=10+10)
_edfSchduler_NextAndPush/100-hosts-12      323ns ± 9%     221ns ± 2%  -31.43%  (p=0.000 n=9+10)
_edfSchduler_NextAndPush/1000-hosts-12     497ns ± 5%     336ns ± 2%  -32.45%  (p=0.000 n=8+10)

name                                    old alloc/op   new alloc/op   delta
_edfSchduler_NextAndPush/10-hosts-12       0.00B          0.00B          ~     (all equal)
_edfSchduler_NextAndPush/100-hosts-12      0.00B          0.00B          ~     (all equal)
_edfSchduler_NextAndPush/1000-hosts-12     0.00B          0.00B          ~     (all equal)

name                                    old allocs/op  new allocs/op  delta
_edfSchduler_NextAndPush/10-hosts-12        0.00           0.00          ~     (all equal)
_edfSchduler_NextAndPush/100-hosts-12       0.00           0.00          ~     (all equal)
_edfSchduler_NextAndPush/1000-hosts-12      0.00           0.00          ~     (all equal)  
```
### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
