### PR TITLE
bugfix: recalculate frame length #1784

### DIFF
--- a/pkg/protocol/xprotocol/bolt/encoder.go
+++ b/pkg/protocol/xprotocol/bolt/encoder.go
@@ -45,13 +45,22 @@ func encodeRequest(ctx context.Context, request *Request) (types.IoBuffer, error
 	// 2.1 calculate frame length
 	if request.Class != "" {
 		request.ClassLen = uint16(len(request.Class))
+	} else {
+		request.ClassLen = 0
 	}
+
 	if len(request.Header.Kvs) != 0 {
 		request.HeaderLen = uint16(xprotocol.GetHeaderEncodeLength(&request.Header))
+	} else {
+		request.HeaderLen = 0
 	}
+
 	if request.Content != nil {
 		request.ContentLen = uint32(request.Content.Len())
+	} else {
+		request.ContentLen = 0
 	}
+
 	frameLen := RequestHeaderLen + int(request.ClassLen) + int(request.HeaderLen) + int(request.ContentLen)
 
 	// 2.2 alloc encode buffer, this buffer will be recycled after connection.Write
@@ -105,13 +114,22 @@ func encodeResponse(ctx context.Context, response *Response) (types.IoBuffer, er
 	// 2.1 calculate frame length
 	if response.Class != "" {
 		response.ClassLen = uint16(len(response.Class))
+	} else {
+		response.ClassLen = 0
 	}
+
 	if len(response.Header.Kvs) != 0 {
 		response.HeaderLen = uint16(xprotocol.GetHeaderEncodeLength(&response.Header))
+	} else {
+		response.HeaderLen = 0
 	}
+
 	if response.Content != nil {
 		response.ContentLen = uint32(response.Content.Len())
+	} else {
+		response.ContentLen = 0
 	}
+
 	frameLen := ResponseHeaderLen + int(response.ClassLen) + int(response.HeaderLen) + int(response.ContentLen)
 
 	// 2.2 alloc encode buffer, this buffer will be recycled after connection.Write

--- a/pkg/protocol/xprotocol/boltv2/encoder.go
+++ b/pkg/protocol/xprotocol/boltv2/encoder.go
@@ -45,13 +45,22 @@ func encodeRequest(ctx context.Context, request *Request) (types.IoBuffer, error
 	// 2.1 calculate frame length
 	if request.Class != "" {
 		request.ClassLen = uint16(len(request.Class))
+	} else {
+		request.ClassLen = 0
 	}
+
 	if len(request.Header.Kvs) != 0 {
 		request.HeaderLen = uint16(xprotocol.GetHeaderEncodeLength(&request.Header))
+	} else {
+		request.HeaderLen = 0
 	}
+
 	if request.Content != nil {
 		request.ContentLen = uint32(request.Content.Len())
+	} else {
+		request.ContentLen = 0
 	}
+
 	frameLen := RequestHeaderLen + int(request.ClassLen) + int(request.HeaderLen) + int(request.ContentLen)
 
 	// 2.2 alloc encode buffer, this buffer will be recycled after connection.Write
@@ -107,13 +116,22 @@ func encodeResponse(ctx context.Context, response *Response) (types.IoBuffer, er
 	// 2.1 calculate frame length
 	if response.Class != "" {
 		response.ClassLen = uint16(len(response.Class))
+	} else {
+		response.ClassLen = 0
 	}
+
 	if len(response.Header.Kvs) != 0 {
 		response.HeaderLen = uint16(xprotocol.GetHeaderEncodeLength(&response.Header))
+	} else {
+		response.HeaderLen = 0
 	}
+
 	if response.Content != nil {
 		response.ContentLen = uint32(response.Content.Len())
+	} else {
+		response.ContentLen = 0
 	}
+
 	frameLen := ResponseHeaderLen + int(response.ClassLen) + int(response.HeaderLen) + int(response.ContentLen)
 
 	// 2.2 alloc encode buffer, this buffer will be recycled after connection.Write


### PR DESCRIPTION
### Issues associated with this PR
问题描述: 响应头中的一些 Length 没有进行重计算。在网关场景下，假如在 Filter 中篡改了部分 Response 数据，比如删除了 Response 中所有的响应头，那么可能会造成 Length 和后面的数据不对等的情况，这可能会造成和客户端的链接上的数据包错乱

Issues: 
#1784 

### Solutions
对一些极端场景做出兼容，比如 Response 所有的响应头都被删除的时候，直接将 Header Length 设置为 0。另外Request 的处理可能存在类似的问题，也做了修改

### UT result
本地运行了 make unit-test 通过

### Benchmark
这里仅加了一个赋值的操作用于处理特殊情况，没有什么额外的性能开销
