### PR TITLE
bugfix: should close logger at the end, otherwise, may lost log during close Mosn instance, fix #1554.

### DIFF
--- a/cmd/mosn/main/control.go
+++ b/cmd/mosn/main/control.go
@@ -146,6 +146,9 @@ var (
 
 			// wait mosn finished
 			stm.WaitFinish()
+
+			// free resource
+			stm.Stop()
 			return nil
 
 		},

--- a/istio/istio152/main/control.go
+++ b/istio/istio152/main/control.go
@@ -146,6 +146,9 @@ var (
 
 			// wait mosn finished
 			stm.WaitFinish()
+
+			// free resource
+			stm.Stop()
 			return nil
 
 		},

--- a/pkg/mosn/stage_manager.go
+++ b/pkg/mosn/stage_manager.go
@@ -24,6 +24,7 @@ import (
 	"mosn.io/mosn/pkg/config/v2"
 	"mosn.io/mosn/pkg/configmanager"
 	"mosn.io/mosn/pkg/log"
+	logger "mosn.io/pkg/log"
 )
 
 // Data contains objects used in stages
@@ -165,4 +166,13 @@ func (stm *StageManager) WaitFinish() {
 		return
 	}
 	stm.data.mosn.Wait()
+}
+
+// free resourse
+// TODO: move more behaviour here, only close log now.
+func (stm *StageManager) Stop() {
+	if !stm.started {
+		return
+	}
+	logger.CloseAll()
 }

--- a/pkg/mosn/stage_manager_test.go
+++ b/pkg/mosn/stage_manager_test.go
@@ -83,4 +83,5 @@ func TestStageManager(t *testing.T) {
 	}
 	stm.data.mosn.Close()
 	stm.WaitFinish()
+	stm.Stop()
 }

--- a/pkg/mosn/stage_manager_test.go
+++ b/pkg/mosn/stage_manager_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/urfave/cli"
-	"mosn.io/mosn/pkg/config/v2"
+	v2 "mosn.io/mosn/pkg/config/v2"
 	"mosn.io/mosn/pkg/configmanager"
 )
 
@@ -71,6 +71,11 @@ func TestStageManager(t *testing.T) {
 		if testCall != 2 {
 			t.Errorf("pre start stage call: 2")
 		}
+	}).AppendAfterStopStage(func(_ *Mosn) {
+		testCall++
+		if testCall != 3 {
+			t.Errorf("after stage stage call: 3")
+		}
 	})
 	if testCall != 0 {
 		t.Errorf("should call nothing")
@@ -83,5 +88,15 @@ func TestStageManager(t *testing.T) {
 	}
 	stm.data.mosn.Close()
 	stm.WaitFinish()
+	if !(testCall == 2 &&
+		stm.data.mosn != nil &&
+		stm.data.config != nil) {
+		t.Errorf("WaitFinish runs failed...")
+	}
 	stm.Stop()
+	if !(testCall == 3 &&
+		stm.data.mosn != nil &&
+		stm.data.config != nil) {
+		t.Errorf("Stop runs failed...")
+	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -25,7 +25,6 @@ import (
 	"mosn.io/mosn/pkg/configmanager"
 	mlog "mosn.io/mosn/pkg/log"
 	"mosn.io/mosn/pkg/network"
-	"mosn.io/mosn/pkg/server/keeper"
 	"mosn.io/mosn/pkg/types"
 	"mosn.io/pkg/buffer"
 	"mosn.io/pkg/log"
@@ -74,8 +73,6 @@ func NewServer(config *Config, cmFilter types.ClusterManagerFilter, clMng types.
 			log.DefaultLogger.Infof("[server] [reconfigure] [new server] Netpoll mode enabled.")
 		}
 	}
-
-	keeper.OnProcessShutDown(log.CloseAll)
 
 	server := &server{
 		serverName: config.ServerName,


### PR DESCRIPTION
### Issues associated with this PR

#1554

### Solutions
Move the logger.CloseAll to the end, after stm.WaitFinish.

### UT result

Passed.

### Benchmark
The code does not involve the processing of every request, no need benchmark.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
