### PR TITLE
fix: EDF wrr lb cannot choose a healthy host 

### DIFF
--- a/pkg/upstream/cluster/loadbalancer.go
+++ b/pkg/upstream/cluster/loadbalancer.go
@@ -297,19 +297,22 @@ func (lb *EdfLoadBalancer) ChooseHost(context types.LoadBalancerContext) types.H
 		}
 		return nil
 	}
-	for i := 0; i < total; i++ {
-		if lb.scheduler != nil {
+
+	if lb.scheduler != nil {
+		for i := 0; i < total; i++ {
 			// do weight selection
 			candicate = lb.scheduler.NextAndPush(lb.hostWeightFunc).(types.Host)
-		} else {
-			// do unweight selection
-			candicate = lb.unweightChooseHostFunc(context)
-		}
-		// only return when candicate is healthy
-		if candicate.Health() {
-			return candicate
+			if candicate != nil && candicate.Health() {
+				return candicate
+			}
 		}
 	}
+
+	candicate = lb.unweightChooseHostFunc(context)
+	if candicate.Health() {
+		return candicate
+	}
+
 	// refer https://github.com/mosn/mosn/pull/1713
 	// return nil when all instances are unhealthy
 	return nil

--- a/pkg/upstream/cluster/loadbalancer.go
+++ b/pkg/upstream/cluster/loadbalancer.go
@@ -308,14 +308,8 @@ func (lb *EdfLoadBalancer) ChooseHost(context types.LoadBalancerContext) types.H
 		}
 	}
 
-	candicate = lb.unweightChooseHostFunc(context)
-	if candicate.Health() {
-		return candicate
-	}
-
-	// refer https://github.com/mosn/mosn/pull/1713
-	// return nil when all instances are unhealthy
-	return nil
+	// Use unweighted roud-robin as a fallback while failed to pick a healthy host by weighted round-robin.
+	return lb.unweightChooseHostFunc(context)
 }
 
 func (lb *EdfLoadBalancer) IsExistsHosts(metadata api.MetadataMatchCriteria) bool {


### PR DESCRIPTION
Fix #1867 

### Solutions
如果在一次使用 edf 调度器调度时没有选中健康的 host，则使用 unweighted 的调度器重新调度。
