### PR TITLE
feat: support dynamic phase

### DIFF
--- a/pkg/filter/stream/transcoder/config.go
+++ b/pkg/filter/stream/transcoder/config.go
@@ -19,10 +19,34 @@ package transcoder
 
 import (
 	"encoding/json"
+
+	"mosn.io/api"
 )
 
 type config struct {
-	Type string `json:"type,omitempty"`
+	Type  string                 `json:"type,omitempty"`
+	Trans map[string]interface{} `json:"trans,omitempty"`
+}
+
+func (c *config) GetPhase(key string) api.ReceiverFilterPhase {
+	phase := api.ReceiverFilterPhase(-1)
+	switch tt := c.Trans[key].(type) {
+	case float64:
+		phase = api.ReceiverFilterPhase(tt)
+	case float32:
+		phase = api.ReceiverFilterPhase(tt)
+	case int:
+		phase = api.ReceiverFilterPhase(tt)
+	case int32:
+		phase = api.ReceiverFilterPhase(tt)
+	case int64:
+		phase = api.ReceiverFilterPhase(tt)
+	}
+	if phase <= api.AfterChooseHost && phase >= api.BeforeRoute {
+		return phase
+	}
+	// If receiver_phase does not exist in the configuration, set the default api.AfterRoute value
+	return api.AfterRoute
 }
 
 func parseConfig(cfg interface{}) (*config, error) {

--- a/pkg/filter/stream/transcoder/config.go
+++ b/pkg/filter/stream/transcoder/config.go
@@ -29,21 +29,12 @@ type config struct {
 }
 
 func (c *config) GetPhase(key string) api.ReceiverFilterPhase {
-	phase := api.ReceiverFilterPhase(-1)
-	switch tt := c.Trans[key].(type) {
-	case float64:
-		phase = api.ReceiverFilterPhase(tt)
-	case float32:
-		phase = api.ReceiverFilterPhase(tt)
-	case int:
-		phase = api.ReceiverFilterPhase(tt)
-	case int32:
-		phase = api.ReceiverFilterPhase(tt)
-	case int64:
-		phase = api.ReceiverFilterPhase(tt)
+	phase, ok := c.Trans[key].(float64)
+	if !ok {
+		return api.AfterRoute
 	}
-	if phase <= api.AfterChooseHost && phase >= api.BeforeRoute {
-		return phase
+	if api.ReceiverFilterPhase(phase) <= api.AfterChooseHost && api.ReceiverFilterPhase(phase) >= api.BeforeRoute {
+		return api.ReceiverFilterPhase(phase)
 	}
 	// If receiver_phase does not exist in the configuration, set the default api.AfterRoute value
 	return api.AfterRoute

--- a/pkg/filter/stream/transcoder/factory.go
+++ b/pkg/filter/stream/transcoder/factory.go
@@ -21,7 +21,7 @@ import (
 	"context"
 
 	"mosn.io/api"
-	"mosn.io/mosn/pkg/config/v2"
+	v2 "mosn.io/mosn/pkg/config/v2"
 )
 
 // stream factory
@@ -35,10 +35,12 @@ type filterChainFactory struct {
 
 func (f *filterChainFactory) CreateFilterChain(context context.Context, callbacks api.StreamFilterChainFactoryCallbacks) {
 	transcodeFilter := newTranscodeFilter(context, f.cfg)
-	if transcodeFilter != nil {
-		callbacks.AddStreamReceiverFilter(transcodeFilter, api.AfterRoute)
-		callbacks.AddStreamSenderFilter(transcodeFilter, api.BeforeSend)
+	if transcodeFilter == nil {
+		return
 	}
+
+	callbacks.AddStreamReceiverFilter(transcodeFilter, f.cfg.GetPhase("receiver_phase"))
+	callbacks.AddStreamSenderFilter(transcodeFilter, api.BeforeSend)
 }
 
 func createFilterChainFactory(conf map[string]interface{}) (api.StreamFilterChainFactory, error) {

--- a/pkg/filter/stream/transcoder/factory_test.go
+++ b/pkg/filter/stream/transcoder/factory_test.go
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package transcoder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"mosn.io/api"
+)
+
+type tt struct {
+	Transcoder
+}
+
+type mockCallback struct {
+	receiverPhase     api.ReceiverFilterPhase
+	senderFilterPhase api.SenderFilterPhase
+}
+
+func (mock *mockCallback) AddStreamSenderFilter(filter api.StreamSenderFilter, p api.SenderFilterPhase) {
+	mock.senderFilterPhase = p
+}
+
+func (mock *mockCallback) AddStreamReceiverFilter(filter api.StreamReceiverFilter, p api.ReceiverFilterPhase) {
+	mock.receiverPhase = p
+}
+
+func (mock *mockCallback) AddStreamAccessLog(accessLog api.AccessLog) {
+}
+
+func TestCreateFilter(t *testing.T) {
+	testcase := []struct {
+		conf           map[string]interface{}
+		expectReceiver api.ReceiverFilterPhase
+	}{
+		{
+			conf: map[string]interface{}{
+				"type":  "http2bolt_simple",
+				"trans": map[string]interface{}{"receiver_phase": api.AfterChooseHost},
+			},
+			expectReceiver: api.AfterChooseHost,
+		},
+		{
+			conf: map[string]interface{}{
+				"type": "http2bolt_simple",
+			},
+			expectReceiver: api.AfterRoute,
+		},
+		{
+			conf: map[string]interface{}{
+				"type":  "http2bolt_simple",
+				"trans": map[string]interface{}{"receiver_phase": 100},
+			},
+			expectReceiver: api.AfterRoute,
+		},
+		{
+			conf: map[string]interface{}{
+				"type":  "http2bolt_simple",
+				"trans": map[string]interface{}{"receiver_phase": int(api.BeforeRoute)},
+			},
+			expectReceiver: api.BeforeRoute,
+		},
+		{
+			conf: map[string]interface{}{
+				"type":  "http2bolt",
+				"trans": map[string]interface{}{"receiver_phase": int(api.BeforeRoute)},
+			},
+			expectReceiver: api.BeforeRoute,
+		},
+	}
+	MustRegister("http2bolt_simple", &tt{})
+	for _, tcase := range testcase {
+		ff, err := createFilterChainFactory(tcase.conf)
+		assert.NoError(t, err)
+		mock := &mockCallback{}
+		ff.CreateFilterChain(context.Background(), mock)
+		assert.Equal(t, tcase.expectReceiver, mock.receiverPhase)
+	}
+}

--- a/pkg/filter/stream/transcoder/factory_test.go
+++ b/pkg/filter/stream/transcoder/factory_test.go
@@ -53,7 +53,7 @@ func TestCreateFilter(t *testing.T) {
 		{
 			conf: map[string]interface{}{
 				"type":  "http2bolt_simple",
-				"trans": map[string]interface{}{"receiver_phase": api.AfterChooseHost},
+				"trans": map[string]interface{}{"receiver_phase": float64(api.AfterChooseHost)},
 			},
 			expectReceiver: api.AfterChooseHost,
 		},
@@ -66,21 +66,21 @@ func TestCreateFilter(t *testing.T) {
 		{
 			conf: map[string]interface{}{
 				"type":  "http2bolt_simple",
-				"trans": map[string]interface{}{"receiver_phase": 100},
+				"trans": map[string]interface{}{"receiver_phase": float64(100)},
 			},
 			expectReceiver: api.AfterRoute,
 		},
 		{
 			conf: map[string]interface{}{
 				"type":  "http2bolt_simple",
-				"trans": map[string]interface{}{"receiver_phase": int(api.BeforeRoute)},
+				"trans": map[string]interface{}{"receiver_phase": float64(api.BeforeRoute)},
 			},
 			expectReceiver: api.BeforeRoute,
 		},
 		{
 			conf: map[string]interface{}{
 				"type":  "http2bolt",
-				"trans": map[string]interface{}{"receiver_phase": int(api.BeforeRoute)},
+				"trans": map[string]interface{}{"receiver_phase": float64(api.BeforeRoute)},
 			},
 			expectReceiver: api.BeforeRoute,
 		},


### PR DESCRIPTION
### Issues associated with this PR
当前 filter 生效点在：api.AfterRoute 和 api.BeforeSend 。而且是不可以修改的。 
在协议场景 filter 生效在 api.BeforRoute 和 api.BeforeSend ，目前无法满足。

### Solutions
在配置中增加 ReceiverPhase 结构，用户可以通过配置进行动态修改。
ReceiverPhase 类型是 *api.ReceiverFilterPhase，默认是 nil。
兼容性考虑：
ReceiverPhase = nil ，生效范围保持 api.AfterRoute 就配置一直。
ReceiverPhase != nil, && 在合理范围内，以配置为准。
