### PR TITLE
fix sds bug for xds refactory

### DIFF
--- a/pkg/config/v2/tls.go
+++ b/pkg/config/v2/tls.go
@@ -17,6 +17,14 @@
 
 package v2
 
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+)
+
 // TLSConfig is a configuration of tls context
 type TLSConfig struct {
 	Status            bool                   `json:"status,omitempty"`
@@ -45,11 +53,43 @@ type SdsConfig struct {
 }
 
 type SecretConfigWrapper struct {
-	Name      string      `json:"name"`
-	SdsConfig interface{} `json:"sdsConfig"`
+	Name      string      `json:"-"`
+	SdsConfig interface{} `json:"-"`
+	raw       SecretConfigWrapperConfig
+}
+
+func (scw SecretConfigWrapper) MarshalJSON() (b []byte, err error) {
+	// if we build SecretConfigWrapper directly, we should use a proto.Message to build it.
+	if pm, ok := scw.SdsConfig.(proto.Message); ok {
+		var buf bytes.Buffer
+		marshaler := &jsonpb.Marshaler{}
+		_ = marshaler.Marshal(&buf, pm)
+		// use jsonpb format to marshal
+		m := map[string]interface{}{}
+		json.Unmarshal(buf.Bytes(), &m)
+		scw.raw.SdsConfig = m
+	}
+	scw.raw.Name = scw.Name
+	return json.Marshal(scw.raw)
+}
+
+func (scw *SecretConfigWrapper) UnmarshalJSON(b []byte) error {
+	cfg := SecretConfigWrapperConfig{}
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		return err
+	}
+	scw.Name = cfg.Name
+	scw.SdsConfig = cfg.SdsConfig
+	scw.raw = cfg
+	return nil
 }
 
 // Valid checks the whether the SDS Config is valid or not
 func (c *SdsConfig) Valid() bool {
 	return c != nil && c.CertificateConfig != nil && c.ValidationConfig != nil
+}
+
+type SecretConfigWrapperConfig struct {
+	Name      string                 `json:"name"`
+	SdsConfig map[string]interface{} `json:"sdsConfig"`
 }


### PR DESCRIPTION
## BUG 描述
修复xDS重构以后，SDS配置解析中,jsonpb的输出格式和json格式不一致。 当前有BUG的版本，sds config marshal是按照json处理的，处理完以后再Unmarshal 就无法解析会jsonpb的格式了。
同样的问题，也导致xds直接构造的格式和json unmarshal解析的格式不一致
## 修复
1. marshal json处理的时候，按照jsonpb格式的进行输出
2.支持来自xds生成的配置处理