### PR TITLE
fix: cannot start a stopped listener properly

### DIFF
--- a/pkg/network/listener.go
+++ b/pkg/network/listener.go
@@ -291,11 +291,15 @@ func (l *listener) Close(lctx context.Context) error {
 	}
 
 	if l.rawl != nil {
-		l.cb.OnClose()
+		if l.cb != nil {
+			l.cb.OnClose()
+		}
 		return l.rawl.Close()
 	}
 	if l.packetConn != nil {
-		l.cb.OnClose()
+		if l.cb != nil {
+			l.cb.OnClose()
+		}
 		return l.packetConn.Close()
 	}
 	return nil
@@ -341,7 +345,9 @@ func (l *listener) accept(lctx context.Context) error {
 
 	// TODO: use thread pool
 	utils.GoWithRecover(func() {
-		l.cb.OnAccept(rawc, l.useOriginalDst, nil, nil, nil)
+		if l.cb != nil {
+			l.cb.OnAccept(rawc, l.useOriginalDst, nil, nil, nil)
+		}
 	}, nil)
 
 	return nil

--- a/pkg/network/listener.go
+++ b/pkg/network/listener.go
@@ -39,7 +39,8 @@ type ListenerState int
 // listener state
 // ListenerInited means listener is inited, a inited listener can be started or stopped
 // ListenerRunning means listener is running, start a running listener will be ignored.
-// ListenerStopped means listener is stopped, start a stopped listener without restart flag will be ignored.
+// ListenerStopped means listener is stopped.
+// ListenerClosed  means listener is closed, start a closed listener without restart flag will be ignored.
 const (
 	ListenerInited ListenerState = iota
 	ListenerRunning
@@ -125,9 +126,6 @@ func (l *listener) Start(lctx context.Context, restart bool) {
 				log.DefaultLogger.Debugf("[network] [listener start] %s is running", l.name)
 				return true
 			case ListenerStopped:
-				if !restart {
-					return true
-				}
 				if err := l.setDeadline(time.Time{}); err != nil {
 					log.DefaultLogger.Alertf("listener.start", "[network] [listener start] [listen] %s reset deadline failed, %v", l.name, err)
 				}
@@ -209,11 +207,16 @@ func (l *listener) readMsgEventLoop(lctx context.Context) {
 }
 
 func (l *listener) Stop() error {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	if l.state == ListenerClosed {
+		return nil
+	}
 	l.state = ListenerStopped
+
 	if !l.bindToPort {
 		return nil
 	}
-	l.cb.OnClose()
 	return l.setDeadline(time.Now())
 }
 


### PR DESCRIPTION
### Issues associated with this PR

#1882 

### Solutions
由于 Listener Stop 和 Close 的实现逻辑不同，Stop 是通过设置 SetDeadline，Close 是真正的关闭 Listener。因此，在处理 Start 时也应该分开处理。增加一个 ListenerClosed 来表示 Listener 是通过 Close 关闭的，原来的 ListenerStopped 用来表示 Listener 是通过 Stop 关闭的。

