### PR TITLE
Feature: support unix domain socket directory configuration

### DIFF
--- a/pkg/config/v2/config.go
+++ b/pkg/config/v2/config.go
@@ -37,6 +37,7 @@ type MOSNConfig struct {
 	RawAdmin             *Admin               `json:"admin,omitempty"`             // admin
 	Debug                PProfConfig          `json:"pprof,omitempty"`
 	Pid                  string               `json:"pid,omitempty"`                 // pid file
+	UDSdir               string               `json:"uds_dir,omitempty"`             // unix domain socket directory
 	Plugin               PluginConfig         `json:"plugin,omitempty"`              // plugin config
 	ThirdPartCodec       ThirdPartCodecConfig `json:"third_part_codec,omitempty"`    // third part codec config
 	Extends              []ExtendConfig       `json:"extends,omitempty"`             // extend config

--- a/pkg/mosn/default_stages.go
+++ b/pkg/mosn/default_stages.go
@@ -33,6 +33,7 @@ import (
 // modify it in main function
 func DefaultInitStage(c *v2.MOSNConfig) {
 	types.InitDefaultPath(configmanager.GetConfigPath())
+	InitUDSdir(c)
 	InitDebugServe(c)
 	InitializePidFile(c)
 	InitializeTracing(c)

--- a/pkg/mosn/init.go
+++ b/pkg/mosn/init.go
@@ -99,6 +99,10 @@ func initializeMetrics(config v2.MetricsConfig) {
 	}
 }
 
+func InitUDSdir (c *v2.MOSNConfig) {
+	types.InitUDSdir(c.UDSdir)
+}
+
 func InitializePidFile(c *v2.MOSNConfig) {
 	initializePidFile(c.Pid)
 }

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -77,3 +77,23 @@ end:
 	os.MkdirAll(MosnLogBasePath, 0755)
 	os.MkdirAll(MosnConfigPath, 0755)
 }
+
+
+func InitUDSdir(dir string){
+	if dir == "" {
+		return
+	}
+
+	unixDomainSocketDir, err := filepath.Abs(dir)
+	if err != nil {
+		return
+	}
+
+	os.MkdirAll(unixDomainSocketDir, 0755)
+
+	ReconfigureDomainSocket = unixDomainSocketDir + string(os.PathSeparator) + "reconfig.sock"
+	TransferConnDomainSocket = unixDomainSocketDir + string(os.PathSeparator) + "conn.sock"
+	TransferStatsDomainSocket = unixDomainSocketDir + string(os.PathSeparator) + "stats.sock"
+	TransferListenDomainSocket = unixDomainSocketDir + string(os.PathSeparator) + "listen.sock"
+	TransferMosnconfigDomainSocket = unixDomainSocketDir + string(os.PathSeparator) + "mosnconfig.sock"
+}

--- a/pkg/types/config_test.go
+++ b/pkg/types/config_test.go
@@ -54,3 +54,37 @@ func TestInitDefaultPath(t *testing.T) {
 	// clean
 	os.RemoveAll(testPath)
 }
+
+
+func TestInitUDSdir(t *testing.T) {
+	ReconfigureDomainSocket = "/home/admin/mosn/conf/reconfig.sock"
+	testCases := []struct {
+		name         string
+		udsDir       string
+		expectedPath string
+	}{
+		{
+			name:         "empty_dir",
+			udsDir:       "",
+			expectedPath: "/home/admin/mosn/conf/reconfig.sock",
+		},
+		{
+			name:         "normal_dir",
+			udsDir:       "/tmp/mosn/socks",
+			expectedPath: "/tmp/mosn/socks/reconfig.sock",
+		},
+		{
+			name:         "multiple_separator",
+			udsDir:       "/tmp//mosn/sock//",
+			expectedPath: "/tmp/mosn/sock/reconfig.sock",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			InitUDSdir(testCase.udsDir)
+			if ReconfigureDomainSocket != testCase.expectedPath {
+				t.Errorf("expected path: %s, got: %s", testCase.expectedPath, ReconfigureDomainSocket)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Issues associated with this PR
mosn's reconfig.sock path is fixed,  to support hot upgrade between two containers, reconfigure unix domain socket path needs to be configurable.

### Solutions
add "uds_dir" filed, which is used to store *.sock files

