### PR TITLE
optimize grpc server

### DIFF
--- a/pkg/filter/network/grpc/conn.go
+++ b/pkg/filter/network/grpc/conn.go
@@ -156,12 +156,10 @@ func (c *Connection) OnEvent(event api.ConnectionEvent) {
 func (c *Connection) Send(buf buffer.IoBuffer) {
 	// copy data to the data buffer
 	// TODO: limit the data buffer, or shrink the data buffer when the connection is idle
-	b := make([]byte, buf.Len())
-	copy(b, buf.Bytes())
-	buf.Drain(buf.Len())
-	if _, err := c.databuf.Write(b); err != nil {
+	if _, err := c.databuf.Write(buf.Bytes()); err != nil {
 		log.DefaultLogger.Errorf("[grpc] connection write error. local %v, remote %v, error: %v", c.raw.LocalAddr(), c.raw.RemoteAddr(), err)
 	}
+	buf.Drain(buf.Len())
 	if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
 		log.DefaultLogger.Debugf("[grpc] grpc send data to the data buffer")
 	}

--- a/pkg/filter/network/grpc/factory.go
+++ b/pkg/filter/network/grpc/factory.go
@@ -48,11 +48,10 @@ func init() {
 // The registered grpc server needs to be implemented independently by the user, and registered to factory.
 // A MOSN can contains multiple registered grpc servers, each grpc server has only one instance.
 type grpcServerFilterFactory struct {
-	server              RegisteredServer
 	config              *v2.GRPC
 	handler             *Handler
+	server              *registerServerWrapper
 	streamFilterFactory streamfilter.StreamFilterFactory
-	ln                  *Listener
 }
 
 var _ api.NetworkFilterChainFactory = (*grpcServerFilterFactory)(nil)
@@ -62,7 +61,7 @@ func (f *grpcServerFilterFactory) CreateFilterChain(ctx context.Context, callbac
 	if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
 		log.DefaultLogger.Debugf("create a new grpc filter")
 	}
-	rf := NewGrpcFilter(ctx, f.ln)
+	rf := NewGrpcFilter(ctx, f.server.ln)
 	callbacks.AddReadFilter(rf)
 }
 
@@ -75,10 +74,7 @@ func (f *grpcServerFilterFactory) Init(param interface{}) error {
 	if addr == "" {
 		addr = cfg.Addr.String()
 	}
-	ln, err := NewListener(addr)
-	if err != nil {
-		return err
-	}
+
 	// GetStreamFilters from listener name
 	f.streamFilterFactory = streamfilter.GetStreamFilterManager().GetStreamFilterFactory(cfg.Name)
 
@@ -87,38 +83,14 @@ func (f *grpcServerFilterFactory) Init(param interface{}) error {
 		grpc.UnaryInterceptor(f.UnaryInterceptorFilter),
 		grpc.StreamInterceptor(f.StreamInterceptorFilter),
 	}
-	srv, err := f.handler.Start(ln, f.config.GrpcConfig, opts...)
+	sw, err := f.handler.New(addr, f.config.GrpcConfig, opts...)
 	if err != nil {
 		return err
 	}
+	// start server with timeout
+	sw.Start(f.config.GracefulStopTimeout)
+	f.server = sw
 	log.DefaultLogger.Debugf("grpc server filter initialized success")
-	// we keep the server but it is not be used currently.
-	// maybe it will be used when server stop/restart are supported
-	f.server = srv
-	f.ln = ln
-	// stop grpc server when mosn process shutdown
-	keeper.OnProcessShutDown(func() error {
-		return f.close()
-	})
-	return nil
-}
-
-func (f *grpcServerFilterFactory) close() error {
-	// use default timeout
-	gracefulStopTimeout := v2.GrpcDefaultGracefulStopTimeout
-	if f.config.GracefulStopTimeout > 0 {
-		// use the user-set timeout
-		gracefulStopTimeout = f.config.GracefulStopTimeout
-	}
-	// sync stop grpc server
-	timer := time.AfterFunc(gracefulStopTimeout, func() {
-		f.server.Stop()
-		log.DefaultLogger.Errorf("[grpc networkFilter] force stop grpc server: %v", f.config.ServerName)
-	})
-	defer timer.Stop()
-	log.DefaultLogger.Infof("[grpc networkFilter] graceful stopping grpc server: %v", f.config.ServerName)
-	f.server.GracefulStop()
-	log.DefaultLogger.Infof("[grpc networkFilter] graceful stoped grpc server success: %v", f.config.ServerName)
 	return nil
 }
 
@@ -207,9 +179,8 @@ func (f *grpcServerFilterFactory) StreamInterceptorFilter(srv interface{}, ss gr
 }
 
 var (
-	ErrUnknownServer    = errors.New("cannot found the grpc server")
-	ErrDuplicateStarted = errors.New("grpc server has already started")
-	ErrInvalidConfig    = errors.New("invalid config for grpc listener")
+	ErrUnknownServer = errors.New("cannot found the grpc server")
+	ErrInvalidConfig = errors.New("invalid config for grpc listener")
 )
 
 // CreateGRPCServerFilterFactory returns a grpc network filter factory.
@@ -254,35 +225,78 @@ type NewRegisteredServer func(config json.RawMessage, options ...grpc.ServerOpti
 
 // Handler is a wrapper to call NewRegisteredServer
 type Handler struct {
-	once sync.Once
-	f    NewRegisteredServer
+	f       NewRegisteredServer
+	mutex   sync.Mutex
+	servers map[string]*registerServerWrapper // support different listener start different grpc server
 }
 
-// Start call the grpc server Serves. If the server is already started returns an error
-func (s *Handler) Start(ln net.Listener, conf json.RawMessage, options ...grpc.ServerOption) (srv RegisteredServer, err error) {
-	err = ErrDuplicateStarted
-	s.once.Do(func() {
-		srv, err = s.f(conf, options...)
-		if err != nil {
-			log.DefaultLogger.Errorf("start a registered server failed: %v", err)
-			return
-		}
+// New a grpc server with address. Same address returns same server, which can be start only once.
+func (s *Handler) New(addr string, conf json.RawMessage, options ...grpc.ServerOption) (*registerServerWrapper, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	sw, ok := s.servers[addr]
+	if ok {
+		return sw, nil
+	}
+	ln, err := NewListener(addr)
+	if err != nil {
+		log.DefaultLogger.Errorf("create a listener failed: %v", err)
+		return nil, err
+	}
+	srv, err := s.f(conf, options...)
+	if err != nil {
+		log.DefaultLogger.Errorf("create a registered server failed: %v", err)
+		return nil, err
+	}
+	sw = &registerServerWrapper{
+		server: srv,
+		ln:     ln,
+	}
+	s.servers[addr] = sw
+	return sw, nil
+}
+
+// registerServerWrapper wraps a registered server and its listener
+type registerServerWrapper struct {
+	once   sync.Once
+	server RegisteredServer
+	ln     *Listener
+}
+
+// Start call the grpc server Serves. If the server is already started, ignore it.
+// TODO: support restart and dynamic update, which are not supported at time.
+func (rsw *registerServerWrapper) Start(graceful time.Duration) {
+	rsw.once.Do(func() {
 		go func() {
-			// TODO: support restart and dynamic update, which are not supported at time.
-			if r := srv.Serve(ln); r != nil {
-				log.DefaultLogger.Errorf("grpc server serves error: %v", r)
+			if err := rsw.server.Serve(rsw.ln); err != nil {
+				log.DefaultLogger.Errorf("grpc server serves error: %v", err)
 			}
 		}()
-		err = nil
+		// stop grpc server when mosn process shutdown
+		keeper.OnProcessShutDown(func() error {
+			if graceful <= 0 {
+				graceful = v2.GrpcDefaultGracefulStopTimeout // use default timeout
+			}
+			// sync stop grpc server
+			timer := time.AfterFunc(graceful, func() {
+				rsw.server.Stop()
+				log.DefaultLogger.Errorf("[grpc networkFilter] force stop grpc server: %s", rsw.ln.Addr().String())
+			})
+			defer timer.Stop()
+			log.DefaultLogger.Infof("[grpc networkFilter] graceful stopping grpc server: %s", rsw.ln.Addr().String())
+			rsw.server.GracefulStop()
+			log.DefaultLogger.Infof("[grpc networkFilter] graceful stoped grpc server success:  %s", rsw.ln.Addr().String())
+			return nil
+		})
 	})
-	return srv, err
 }
 
 var stores sync.Map
 
 func RegisterServerHandler(name string, f NewRegisteredServer) bool {
 	_, loaded := stores.LoadOrStore(name, &Handler{
-		f: f,
+		f:       f,
+		servers: map[string]*registerServerWrapper{},
 	})
 	// loaded means duplicate name registered
 	ok := !loaded

--- a/pkg/filter/network/grpc/filter.go
+++ b/pkg/filter/network/grpc/filter.go
@@ -53,7 +53,9 @@ func (f *grpcFilter) OnNewConnection() api.FilterStatus {
 	if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
 		log.DefaultLogger.Debugf("grpc filter send a new connection to grpc server")
 	}
-	f.ln.NewConnection(f.conn)
+	if err := f.ln.NewConnection(f.conn); err != nil {
+		return api.Stop
+	}
 	return api.Continue
 }
 

--- a/pkg/filter/network/grpc/filter_test.go
+++ b/pkg/filter/network/grpc/filter_test.go
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grpc
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"mosn.io/api"
+)
+
+func TestFilterOnNewConnection(t *testing.T) {
+	addr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+	ln := &Listener{
+		accepts: make(chan net.Conn), // mock a listener without buffer,
+		addr:    addr,
+	}
+	f := NewGrpcFilter(nil, ln)
+	verify := func(expected api.FilterStatus) {
+		mockCb := &MockReadFilterCallbacks{
+			conn: &MockConnection{},
+		}
+		f.InitializeReadFilterCallbacks(mockCb)
+		timer := time.NewTimer(5 * time.Second)
+
+		ch := make(chan struct{})
+		go func() {
+			status := f.OnNewConnection()
+			// no listener accept, read timeout
+			require.Equal(t, expected, status)
+			if expected == api.Stop {
+				require.True(t, mockCb.conn.closed)
+			} else {
+				require.False(t, mockCb.conn.closed)
+			}
+			close(ch)
+		}()
+		select {
+		case <-ch:
+			timer.Stop()
+		case <-timer.C:
+			t.Fatalf("OnNewConnection without returns")
+		}
+
+	}
+	verify(api.Stop)
+	// start a accept
+	go func() {
+		for {
+			_, err := ln.Accept()
+			if err != nil {
+				return
+			}
+		}
+	}()
+	verify(api.Continue)
+	// stop listener
+	ln.Close()
+	verify(api.Stop)
+}

--- a/pkg/filter/network/grpc/grpc_test.go
+++ b/pkg/filter/network/grpc/grpc_test.go
@@ -164,7 +164,8 @@ func (cb *MockReadFilterCallbacks) Connection() api.Connection {
 
 type MockConnection struct {
 	api.Connection
-	raw net.Conn
+	raw    net.Conn
+	closed bool
 }
 
 func (c *MockConnection) Write(buf ...buffer.IoBuffer) error {
@@ -178,10 +179,16 @@ func (c *MockConnection) Write(buf ...buffer.IoBuffer) error {
 }
 
 func (c *MockConnection) LocalAddr() net.Addr {
+	if c.raw == nil {
+		return nil
+	}
 	return c.raw.LocalAddr()
 }
 
 func (c *MockConnection) RemoteAddr() net.Addr {
+	if c.raw == nil {
+		return nil
+	}
 	return c.raw.RemoteAddr()
 }
 
@@ -193,5 +200,9 @@ func (c *MockConnection) AddConnectionEventListener(api.ConnectionEventListener)
 }
 
 func (c *MockConnection) Close(_ api.ConnectionCloseType, _ api.ConnectionEvent) error {
+	c.closed = true
+	if c.raw == nil {
+		return nil
+	}
 	return c.raw.Close()
 }

--- a/pkg/filter/network/grpc/listener.go
+++ b/pkg/filter/network/grpc/listener.go
@@ -20,6 +20,7 @@ package grpc
 import (
 	"net"
 	"syscall"
+	"time"
 
 	"go.uber.org/atomic"
 	"mosn.io/mosn/pkg/log"
@@ -28,7 +29,7 @@ import (
 // Listener is an implementation of net.Listener
 type Listener struct {
 	closed  atomic.Bool
-	accepts chan net.Conn
+	accepts chan net.Conn // TODO: use a queue instead of channel to avoid hang up
 	addr    net.Addr
 }
 
@@ -44,7 +45,7 @@ func NewListener(address string) (*Listener, error) {
 		return nil, err
 	}
 	return &Listener{
-		accepts: make(chan net.Conn),
+		accepts: make(chan net.Conn, 10),
 		addr:    addr,
 	}, nil
 }
@@ -55,6 +56,9 @@ func (l *Listener) Accept() (net.Conn, error) {
 	c, ok := <-l.accepts
 	if !ok {
 		return nil, syscall.EINVAL
+	}
+	if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
+		log.DefaultLogger.Debugf("[grpc] listener %s receive a connection", l.addr.String())
 	}
 	return c, nil
 }
@@ -72,5 +76,22 @@ func (l *Listener) Close() error {
 }
 
 func (l *Listener) NewConnection(conn net.Conn) {
-	l.accepts <- conn
+	defer func() {
+		if r := recover(); r != nil {
+			log.DefaultLogger.Errorf("[grpc] listener has been closed, send on closed channel")
+			if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
+				log.DefaultLogger.Debugf("[grpc] listener has been closed, %v", r)
+			}
+		}
+	}()
+	timer := time.NewTimer(3 * time.Second)
+	select {
+	case l.accepts <- conn:
+		timer.Stop()
+		if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
+			log.DefaultLogger.Debugf("[grpc] listener %s new a connection, wait to accept", l.addr.String())
+		}
+	case <-timer.C:
+		log.DefaultLogger.Errorf("[grpc] connection buffer full, and timeout")
+	}
 }


### PR DESCRIPTION
1. 优化gRPC框架，支持Init函数可重入，但是不会运行多次Server。
2. 不同的Listener可以支持同名rpc server独立运行
3. 优化connection 数据触发方式，使用Pipe Buffer代替channel，避免channel阻塞问题