### PR TITLE
feature: h2 server standard lib

### DIFF
--- a/pkg/module/http2/server.go
+++ b/pkg/module/http2/server.go
@@ -463,7 +463,7 @@ type serverConn struct {
 	bw               *bufferedWriter // writing to conn
 	handler          http.Handler
 	baseCtx          context.Context
-	framer           *Framer
+	framer           IFramer
 	doneServing      chan struct{}          // closed when serverConn.serve ends
 	readFrameCh      chan readFrameResult   // written by serverConn.readFrames
 	wantWriteFrameCh chan FrameWriteRequest // from handlers -> serve
@@ -563,7 +563,7 @@ type stream struct {
 	reqTrailer http.Header // handler's Request.Trailer
 }
 
-func (sc *serverConn) Framer() *Framer  { return sc.framer }
+func (sc *serverConn) Framer() IFramer  { return sc.framer }
 func (sc *serverConn) CloseConn() error { return sc.conn.Close() }
 func (sc *serverConn) Flush() error     { return sc.bw.Flush() }
 func (sc *serverConn) HeaderEncoder() (*hpack.Encoder, *bytes.Buffer) {

--- a/pkg/module/http2/write.go
+++ b/pkg/module/http2/write.go
@@ -37,7 +37,7 @@ type writeFramer interface {
 // currently implementing priorities), or b) delete this and
 // make the server code a bit more concrete.
 type writeContext interface {
-	Framer() *Framer
+	Framer() IFramer
 	Flush() error
 	CloseConn() error
 	// HeaderEncoder returns an HPACK encoder that writes to the

--- a/pkg/module/http2/xframe.go
+++ b/pkg/module/http2/xframe.go
@@ -1,0 +1,499 @@
+package http2
+
+import (
+	"encoding/binary"
+	"errors"
+	"golang.org/x/net/http/httpguts"
+	"log"
+	"mosn.io/api"
+	"mosn.io/mosn/pkg/module/http2/hpack"
+	"mosn.io/pkg/buffer"
+	"strings"
+)
+
+type IFramer interface {
+	WriteSettings(settings ...Setting) error
+	WriteGoAway(maxStreamID uint32, code ErrCode, debugData []byte) error
+	WriteData(streamID uint32, endStream bool, data []byte) error
+	WriteRSTStream(streamID uint32, code ErrCode) error
+	WritePing(ack bool, data [8]byte) error
+	WriteSettingsAck() error
+	WriteHeaders(p HeadersFrameParam) error
+	WriteContinuation(streamID uint32, endHeaders bool, headerBlockFragment []byte) error
+	WritePushPromise(p PushPromiseParam) error
+	WriteWindowUpdate(streamID, incr uint32) error
+	ReadFrame() (Frame, error)
+}
+
+type XFramer struct {
+	*Framer
+	api.Connection
+}
+
+func NewMFramer(conn api.Connection) *XFramer {
+	fr := &XFramer{
+		Framer: &Framer{
+			logReads:          logFrameReads,
+			logWrites:         logFrameWrites,
+			debugReadLoggerf:  log.Printf,
+			debugWriteLoggerf: log.Printf,
+		},
+		Connection: conn,
+	}
+	fr.SetMaxReadFrameSize(maxFrameSize)
+	return fr
+}
+
+func (f *XFramer) startWrite(buf buffer.IoBuffer, ftype FrameType, flags Flags, streamID uint32) {
+	// Write the FrameHeader.
+	header := []byte{
+		0, // 3 bytes of length, filled in in endWrite
+		0,
+		0,
+		byte(ftype),
+		byte(flags),
+		byte(streamID >> 24),
+		byte(streamID >> 16),
+		byte(streamID >> 8),
+		byte(streamID),
+	}
+	// header 是否逃逸？
+	buf.Write(header)
+}
+
+func (f *XFramer) endWrite(buf buffer.IoBuffer) error {
+	// Now that we know the final size, fill in the FrameHeader in
+	// the space previously reserved for it. Abuse append.
+	length := buf.Len() - frameHeaderLen
+	if length >= (1 << 24) {
+		return ErrFrameTooLarge
+	}
+	header := buf.Bytes()
+	header[0] = byte(length >> 16)
+	header[1] = byte(length >> 8)
+	header[2] = byte(length)
+	return f.Connection.Write(buf)
+}
+
+func (f *XFramer) writeByte(b buffer.IoBuffer, v byte)     { b.Write([]byte{v}) }
+func (f *XFramer) writeBytes(b buffer.IoBuffer, v []byte)  { b.Write(v) }
+func (f *XFramer) writeUint16(b buffer.IoBuffer, v uint16) { b.Write([]byte{byte(v >> 8), byte(v)}) }
+func (f *XFramer) writeUint32(b buffer.IoBuffer, v uint32) {
+	b.Write([]byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)})
+}
+
+func (fr *XFramer) ReadFrame() (Frame, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func mReadFrameHeader(data buffer.IoBuffer, off int) (FrameHeader, error) {
+	if data.Len() < off+frameHeaderLen {
+		return FrameHeader{}, ErrAGAIN
+	}
+	buf := data.Bytes()[off:]
+	return FrameHeader{
+		Length:   (uint32(buf[0])<<16 | uint32(buf[1])<<8 | uint32(buf[2])),
+		Type:     FrameType(buf[3]),
+		Flags:    Flags(buf[4]),
+		StreamID: binary.BigEndian.Uint32(buf[5:]) & (1<<31 - 1),
+		valid:    true,
+	}, nil
+}
+
+func (fr *XFramer) DecodeFrame(data buffer.IoBuffer, off int) (Frame, int, error) {
+	fr.errDetail = nil
+	last := fr.lastFrame
+	lastHeader := fr.lastHeaderStream
+	fh, err := mReadFrameHeader(data, off)
+	if err != nil {
+		return nil, 0, err
+	}
+	if fh.Length > fr.maxReadSize {
+		return nil, 0, ErrFrameTooLarge
+	}
+
+	if int(fh.Length) > data.Len()-(off+frameHeaderLen) {
+		return nil, 0, ErrAGAIN
+	}
+
+	payload := data.Bytes()[off+frameHeaderLen : off+frameHeaderLen+int(fh.Length)]
+	f, err := typeFrameParser(fh.Type)(fr.frameCache, fh, payload)
+	if err != nil {
+		if ce, ok := err.(connError); ok {
+			return nil, 0, fr.connError(ce.Code, ce.Reason)
+		}
+		return nil, 0, err
+	}
+	if err := fr.checkFrameOrder(f); err != nil {
+		return nil, 0, err
+	}
+	size := frameHeaderLen + int(fh.Length)
+	msize := 0
+	if fh.Type == FrameHeaders && fr.ReadMetaHeaders != nil {
+		f, msize, err = fr.readMetaFrame(f.(*HeadersFrame), data, off+size)
+
+		if err != nil {
+			fr.lastFrame = last
+			fr.lastHeaderStream = lastHeader
+			if ce, ok := err.(connError); ok {
+				return nil, 0, fr.connError(ce.Code, ce.Reason)
+			}
+			return nil, 0, err
+		}
+	}
+
+	if fh.Type != FrameContinuation {
+		data.Drain(size + msize)
+	}
+
+	return f, size + msize, nil
+}
+
+// WriteData writes a DATA frame.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility not to violate the maximum frame size
+// and to not call other Write methods concurrently.
+func (f *XFramer) WriteData(streamID uint32, endStream bool, data []byte) error {
+	return f.WriteDataPadded(streamID, endStream, data, nil)
+}
+
+// WriteData writes a DATA frame with optional padding.
+//
+// If pad is nil, the padding bit is not sent.
+// The length of pad must not exceed 255 bytes.
+// The bytes of pad must all be zero, unless f.AllowIllegalWrites is set.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility not to violate the maximum frame size
+// and to not call other Write methods concurrently.
+func (f *XFramer) WriteDataPadded(streamID uint32, endStream bool, data, pad []byte) error {
+	if !validStreamID(streamID) && !f.AllowIllegalWrites {
+		return errStreamID
+	}
+	if len(pad) > 0 {
+		if len(pad) > 255 {
+			return errPadLength
+		}
+		if !f.AllowIllegalWrites {
+			for _, b := range pad {
+				if b != 0 {
+					// "Padding octets MUST be set to zero when sending."
+					return errPadBytes
+				}
+			}
+		}
+	}
+	var flags Flags
+	if endStream {
+		flags |= FlagDataEndStream
+	}
+	if pad != nil {
+		flags |= FlagDataPadded
+	}
+	buf := buffer.GetIoBuffer(len(data) + frameHeaderLen + 8)
+	f.startWrite(buf, FrameData, flags, streamID)
+	if pad != nil {
+		f.writeByte(buf, byte(len(pad)))
+	}
+	buf.Write(data)
+	buf.Write(pad)
+	return f.endWrite(buf)
+}
+
+// WriteSettings writes a SETTINGS frame with zero or more settings
+// specified and the ACK bit not set.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility to not call other Write methods concurrently.
+func (f *XFramer) WriteSettings(settings ...Setting) error {
+	buf := buffer.NewIoBuffer(len(settings)*6 + frameHeaderLen)
+	f.startWrite(buf, FrameSettings, 0, 0)
+	for _, s := range settings {
+		f.writeUint16(buf, uint16(s.ID))
+		f.writeUint32(buf, s.Val)
+	}
+	return f.endWrite(buf)
+}
+
+// WriteSettingsAck writes an empty SETTINGS frame with the ACK bit set.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility to not call other Write methods concurrently.
+func (f *XFramer) WriteSettingsAck() error {
+	buf := buffer.NewIoBuffer(frameHeaderLen)
+	f.startWrite(buf, FrameSettings, FlagSettingsAck, 0)
+	return f.endWrite(buf)
+}
+
+func (f *XFramer) WritePing(ack bool, data [8]byte) error {
+	var flags Flags
+	if ack {
+		flags = FlagPingAck
+	}
+	buf := buffer.NewIoBuffer(len(data[:]) + frameHeaderLen)
+	f.startWrite(buf, FramePing, flags, 0)
+	f.writeBytes(buf, data[:])
+	return f.endWrite(buf)
+}
+
+func (f *XFramer) WriteGoAway(maxStreamID uint32, code ErrCode, debugData []byte) error {
+	buf := buffer.NewIoBuffer(8 + len(debugData) + frameHeaderLen)
+	f.startWrite(buf, FrameGoAway, 0, 0)
+	f.writeUint32(buf, maxStreamID&(1<<31-1))
+	f.writeUint32(buf, uint32(code))
+	f.writeBytes(buf, debugData)
+	return f.endWrite(buf)
+}
+
+// WriteWindowUpdate writes a WINDOW_UPDATE frame.
+// The increment value must be between 1 and 2,147,483,647, inclusive.
+// If the Stream ID is zero, the window update applies to the
+// connection as a whole.
+func (f *XFramer) WriteWindowUpdate(streamID, incr uint32) error {
+	// "The legal range for the increment to the flow control window is 1 to 2^31-1 (2,147,483,647) octets."
+	if (incr < 1 || incr > 2147483647) && !f.AllowIllegalWrites {
+		return errors.New("illegal window increment value")
+	}
+	buf := buffer.NewIoBuffer(4 + frameHeaderLen)
+	f.startWrite(buf, FrameWindowUpdate, 0, streamID)
+	f.writeUint32(buf, incr)
+	return f.endWrite(buf)
+}
+
+// WriteHeaders writes a single HEADERS frame.
+//
+// This is a low-level header writing method. Encoding headers and
+// splitting them into any necessary CONTINUATION frames is handled
+// elsewhere.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility to not call other Write methods concurrently.
+func (f *XFramer) WriteHeaders(p HeadersFrameParam) error {
+	if !validStreamID(p.StreamID) && !f.AllowIllegalWrites {
+		return errStreamID
+	}
+	var flags Flags
+	buf := buffer.GetIoBuffer(len(p.BlockFragment) + frameHeaderLen + 8)
+	if p.PadLength != 0 {
+		flags |= FlagHeadersPadded
+	}
+	if p.EndStream {
+		flags |= FlagHeadersEndStream
+	}
+	if p.EndHeaders {
+		flags |= FlagHeadersEndHeaders
+	}
+	if !p.Priority.IsZero() {
+		flags |= FlagHeadersPriority
+	}
+	f.startWrite(buf, FrameHeaders, flags, p.StreamID)
+	if p.PadLength != 0 {
+		f.writeByte(buf, p.PadLength)
+	}
+	if !p.Priority.IsZero() {
+		v := p.Priority.StreamDep
+		if !validStreamIDOrZero(v) && !f.AllowIllegalWrites {
+			return errDepStreamID
+		}
+		if p.Priority.Exclusive {
+			v |= 1 << 31
+		}
+		f.writeUint32(buf, v)
+		f.writeByte(buf, p.Priority.Weight)
+	}
+	buf.Write(p.BlockFragment)
+	buf.Write(padZeros[:p.PadLength])
+	return f.endWrite(buf)
+}
+
+// WritePriority writes a PRIORITY frame.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility to not call other Write methods concurrently.
+func (f *XFramer) WritePriority(streamID uint32, p PriorityParam) error {
+	if !validStreamID(streamID) && !f.AllowIllegalWrites {
+		return errStreamID
+	}
+	if !validStreamIDOrZero(p.StreamDep) {
+		return errDepStreamID
+	}
+	buf := buffer.GetIoBuffer(5 + frameHeaderLen)
+	f.startWrite(buf, FramePriority, 0, streamID)
+	v := p.StreamDep
+	if p.Exclusive {
+		v |= 1 << 31
+	}
+	f.writeUint32(buf, v)
+	f.writeByte(buf, p.Weight)
+	return f.endWrite(buf)
+}
+
+// WriteRSTStream writes a RST_STREAM frame.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility to not call other Write methods concurrently.
+func (f *XFramer) WriteRSTStream(streamID uint32, code ErrCode) error {
+	if !validStreamID(streamID) && !f.AllowIllegalWrites {
+		return errStreamID
+	}
+	buf := buffer.GetIoBuffer(4 + frameHeaderLen)
+	f.startWrite(buf, FrameRSTStream, 0, streamID)
+	f.writeUint32(buf, uint32(code))
+	return f.endWrite(buf)
+}
+
+// WriteContinuation writes a CONTINUATION frame.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility to not call other Write methods concurrently.
+func (f *XFramer) WriteContinuation(streamID uint32, endHeaders bool, headerBlockFragment []byte) error {
+	if !validStreamID(streamID) && !f.AllowIllegalWrites {
+		return errStreamID
+	}
+	var flags Flags
+	if endHeaders {
+		flags |= FlagContinuationEndHeaders
+	}
+	buf := buffer.GetIoBuffer(len(headerBlockFragment) + frameHeaderLen)
+	f.startWrite(buf, FrameContinuation, flags, streamID)
+	buf.Write(headerBlockFragment)
+	return f.endWrite(buf)
+}
+
+// WritePushPromise writes a single PushPromise Frame.
+//
+// As with Header Frames, This is the low level call for writing
+// individual frames. Continuation frames are handled elsewhere.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility to not call other Write methods concurrently.
+func (f *XFramer) WritePushPromise(p PushPromiseParam) error {
+	if !validStreamID(p.StreamID) && !f.AllowIllegalWrites {
+		return errStreamID
+	}
+	var flags Flags
+	if p.PadLength != 0 {
+		flags |= FlagPushPromisePadded
+	}
+	if p.EndHeaders {
+		flags |= FlagPushPromiseEndHeaders
+	}
+	buf := buffer.GetIoBuffer(len(p.BlockFragment) + frameHeaderLen + 12)
+	f.startWrite(buf, FramePushPromise, flags, p.StreamID)
+	if p.PadLength != 0 {
+		f.writeByte(buf, p.PadLength)
+	}
+	if !validStreamID(p.PromiseID) && !f.AllowIllegalWrites {
+		return errStreamID
+	}
+	f.writeUint32(buf, p.PromiseID)
+	buf.Write(p.BlockFragment)
+	buf.Write(padZeros[:p.PadLength])
+	return f.endWrite(buf)
+}
+
+// WriteRawFrame writes a raw frame. This can be used to write
+// extension frames unknown to this package.
+func (f *XFramer) WriteRawFrame(t FrameType, flags Flags, streamID uint32, payload []byte) error {
+	buf := buffer.GetIoBuffer(len(payload) + frameHeaderLen)
+	f.startWrite(buf, t, flags, streamID)
+	f.writeBytes(buf, payload)
+	return f.endWrite(buf)
+}
+
+// readMetaFrame returns 0 or more CONTINUATION frames from fr and
+// merge them into the provided hf and returns a MetaHeadersFrame
+// with the decoded hpack values.
+func (fr *XFramer) readMetaFrame(hf *HeadersFrame, data buffer.IoBuffer, off int) (*MetaHeadersFrame, int, error) {
+	if fr.AllowIllegalReads {
+		return nil, 0, errors.New("illegal use of AllowIllegalReads with ReadMetaHeaders")
+	}
+	mh := &MetaHeadersFrame{
+		HeadersFrame: hf,
+	}
+	var remainSize = fr.maxHeaderListSize()
+	var sawRegular bool
+
+	var invalid error // pseudo header field errors
+	hdec := fr.ReadMetaHeaders
+	hdec.SetEmitEnabled(true)
+	hdec.SetMaxStringLength(fr.maxHeaderStringLen())
+	hdec.SetEmitFunc(func(hf hpack.HeaderField) {
+		if VerboseLogs && fr.logReads {
+			fr.debugReadLoggerf("http2: decoded hpack field %+v", hf)
+		}
+		if !httpguts.ValidHeaderFieldValue(hf.Value) {
+			invalid = headerFieldValueError(hf.Value)
+		}
+		isPseudo := strings.HasPrefix(hf.Name, ":")
+		if isPseudo {
+			if sawRegular {
+				invalid = errPseudoAfterRegular
+			}
+		} else {
+			sawRegular = true
+			if !validWireHeaderFieldName(hf.Name) {
+				invalid = headerFieldNameError(hf.Name)
+			}
+		}
+
+		if invalid != nil {
+			hdec.SetEmitEnabled(false)
+			return
+		}
+
+		size := hf.Size()
+		if size > remainSize {
+			hdec.SetEmitEnabled(false)
+			mh.Truncated = true
+			return
+		}
+		remainSize -= size
+
+		mh.Fields = append(mh.Fields, hf)
+	})
+	// Lose reference to MetaHeadersFrame:
+	defer hdec.SetEmitFunc(func(hf hpack.HeaderField) {})
+
+	var hc headersOrContinuation = hf
+	msize := 0
+	for {
+		frag := hc.HeaderBlockFragment()
+		if _, err := hdec.Write(frag); err != nil {
+			return nil, 0, ConnectionError(ErrCodeCompression)
+		}
+
+		if hc.HeadersEnded() {
+			break
+		}
+		if f, size, err := fr.DecodeFrame(data, off); err != nil {
+			return nil, 0, err
+		} else {
+			msize += size
+			hc = f.(*ContinuationFrame) // guaranteed by checkFrameOrder
+		}
+	}
+
+	mh.HeadersFrame.headerFragBuf = nil
+	mh.HeadersFrame.invalidate()
+
+	if err := hdec.Close(); err != nil {
+		return nil, 0, ConnectionError(ErrCodeCompression)
+	}
+	if invalid != nil {
+		fr.errDetail = invalid
+		if VerboseLogs {
+			log.Printf("http2: invalid header: %v", invalid)
+		}
+		return nil, 0, StreamError{mh.StreamID, ErrCodeProtocol, invalid}
+	}
+	if err := mh.checkPseudos(); err != nil {
+		fr.errDetail = err
+		if VerboseLogs {
+			log.Printf("http2: invalid pseudo headers: %v", err)
+		}
+		return nil, 0, StreamError{mh.StreamID, ErrCodeProtocol, err}
+	}
+	return mh, msize, nil
+}

--- a/pkg/module/http2/xhttp2.go
+++ b/pkg/module/http2/xhttp2.go
@@ -1,0 +1,731 @@
+package http2
+
+import (
+	"bytes"
+	"fmt"
+	"golang.org/x/net/http/httpguts"
+	"io"
+	"math"
+	"mosn.io/api"
+	"mosn.io/mosn/pkg/log"
+	"mosn.io/mosn/pkg/module/http2/hpack"
+	"mosn.io/mosn/pkg/types"
+	"mosn.io/pkg/buffer"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type XStream struct {
+	*stream
+	sentContentLen int64
+	conn           *XServerConn
+	Request        *http.Request
+	Response       *http.Response
+	Trailer        *http.Header
+	SendData       buffer.IoBuffer
+	UseStream      bool
+}
+
+// ID returns stream id
+func (ms *XStream) ID() uint32 {
+	return ms.id
+}
+
+func (ms *XStream) WriteHeader(end bool) error {
+	rsp := ms.Response
+	endStream := end || ms.Request.Method == "HEAD"
+
+	isHeadResp := ms.Request.Method == "HEAD"
+	var ctype, clen string
+	var dataLen int
+	if ms.SendData != nil {
+		dataLen = ms.SendData.Len()
+	}
+
+	if clen = rsp.Header.Get("Content-Length"); clen != "" {
+		rsp.Header.Del("Content-Length")
+		clen64, err := strconv.ParseInt(clen, 10, 64)
+		if err == nil && clen64 >= 0 {
+			ms.sentContentLen = clen64
+		} else {
+			clen = ""
+		}
+	}
+
+	if dataLen == 0 || isHeadResp || !bodyAllowedForStatus(rsp.StatusCode) {
+		clen = "0"
+	}
+
+	hasContentType := rsp.Header.Get("Content-Type")
+	if hasContentType == "" && bodyAllowedForStatus(rsp.StatusCode) && dataLen > 0 {
+		ctype = http.DetectContentType(ms.SendData.Bytes())
+	}
+	var date string
+	if ok := rsp.Header.Get("Date"); ok == "" {
+		date = time.Now().UTC().Format(http.TimeFormat)
+	}
+
+	ws := &writeResHeaders{
+		streamID:      ms.id,
+		httpResCode:   rsp.StatusCode,
+		h:             rsp.Header,
+		endStream:     endStream,
+		contentLength: clen,
+		contentType:   ctype,
+		date:          date,
+	}
+	return ms.conn.writeHeaders(ms.stream, ws)
+}
+
+func (ms *XStream) WriteData() (err error) {
+	if ms.UseStream {
+		var sawEOF bool
+		bufp := buffer.GetBytes(defaultMaxReadFrameSize)
+		defer buffer.PutBytes(bufp)
+		buf := *bufp
+		for !sawEOF {
+			n, err := ms.SendData.Read(buf)
+			if err == io.EOF {
+				sawEOF = true
+				err = nil
+			} else if err != nil {
+				return err
+			}
+			if len(buf[:n]) > 0 {
+				err = ms.conn.writeDataFromHandler(ms.stream, buf[:n], false)
+			}
+		}
+	} else {
+		err = ms.conn.writeDataFromHandler(ms.stream, ms.SendData.Bytes(), false)
+	}
+	return
+}
+
+func (ms *XStream) WriteTrailers() error {
+	var tramap http.Header
+	if ms.Trailer != nil {
+		tramap = *ms.Trailer
+	}
+	var trailers []string
+	if tramap != nil {
+		for k, _ := range tramap {
+			k = http.CanonicalHeaderKey(k)
+			if !httpguts.ValidTrailerHeader(k) {
+				tramap.Del(k)
+			} else {
+				trailers = append(trailers, k)
+			}
+		}
+	}
+
+	var err error
+	if len(trailers) > 0 {
+		ws := &writeResHeaders{
+			streamID:  ms.id,
+			h:         tramap,
+			trailers:  trailers,
+			endStream: true,
+		}
+		err = ms.conn.writeHeaders(ms.stream, ws)
+	} else {
+		err = ms.conn.writeDataFromHandler(ms.stream, nil, true)
+	}
+	// TODO: If state is stateHalfClosedRemote, send err is later than close stream.
+	if err == errStreamClosed {
+		return nil
+	}
+	return err
+}
+
+func (ms *XStream) SendResponse() error {
+	endHeader := ms.SendData == nil && ms.Trailer == nil
+	if err := ms.WriteHeader(endHeader); err != nil || endHeader {
+		return err
+	}
+
+	if err := ms.WriteData(); err != nil {
+		return err
+	}
+	return ms.WriteTrailers()
+}
+
+type FrameHandler interface {
+	HandleFrame(Frame, *XStream, []byte, bool, bool, error)
+}
+
+type XServerConn struct {
+	*serverConn
+	preface  bool
+	mHandler FrameHandler
+}
+
+func NewXServerConn(conn api.Connection, mHandler FrameHandler, opts *ServeConnOpts) *XServerConn {
+	c := conn.RawConn()
+	baseCtx, cancel := serverConnBaseContext(c, opts)
+	defer cancel()
+
+	sc := &XServerConn{
+		serverConn: &serverConn{
+			srv:                         &Server{MaxUploadBufferPerStream: initialConnRecvWindowSize},
+			hs:                          opts.baseConfig(),
+			conn:                        c,
+			baseCtx:                     baseCtx,
+			remoteAddrStr:               c.RemoteAddr().String(),
+			bw:                          newBufferedWriter(c),
+			streams:                     make(map[uint32]*stream),
+			readFrameCh:                 make(chan readFrameResult),
+			wantWriteFrameCh:            make(chan FrameWriteRequest, 8),
+			serveMsgCh:                  make(chan interface{}, 8),
+			wroteFrameCh:                make(chan frameWriteResult, 1), // buffered; one send in writeFrameAsync
+			bodyReadCh:                  make(chan bodyReadMsg),         // buffering doesn't matter either way
+			doneServing:                 make(chan struct{}),
+			clientMaxStreams:            math.MaxUint32, // Section 6.5.2: "Initially, there is no limit to this value"
+			advMaxStreams:               defaultMaxStreams * 100,
+			initialStreamSendWindowSize: initialWindowSize,
+			maxFrameSize:                initialMaxFrameSize,
+			headerTableSize:             initialHeaderTableSize,
+			pushEnabled:                 true,
+		},
+		mHandler: mHandler,
+	}
+
+	// s.state.registerConn(sc)
+	// defer s.state.unregisterConn(sc)
+
+	// The net/http package sets the write deadline from the
+	// http.Server.WriteTimeout during the TLS handshake, but then
+	// passes the connection off to us with the deadline already set.
+	// Write deadlines are set per stream in serverConn.newStream.
+	// Disarm the net.Conn write deadline here.
+	if sc.hs.WriteTimeout != 0 {
+		sc.conn.SetWriteDeadline(time.Time{})
+	}
+
+	//if s.NewWriteScheduler != nil {
+	//	sc.writeSched = s.NewWriteScheduler()
+	//} else {
+	//
+	//}
+	sc.writeSched = NewRandomWriteScheduler()
+
+	// These start at the RFC-specified defaults. If there is a higher
+	// configured value for inflow, that will be updated when we send a
+	// WINDOW_UPDATE shortly after sending SETTINGS.
+	sc.flow.add(initialWindowSize)
+	sc.inflow.add(initialWindowSize)
+	sc.hpackEncoder = hpack.NewEncoder(&sc.headerWriteBuf)
+
+	fr := NewMFramer(conn)
+	fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+	fr.MaxHeaderListSize = sc.maxHeaderListSize()
+	fr.SetMaxReadFrameSize(defaultMaxReadFrameSize)
+	sc.framer = fr
+
+	//if tc, ok := c.(connectionStater); ok {
+	//	sc.tlsState = new(tls.ConnectionState)
+	//	*sc.tlsState = tc.ConnectionState()
+	//	// 9.2 Use of TLS Features
+	//	// An implementation of HTTP/2 over TLS MUST use TLS
+	//	// 1.2 or higher with the restrictions on feature set
+	//	// and cipher suite described in this section. Due to
+	//	// implementation limitations, it might not be
+	//	// possible to fail TLS negotiation. An endpoint MUST
+	//	// immediately terminate an HTTP/2 connection that
+	//	// does not meet the TLS requirements described in
+	//	// this section with a connection error (Section
+	//	// 5.4.1) of type INADEQUATE_SECURITY.
+	//	if sc.tlsState.Version < tls.VersionTLS12 {
+	//		sc.rejectConn(ErrCodeInadequateSecurity, "TLS version too low")
+	//		return
+	//	}
+	//
+	//	if sc.tlsState.ServerName == "" {
+	//		// Client must use SNI, but we don't enforce that anymore,
+	//		// since it was causing problems when connecting to bare IP
+	//		// addresses during development.
+	//		//
+	//		// TODO: optionally enforce? Or enforce at the time we receive
+	//		// a new request, and verify the ServerName matches the :authority?
+	//		// But that precludes proxy situations, perhaps.
+	//		//
+	//		// So for now, do nothing here again.
+	//	}
+	//
+	//	if !s.PermitProhibitedCipherSuites && isBadCipher(sc.tlsState.CipherSuite) {
+	//		// "Endpoints MAY choose to generate a connection error
+	//		// (Section 5.4.1) of type INADEQUATE_SECURITY if one of
+	//		// the prohibited cipher suites are negotiated."
+	//		//
+	//		// We choose that. In my opinion, the spec is weak
+	//		// here. It also says both parties must support at least
+	//		// TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 so there's no
+	//		// excuses here. If we really must, we could allow an
+	//		// "AllowInsecureWeakCiphers" option on the server later.
+	//		// Let's see how it plays out first.
+	//		sc.rejectConn(ErrCodeInadequateSecurity, fmt.Sprintf("Prohibited TLS 1.2 Cipher Suite: %x", sc.tlsState.CipherSuite))
+	//		return
+	//	}
+	//}
+
+	if hook := testHookGetServerConn; hook != nil {
+		hook(sc.serverConn)
+	}
+	go sc.serve()
+	return sc
+}
+
+func (sc *XServerConn) serve() {
+	sc.serveG = newGoroutineLock()
+	defer sc.notePanic()
+	defer sc.conn.Close()
+	defer sc.closeAllStreamsOnConnClose()
+	defer sc.stopShutdownTimer()
+	defer close(sc.doneServing) // unblocks handlers trying to send
+
+	if VerboseLogs {
+		sc.vlogf("http2: server connection from %v on %p", sc.conn.RemoteAddr(), sc.hs)
+	}
+
+	sc.writeFrame(FrameWriteRequest{
+		write: writeSettings{
+			{SettingMaxFrameSize, sc.srv.maxReadFrameSize()},
+			{SettingMaxConcurrentStreams, sc.advMaxStreams},
+			{SettingMaxHeaderListSize, sc.maxHeaderListSize()},
+			{SettingInitialWindowSize, uint32(sc.srv.initialStreamRecvWindowSize())},
+		},
+	})
+	sc.unackedSettings++
+
+	// Each connection starts with intialWindowSize inflow tokens.
+	// If a higher value is configured, we add more tokens.
+	if diff := sc.srv.initialConnRecvWindowSize() - initialWindowSize; diff > 0 {
+		sc.sendWindowUpdate(nil, int(diff))
+	}
+
+	if sc.srv.IdleTimeout != 0 {
+		sc.idleTimer = time.AfterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
+		defer sc.idleTimer.Stop()
+	}
+
+	settingsTimer := time.AfterFunc(firstSettingsTimeout, sc.onSettingsTimer)
+	defer settingsTimer.Stop()
+
+	loopNum := 0
+	for {
+		loopNum++
+		select {
+		case wr := <-sc.wantWriteFrameCh:
+			if se, ok := wr.write.(StreamError); ok {
+				sc.resetStream(se)
+				break
+			}
+			sc.writeFrame(wr)
+		case res := <-sc.wroteFrameCh:
+			sc.wroteFrame(res)
+		case res := <-sc.readFrameCh:
+			if !sc.processFrameFromReader(res) {
+				return
+			}
+			res.readMore()
+			if settingsTimer != nil {
+				settingsTimer.Stop()
+				settingsTimer = nil
+			}
+		case m := <-sc.bodyReadCh:
+			sc.noteBodyRead(m.st, m.n)
+		case msg := <-sc.serveMsgCh:
+			switch v := msg.(type) {
+			case func(int):
+				v(loopNum) // for testing
+			case *serverMessage:
+				switch v {
+				case settingsTimerMsg:
+					sc.logf("timeout waiting for SETTINGS frames from %v", sc.conn.RemoteAddr())
+					return
+				case idleTimerMsg:
+					sc.vlogf("connection is idle")
+					sc.goAway(ErrCodeNo)
+				case shutdownTimerMsg:
+					sc.vlogf("GOAWAY close timer fired; closing conn from %v", sc.conn.RemoteAddr())
+					return
+				case gracefulShutdownMsg:
+					sc.startGracefulShutdownInternal()
+				default:
+					panic("unknown timer")
+				}
+			case *startPushRequest:
+				sc.startPush(v)
+			default:
+				panic(fmt.Sprintf("unexpected type %T", v))
+			}
+		}
+
+		// Start the shutdown timer after sending a GOAWAY. When sending GOAWAY
+		// with no error code (graceful shutdown), don't start the timer until
+		// all open streams have been completed.
+		sentGoAway := sc.inGoAway && !sc.needToSendGoAway && !sc.writingFrame
+		gracefulShutdownComplete := sc.goAwayCode == ErrCodeNo && sc.curOpenStreams() == 0
+		if sentGoAway && sc.shutdownTimer == nil && (sc.goAwayCode != ErrCodeNo || gracefulShutdownComplete) {
+			sc.shutDownIn(goAwayTimeout)
+		}
+	}
+}
+
+// readPreface reads the ClientPreface greeting from the peer or
+// returns errPrefaceTimeout on timeout, or an error if the greeting
+// is invalid.
+func (sc *XServerConn) readPreface(data types.IoBuffer) error {
+	if data.Len() < len(clientPreface) {
+		return ErrAGAIN
+	}
+	if bytes.Equal(data.Bytes()[0:len(clientPreface)], clientPreface) {
+		data.Drain(len(clientPreface))
+		return nil
+	} else {
+		return fmt.Errorf("bogus greeting %q", data.Bytes()[0:len(clientPreface)])
+	}
+}
+
+func (sc *XServerConn) Decode(data types.IoBuffer, off int) error {
+	if !sc.preface {
+		if err := sc.readPreface(data); err != nil {
+			sc.condlogf(err, "http2: server: error reading preface from client %v: %v", sc.conn.RemoteAddr(), err)
+			return err
+		}
+		sc.preface = true
+		// Now that we've got the preface, get us out of the
+		// "StateNew" state. We can't go directly to idle, though.
+		// Active means we read some data and anticipate a request. We'll
+		// do another Active when we get a HEADERS frame.
+		sc.setConnState(http.StateActive)
+		sc.setConnState(http.StateIdle)
+	}
+	//f, _, err := sc.framer.(*XFramer).DecodeFrame(data, off)
+	//if err == ErrAGAIN {
+	//	return err
+	//}
+	//select {
+	//case sc.readFrameCh <- readFrameResult{f, err, nil}:
+	//case <-sc.doneServing:
+	//	return errClientDisconnected
+	//}
+	gate := make(gate)
+	gateDone := gate.Done
+	f, _, err := sc.framer.(*XFramer).DecodeFrame(data, off)
+	if err == ErrAGAIN {
+		return err
+	}
+	select {
+	case sc.readFrameCh <- readFrameResult{f, err, gateDone}:
+	case <-sc.doneServing:
+		return errClientDisconnected
+	}
+	select {
+	case <-gate:
+	case <-sc.doneServing:
+		return errClientDisconnected
+	}
+	return err
+}
+
+// processFrameFromReader processes the serve loop's read from readFrameCh from the
+// frame-reading goroutine.
+// processFrameFromReader returns whether the connection should be kept open.
+func (sc *XServerConn) processFrameFromReader(res readFrameResult) bool {
+	sc.serveG.check()
+	err := res.err
+	if err != nil {
+		if err == ErrFrameTooLarge {
+			sc.goAway(ErrCodeFrameSize)
+			return true // goAway will close the loop
+		}
+		clientGone := err == io.EOF || err == io.ErrUnexpectedEOF || isClosedConnError(err)
+		if clientGone {
+			// TODO: could we also get into this state if
+			// the peer does a half close
+			// (e.g. CloseWrite) because they're done
+			// sending frames but they're still wanting
+			// our open replies?  Investigate.
+			// TODO: add CloseWrite to crypto/tls.Conn first
+			// so we have a way to test this? I suppose
+			// just for testing we could have a non-TLS mode.
+			return false
+		}
+	} else {
+		f := res.f
+		if VerboseLogs {
+			sc.vlogf("http2: server read frame %v", summarizeFrame(f))
+		}
+		err = sc.processFrame(f)
+		if err == nil {
+			return true
+		}
+	}
+
+	switch ev := err.(type) {
+	case StreamError:
+		sc.resetStream(ev)
+		return true
+	case goAwayFlowError:
+		sc.goAway(ErrCodeFlowControl)
+		return true
+	case ConnectionError:
+		sc.logf("http2: server connection error from %v: %v", sc.conn.RemoteAddr(), ev)
+		sc.goAway(ErrCode(ev))
+		return true // goAway will handle shutdown
+	default:
+		if res.err != nil {
+			sc.vlogf("http2: server closing client connection; error reading frame from client %s: %v", sc.conn.RemoteAddr(), err)
+		} else {
+			sc.logf("http2: server closing client connection: %v", err)
+		}
+		return false
+	}
+}
+
+func (sc *XServerConn) processFrame(f Frame) error {
+	sc.serveG.check()
+
+	var err error
+	var ms *XStream
+	var endStream, trailer bool
+	var data []byte
+
+	// First frame received must be SETTINGS.
+	if !sc.sawFirstSettings {
+		if _, ok := f.(*SettingsFrame); !ok {
+			return ConnectionError(ErrCodeProtocol)
+		}
+		sc.sawFirstSettings = true
+	}
+
+	switch f := f.(type) {
+	case *SettingsFrame:
+		err = sc.processSettings(f)
+	case *MetaHeadersFrame:
+		ms, trailer, endStream, err = sc.processHeaders(f)
+	case *WindowUpdateFrame:
+		err = sc.processWindowUpdate(f)
+	case *PingFrame:
+		err = sc.processPing(f)
+	case *DataFrame:
+		data = f.Data()
+		endStream, err = sc.processData(f)
+	case *RSTStreamFrame:
+		err = sc.processResetStream(f)
+	case *PriorityFrame:
+		err = sc.processPriority(f)
+	case *GoAwayFrame:
+		err = sc.processGoAway(f)
+	case *PushPromiseFrame:
+		// A client cannot push. Thus, servers MUST treat the receipt of a PUSH_PROMISE
+		// frame as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+		err = ConnectionError(ErrCodeProtocol)
+	default:
+		sc.vlogf("http2: server ignoring frame: %v", f.Header())
+		return nil
+	}
+
+	sc.mHandler.HandleFrame(f, ms, data, trailer, endStream, err)
+	return err
+}
+
+func (sc *XServerConn) HandleError(f Frame, err error) {
+	if log.DefaultLogger.GetLogLevel() >= log.WARN {
+		log.DefaultLogger.Warnf("[Server Conn] [Handler Err] handler frame：%v error：%v", f, err)
+	}
+}
+
+func (sc *XServerConn) processHeaders(f *MetaHeadersFrame) (*XStream, bool, bool, error) {
+	sc.serveG.check()
+	id := f.StreamID
+	if sc.inGoAway {
+		// Ignore.
+		return nil, false, false, nil
+	}
+	// http://tools.ietf.org/html/rfc7540#section-5.1.1
+	// Streams initiated by a client MUST use odd-numbered stream
+	// identifiers. [...] An endpoint that receives an unexpected
+	// stream identifier MUST respond with a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	if id%2 != 1 {
+		return nil, false, false, ConnectionError(ErrCodeProtocol)
+	}
+	// A HEADERS frame can be used to create a new stream or
+	// send a trailer for an open one. If we already have a stream
+	// open, let it process its own HEADERS frame (trailers at this
+	// point, if it's valid).
+	if st := sc.streams[f.StreamID]; st != nil {
+		if st.resetQueued {
+			// We're sending RST_STREAM to close the stream, so don't bother
+			// processing this frame.
+			return nil, false, false, nil
+		}
+		// RFC 7540, sec 5.1: If an endpoint receives additional frames, other than
+		// WINDOW_UPDATE, PRIORITY, or RST_STREAM, for a stream that is in
+		// this state, it MUST respond with a stream error (Section 5.4.2) of
+		// type STREAM_CLOSED.
+		if st.state == stateHalfClosedRemote {
+			return nil, false, false, streamError(id, ErrCodeStreamClosed)
+		}
+		return nil, true, true, st.processTrailerHeaders(f)
+	}
+
+	// [...] The identifier of a newly established stream MUST be
+	// numerically greater than all streams that the initiating
+	// endpoint has opened or reserved. [...]  An endpoint that
+	// receives an unexpected stream identifier MUST respond with
+	// a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	if id <= sc.maxClientStreamID {
+		return nil, false, false, ConnectionError(ErrCodeProtocol)
+	}
+	sc.maxClientStreamID = id
+
+	if sc.idleTimer != nil {
+		sc.idleTimer.Stop()
+	}
+
+	// http://tools.ietf.org/html/rfc7540#section-5.1.2
+	// [...] Endpoints MUST NOT exceed the limit set by their peer. An
+	// endpoint that receives a HEADERS frame that causes their
+	// advertised concurrent stream limit to be exceeded MUST treat
+	// this as a stream error (Section 5.4.2) of type PROTOCOL_ERROR
+	// or REFUSED_STREAM.
+	if sc.curClientStreams+1 > sc.advMaxStreams {
+		if sc.unackedSettings == 0 {
+			// They should know better.
+			return nil, false, false, streamError(id, ErrCodeProtocol)
+		}
+		// Assume it's a network race, where they just haven't
+		// received our last SETTINGS update. But actually
+		// this can't happen yet, because we don't yet provide
+		// a way for users to adjust server parameters at
+		// runtime.
+		return nil, false, false, streamError(id, ErrCodeRefusedStream)
+	}
+
+	initialState := stateOpen
+	if f.StreamEnded() {
+		initialState = stateHalfClosedRemote
+	}
+	st := sc.newStream(id, 0, initialState)
+
+	if f.HasPriority() {
+		if err := checkPriority(f.StreamID, f.Priority); err != nil {
+			return nil, false, false, err
+		}
+		sc.writeSched.AdjustStream(st.id, f.Priority)
+	}
+
+	rw, req, err := sc.newWriterAndRequest(st, f)
+	if err != nil {
+		return nil, false, false, err
+	}
+	st.reqTrailer = req.Trailer
+	if st.reqTrailer != nil {
+		st.trailer = make(http.Header)
+	}
+	st.declBodyBytes = req.ContentLength
+
+	// The net/http package sets the read deadline from the
+	// http.Server.ReadTimeout during the TLS handshake, but then
+	// passes the connection off to us with the deadline already
+	// set. Disarm it here after the request headers are read,
+	// similar to how the http1 server works. Here it's
+	// technically more like the http1 Server's ReadHeaderTimeout
+	// (in Go 1.8), though. That's a more sane option anyway.
+	if sc.hs.ReadTimeout != 0 {
+		sc.conn.SetReadDeadline(time.Time{})
+	}
+
+	responseWriterStatePool.Put(rw.rws)
+
+	return &XStream{stream: st, Request: req, conn: sc}, false, f.StreamEnded(), nil
+}
+
+func (sc *XServerConn) processData(f *DataFrame) (bool, error) {
+	sc.serveG.check()
+	if sc.inGoAway && sc.goAwayCode != ErrCodeNo {
+		return false, nil
+	}
+	data := f.Data()
+
+	// "If a DATA frame is received whose stream is not in "open"
+	// or "half closed (local)" state, the recipient MUST respond
+	// with a stream error (Section 5.4.2) of type STREAM_CLOSED."
+	id := f.Header().StreamID
+	state, st := sc.state(id)
+	if id == 0 || state == stateIdle {
+		// Section 5.1: "Receiving any frame other than HEADERS
+		// or PRIORITY on a stream in this state MUST be
+		// treated as a connection error (Section 5.4.1) of
+		// type PROTOCOL_ERROR."
+		return false, ConnectionError(ErrCodeProtocol)
+	}
+	if st == nil || state != stateOpen || st.gotTrailerHeader || st.resetQueued {
+		// This includes sending a RST_STREAM if the stream is
+		// in stateHalfClosedLocal (which currently means that
+		// the http.Handler returned, so it's done reading &
+		// done writing). Try to stop the client from sending
+		// more DATA.
+
+		// But still enforce their connection-level flow control,
+		// and return any flow control bytes since we're not going
+		// to consume them.
+		if sc.inflow.available() < int32(f.Length) {
+			return false, streamError(id, ErrCodeFlowControl)
+		}
+		// Deduct the flow control from inflow, since we're
+		// going to immediately add it back in
+		// sendWindowUpdate, which also schedules sending the
+		// frames.
+		sc.inflow.take(int32(f.Length))
+		sc.sendWindowUpdate(nil, int(f.Length)) // conn-level
+
+		if st != nil && st.resetQueued {
+			// Already have a stream error in flight. Don't send another.
+			return false, nil
+		}
+		return false, streamError(id, ErrCodeStreamClosed)
+	}
+
+	// Sender sending more than they'd declared?
+	if st.declBodyBytes != -1 && st.bodyBytes+int64(len(data)) > st.declBodyBytes {
+		// RFC 7540, sec 8.1.2.6: A request or response is also malformed if the
+		// value of a content-length header field does not equal the sum of the
+		// DATA frame payload lengths that form the body.
+		return false, streamError(id, ErrCodeProtocol)
+	}
+	if f.Length > 0 {
+		// Check whether the client has flow control quota.
+		if st.inflow.available() < int32(f.Length) {
+			return false, streamError(id, ErrCodeFlowControl)
+		}
+		st.inflow.take(int32(f.Length))
+
+		// Return any padded flow control now, since we won't
+		// refund it later on body reads.
+		if pad := int32(f.Length) - int32(len(data)); pad > 0 {
+			sc.sendWindowUpdate32(nil, pad)
+			sc.sendWindowUpdate32(st, pad)
+		}
+
+		// Check the conn-level first, before the stream-level.
+		if sc.inflow.available() < initialConnRecvWindowSize/2 {
+			i := int(initialConnRecvWindowSize - sc.inflow.available())
+			sc.sendWindowUpdate(nil, i)
+		}
+
+		if st.inflow.available() < initialConnRecvWindowSize/2 {
+			i := int(initialConnRecvWindowSize - st.inflow.available())
+			sc.sendWindowUpdate(st, i)
+		}
+
+		st.bodyBytes += int64(len(data))
+	}
+	if f.StreamEnded() {
+		st.state = stateHalfClosedRemote
+	}
+	return f.StreamEnded(), nil
+}

--- a/pkg/protocol/http2/codec.go
+++ b/pkg/protocol/http2/codec.go
@@ -59,6 +59,26 @@ func (c *serverCodec) Decode(ctx context.Context, data types.IoBuffer) (interfac
 	return frame, err
 }
 
+type xServerCodec struct {
+	sc      *http2.XServerConn
+	preface bool
+	init    bool
+}
+
+func (c *xServerCodec) Name() types.ProtocolName {
+	return protocol.HTTP2
+}
+
+func (c *xServerCodec) Encode(ctx context.Context, model interface{}) (types.IoBuffer, error) {
+	ms := model.(*http2.XStream)
+	err := ms.SendResponse()
+	return nil, err
+}
+
+func (c *xServerCodec) Decode(ctx context.Context, data types.IoBuffer) (interface{}, error) {
+	return nil, c.sc.Decode(data, 0)
+}
+
 type clientCodec struct {
 	cc *http2.MClientConn
 }

--- a/pkg/protocol/http2/factory.go
+++ b/pkg/protocol/http2/factory.go
@@ -27,6 +27,10 @@ func ServerProto(sc *http2.MServerConn) api.Protocol {
 	return &serverCodec{sc: sc}
 }
 
+func XServerProto(sc *http2.XServerConn) api.Protocol {
+	return &xServerCodec{sc: sc}
+}
+
 func ClientProto(cc *http2.MClientConn) api.Protocol {
 	return &clientCodec{cc: cc}
 }

--- a/pkg/stream/http2/stream.go
+++ b/pkg/stream/http2/stream.go
@@ -59,7 +59,17 @@ func (f *streamConnFactory) CreateClientStream(context context.Context, connecti
 
 func (f *streamConnFactory) CreateServerStream(context context.Context, connection api.Connection,
 	serverCallbacks types.ServerStreamConnectionEventListener) types.ServerStreamConnection {
+	var config StreamConfig
+	if pgc := mosnctx.Get(context, types.ContextKeyProxyGeneralConfig); pgc != nil {
+		if extendConfig, ok := pgc.(StreamConfig); ok {
+			config = extendConfig
+		}
+	}
+	if config.Http2UseStandardLib {
+		return newXServerStreamConnection(context, connection, serverCallbacks)
+	}
 	return newServerStreamConnection(context, connection, serverCallbacks)
+
 }
 
 func (f *streamConnFactory) CreateBiDirectStream(context context.Context, connection types.ClientConnection,
@@ -148,11 +158,13 @@ func (s *stream) GetStream() types.Stream {
 }
 
 type StreamConfig struct {
-	Http2UseStream bool `json:"http2_use_stream,omitempty"`
+	Http2UseStream      bool `json:"http2_use_stream,omitempty"`
+	Http2UseStandardLib bool `json:"http_2_use_standard_lib,omitempty"`
 }
 
 var defaultStreamConfig = StreamConfig{
-	Http2UseStream: false,
+	Http2UseStream:      false,
+	Http2UseStandardLib: false,
 }
 
 func streamConfigHandler(v interface{}) interface{} {

--- a/pkg/stream/http2/xstream.go
+++ b/pkg/stream/http2/xstream.go
@@ -1,0 +1,466 @@
+package http2
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"mosn.io/api"
+	mosnctx "mosn.io/mosn/pkg/context"
+	"mosn.io/mosn/pkg/log"
+	"mosn.io/mosn/pkg/module/http2"
+	"mosn.io/mosn/pkg/mtls"
+	"mosn.io/mosn/pkg/protocol"
+	mhttp2 "mosn.io/mosn/pkg/protocol/http2"
+	str "mosn.io/mosn/pkg/stream"
+	"mosn.io/mosn/pkg/trace"
+	"mosn.io/mosn/pkg/types"
+	"mosn.io/mosn/pkg/variable"
+	"mosn.io/pkg/buffer"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// types.DecodeFilter
+// types.StreamConnection
+// types.ClientStreamConnection
+// types.ServerStreamConnection
+type xStreamConnection struct {
+	ctx  context.Context
+	conn api.Connection
+	cm   *str.ContextManager
+
+	bufChan    chan buffer.IoBuffer
+	endRead    chan struct{}
+	connClosed chan bool
+
+	br *bufio.Reader
+
+	useStream bool
+
+	protocol api.Protocol
+}
+
+func (conn *xStreamConnection) Protocol() types.ProtocolName {
+	return protocol.HTTP2
+}
+
+func (conn *xStreamConnection) EnableWorkerPool() bool {
+	return true
+}
+
+func (conn *xStreamConnection) GoAway() {
+	// todo
+}
+
+type xServerStreamConnection struct {
+	xStreamConnection
+	mutex   sync.RWMutex
+	streams map[uint32]*xServerStream
+	sc      *http2.XServerConn
+	config  StreamConfig
+
+	serverCallbacks types.ServerStreamConnectionEventListener
+}
+
+func newXServerStreamConnection(ctx context.Context, connection api.Connection, serverCallbacks types.ServerStreamConnectionEventListener) types.ServerStreamConnection {
+
+	sc := &xServerStreamConnection{
+		xStreamConnection: xStreamConnection{
+			ctx:        ctx,
+			conn:       connection,
+			bufChan:    make(chan buffer.IoBuffer),
+			endRead:    make(chan struct{}),
+			connClosed: make(chan bool, 1),
+
+			cm: str.NewContextManager(ctx),
+		},
+		config: parseStreamConfig(ctx),
+
+		serverCallbacks: serverCallbacks,
+	}
+	h2sc := http2.NewXServerConn(connection, sc, nil)
+	sc.sc = h2sc
+	sc.protocol = mhttp2.XServerProto(h2sc)
+
+	if pgc := mosnctx.Get(ctx, types.ContextKeyProxyGeneralConfig); pgc != nil {
+		if extendConfig, ok := pgc.(StreamConfig); ok {
+			sc.useStream = extendConfig.Http2UseStream
+		}
+	}
+
+	// init first context
+	sc.cm.Next()
+
+	// set not support transfer connection
+	sc.conn.SetTransferEventListener(func() bool {
+		return false
+	})
+
+	sc.streams = make(map[uint32]*xServerStream, 32)
+
+	connection.AddConnectionEventListener(sc)
+	if log.Proxy.GetLogLevel() >= log.DEBUG {
+		log.Proxy.Debugf(ctx, "new http2 server stream connection, stream config: %v", sc.config)
+	}
+
+	return sc
+}
+
+func (conn *xServerStreamConnection) OnEvent(event api.ConnectionEvent) {
+	conn.mutex.Lock()
+	defer conn.mutex.Unlock()
+	if event.IsClose() || event.ConnectFailure() {
+		for _, stream := range conn.streams {
+			stream.ResetStream(types.StreamRemoteReset)
+		}
+	}
+}
+
+// types.StreamConnectionM
+func (conn *xServerStreamConnection) Dispatch(buf types.IoBuffer) {
+	for {
+		_, err := conn.protocol.Decode(nil, buf)
+		if err != nil {
+			break
+		}
+	}
+}
+
+func (conn *xServerStreamConnection) ActiveStreamsNum() int {
+	conn.mutex.RLock()
+	defer conn.mutex.Unlock()
+
+	return len(conn.streams)
+}
+
+func (conn *xServerStreamConnection) CheckReasonError(connected bool, event api.ConnectionEvent) (types.StreamResetReason, bool) {
+	reason := types.StreamConnectionSuccessed
+	if event.IsClose() || event.ConnectFailure() {
+		reason = types.StreamConnectionFailed
+		if connected {
+			reason = types.StreamConnectionTermination
+		}
+		return reason, false
+
+	}
+
+	return reason, true
+}
+
+func (conn *xServerStreamConnection) Reset(reason types.StreamResetReason) {
+	conn.mutex.RLock()
+	defer conn.mutex.Unlock()
+
+	for _, stream := range conn.streams {
+		stream.ResetStream(reason)
+	}
+}
+
+// decode失败错误怎么处理？
+func (conn *xServerStreamConnection) HandleFrame(f http2.Frame, h2s *http2.XStream, data []byte, hasTrailer, endStream bool, err error) {
+	ctx := conn.cm.Get()
+	defer conn.cm.Next()
+
+	if h2s == nil && data == nil && !hasTrailer && !endStream {
+		return
+	}
+
+	id := f.Header().StreamID
+
+	var stream *xServerStream
+	// header
+	if h2s != nil {
+		stream, err = conn.onNewStreamDetect(mosnctx.Clone(ctx), h2s, endStream)
+		if err != nil {
+			conn.handleError(ctx, f, err)
+			return
+		}
+		header := mhttp2.NewReqHeader(h2s.Request)
+
+		scheme := "http"
+		if _, ok := conn.conn.RawConn().(*mtls.TLSConn); ok {
+			scheme = "https"
+		}
+
+		h2s.Request.URL.Scheme = strings.ToLower(scheme)
+
+		variable.SetString(ctx, types.VarScheme, scheme)
+		variable.SetString(ctx, types.VarMethod, h2s.Request.Method)
+		variable.SetString(ctx, types.VarHost, h2s.Request.Host)
+		variable.SetString(ctx, types.VarIstioHeaderHost, h2s.Request.Host) // be consistent with http1
+		variable.SetString(ctx, types.VarPath, h2s.Request.URL.Path)
+		variable.SetString(ctx, types.VarPathOriginal, h2s.Request.URL.EscapedPath())
+
+		if h2s.Request.URL.RawQuery != "" {
+			variable.SetString(ctx, types.VarQueryString, h2s.Request.URL.RawQuery)
+		}
+
+		if log.Proxy.GetLogLevel() >= log.DEBUG {
+			log.Proxy.Debugf(stream.ctx, "http2 server header: %d, %+v", id, h2s.Request.Header)
+		}
+
+		if endStream {
+			stream.receiver.OnReceive(stream.ctx, header, nil, nil)
+			return
+		}
+		stream.header = header
+		stream.trailer = &mhttp2.HeaderMap{}
+	}
+
+	if stream == nil {
+		stream = conn.onStreamRecv(ctx, id, endStream)
+		if stream == nil {
+			log.Proxy.Errorf(ctx, "http2 server OnStreamRecv error, invaild id = %d", id)
+			return
+		}
+	}
+
+	// data
+	if data != nil {
+		if log.Proxy.GetLogLevel() >= log.DEBUG {
+			log.Proxy.Debugf(ctx, "http2 server receive data: %d", id)
+		}
+
+		if stream.recData == nil {
+			if endStream || !conn.useStream {
+				stream.recData = buffer.GetIoBuffer(len(data))
+			} else {
+				stream.recData = buffer.NewPipeBuffer(len(data))
+				stream.reqUseStream = true
+				variable.Set(stream.ctx, types.VarHttp2RequestUseStream, stream.reqUseStream)
+				stream.receiver.OnReceive(stream.ctx, stream.header, stream.recData, stream.trailer)
+			}
+		}
+
+		if _, err = stream.recData.Write(data); err != nil {
+			conn.handleError(ctx, f, http2.StreamError{
+				StreamID: id,
+				Code:     http2.ErrCodeCancel,
+				Cause:    err,
+			})
+			return
+		}
+	}
+
+	if hasTrailer {
+		stream.trailer.H = stream.h2s.Request.Trailer
+		if log.Proxy.GetLogLevel() >= log.DEBUG {
+			log.Proxy.Debugf(stream.ctx, "http2 server trailer: %d, %v", id, stream.h2s.Request.Trailer)
+		}
+	}
+
+	if endStream {
+		if stream.reqUseStream {
+			stream.recData.CloseWithError(io.EOF)
+		} else {
+			if stream.recData == nil {
+				stream.recData = buffer.GetIoBuffer(0)
+			}
+			stream.receiver.OnReceive(stream.ctx, stream.header, stream.recData, stream.trailer)
+		}
+		if log.Proxy.GetLogLevel() >= log.DEBUG {
+			log.Proxy.Debugf(stream.ctx, "http2 server stream end %d", id)
+		}
+	}
+
+}
+
+func (conn *xServerStreamConnection) handleError(ctx context.Context, f http2.Frame, err error) {
+	conn.sc.HandleError(f, err)
+	if err != nil {
+		switch err := err.(type) {
+		// todo: other error scenes
+		case http2.StreamError:
+			if err.Code == http2.ErrCodeNo {
+				return
+			}
+			log.Proxy.Errorf(ctx, "Http2 server handleError stream error: %v", err)
+			conn.mutex.Lock()
+			s := conn.streams[err.StreamID]
+			if s != nil {
+				delete(conn.streams, err.StreamID)
+			}
+			conn.mutex.Unlock()
+			if s != nil {
+				s.ResetStream(types.StreamLocalReset)
+			}
+		case http2.ConnectionError:
+			log.Proxy.Errorf(ctx, "Http2 server handleError conn err: %v", err)
+			conn.conn.Close(api.NoFlush, api.OnReadErrClose)
+		default:
+			log.Proxy.Errorf(ctx, "Http2 server handleError err: %v", err)
+			conn.conn.Close(api.NoFlush, api.RemoteClose)
+		}
+	}
+}
+
+func (conn *xServerStreamConnection) onNewStreamDetect(ctx context.Context, h2s *http2.XStream, endStream bool) (*xServerStream, error) {
+	stream := &xServerStream{}
+	stream.id = h2s.ID()
+	stream.ctx = mosnctx.WithValue(ctx, types.ContextKeyStreamID, stream.id)
+	stream.sc = conn
+	stream.h2s = h2s
+	stream.conn = conn.conn
+
+	conn.mutex.Lock()
+	conn.streams[stream.id] = stream
+	conn.mutex.Unlock()
+
+	var span api.Span
+	if trace.IsEnabled() {
+		// try build trace span
+		tracer := trace.Tracer(protocol.HTTP2)
+
+		if tracer != nil {
+			span = tracer.Start(ctx, h2s.Request, time.Now())
+		}
+	}
+
+	stream.receiver = conn.serverCallbacks.NewStreamDetect(stream.ctx, stream, span)
+	return stream, nil
+}
+
+func (conn *xServerStreamConnection) onStreamRecv(ctx context.Context, id uint32, endStream bool) *xServerStream {
+	conn.mutex.Lock()
+	defer conn.mutex.Unlock()
+	if stream, ok := conn.streams[id]; ok {
+		if log.Proxy.GetLogLevel() >= log.DEBUG {
+			log.Proxy.Debugf(stream.ctx, "http2 server OnStreamRecv, id = %d", stream.id)
+		}
+		return stream
+	}
+	return nil
+}
+
+type xServerStream struct {
+	stream
+	h2s           *http2.XStream
+	sc            *xServerStreamConnection
+	reqUseStream  bool
+	respUseStream bool
+}
+
+// types.StreamSender
+func (s *xServerStream) AppendHeaders(ctx context.Context, headers api.HeaderMap, endStream bool) error {
+	if useStream, err := variable.Get(ctx, types.VarHttp2ResponseUseStream); err == nil {
+		if h2UseStream, ok := useStream.(bool); ok {
+			s.respUseStream = h2UseStream
+		}
+	}
+	var rsp *http.Response
+
+	var status int
+
+	value, err := variable.GetString(ctx, types.VarHeaderStatus)
+	if err != nil || value == "" {
+		status = 200
+	} else {
+		status, _ = strconv.Atoi(value)
+	}
+
+	switch header := headers.(type) {
+	case *mhttp2.RspHeader:
+		rsp = header.Rsp
+	case *mhttp2.ReqHeader:
+		// indicates the invocation is under hijack scene
+		rsp = new(http.Response)
+		rsp.StatusCode = status
+		rsp.Header = s.h2s.Request.Header
+	default:
+		rsp = new(http.Response)
+		rsp.StatusCode = status
+		rsp.Header = mhttp2.EncodeHeader(headers)
+	}
+
+	s.h2s.Response = rsp
+	s.h2s.UseStream = s.respUseStream
+
+	if log.Proxy.GetLogLevel() >= log.DEBUG {
+		log.Proxy.Debugf(s.ctx, "http2 server ApppendHeaders id = %d, headers = %+v", s.id, rsp.Header)
+	}
+
+	if endStream {
+		s.endStream()
+	}
+
+	return nil
+}
+
+func (s *xServerStream) AppendData(context context.Context, data buffer.IoBuffer, endStream bool) error {
+	s.h2s.SendData = data
+	if log.Proxy.GetLogLevel() >= log.DEBUG {
+		log.Proxy.Debugf(s.ctx, "http2 server ApppendData id = %d", s.id)
+	}
+
+	if endStream {
+		s.endStream()
+	}
+
+	return nil
+}
+
+func (s *xServerStream) AppendTrailers(context context.Context, trailers api.HeaderMap) error {
+	if trailers != nil {
+		switch trailer := trailers.(type) {
+		case *mhttp2.HeaderMap:
+			s.h2s.Trailer = &trailer.H
+		default:
+			header := mhttp2.EncodeHeader(trailer)
+			s.h2s.Trailer = &header
+		}
+		if log.Proxy.GetLogLevel() >= log.DEBUG {
+			log.Proxy.Debugf(s.ctx, "http2 server ApppendTrailers id = %d, trailer = %+v", s.id, s.h2s.Trailer)
+		}
+	}
+	s.endStream()
+
+	return nil
+}
+
+func (s *xServerStream) ResetStream(reason types.StreamResetReason) {
+	// on stream reset
+	if log.Proxy.GetLogLevel() >= log.WARN {
+		log.Proxy.Warnf(s.ctx, "http2 server reset stream id = %d, error = %v", s.id, reason)
+	}
+	if s.reqUseStream && s.recData != nil {
+		s.recData.CloseWithError(io.EOF)
+	}
+
+	s.stream.ResetStream(reason)
+}
+
+func (s *xServerStream) GetStream() types.Stream {
+	return s
+}
+
+func (s *xServerStream) endStream() {
+	if s.h2s.SendData != nil {
+		// Need to reset the 'Content-Length' response header when it's a direct response.
+		isDirectResponse, _ := variable.GetString(s.ctx, types.VarProxyIsDirectResponse)
+		if isDirectResponse == types.IsDirectResponse {
+			s.h2s.Response.Header.Set("Content-Length", strconv.Itoa(s.h2s.SendData.Len()))
+		}
+	}
+
+	_, err := s.sc.protocol.Encode(s.ctx, s.h2s)
+
+	s.sc.mutex.Lock()
+	delete(s.sc.streams, s.id)
+	s.sc.mutex.Unlock()
+
+	if err != nil {
+		log.Proxy.Errorf(s.ctx, "http2 server SendResponse error :%v", err)
+		s.ResetStream(types.StreamLocalReset)
+		return
+	}
+	if s.reqUseStream && s.recData != nil {
+		s.recData.CloseWithError(io.EOF)
+	}
+
+	if log.Proxy.GetLogLevel() >= log.DEBUG {
+		log.Proxy.Debugf(s.ctx, "http2 server SendResponse id = %d", s.id)
+	}
+}


### PR DESCRIPTION
为解决独立实现的H2库稳定性不可控，容易与标准库脱钩导致后续维护困难的问题，调整H2库的底层实现，复用标准库的主体代码。
但实现上，为了使mosn的io层和内存复用在性能上发挥作用，在代码零侵入的条件上做了妥协。也就是没有和H1代理一样使用pipe封装connection，而是重写了framer和read frame goroutine。
TODO: 
1. 性能优化；
2. h2 client支持；
3. 单元测试&集成测试；