### PR TITLE
chore: used the "/var/run/" path instead of "/dev/shm/" path for supervisor in docker image.

### DIFF
--- a/etc/supervisor/supervisord.conf
+++ b/etc/supervisor/supervisord.conf
@@ -9,14 +9,14 @@
 ;  - Comments must have a leading space: "a=b ;comment" not "a=b;comment".
 
 [unix_http_server]
-file=/dev/shm/supervisor.sock
+file=/var/run/supervisor.sock
 
 [supervisord]
-logfile=/tmp/supervisord.log ; (main log file;default $CWD/supervisord.log)
+logfile=/var/run/supervisord.log ; (main log file;default $CWD/supervisord.log)
 logfile_maxbytes=50MB        ; (max main logfile bytes b4 rotation;default 50MB)
 logfile_backups=10           ; (num of main logfile rotation backups;default 10)
 loglevel=info                ; (log level;default info; others: debug,warn,trace)
-pidfile=/tmp/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
 nodaemon=true                ; (start in foreground if true;default false)
 minfds=1024                  ; (min. avail startup file descriptors;default 1024)
 minprocs=200                 ; (min. avail process descriptors;default 200)
@@ -28,7 +28,7 @@ minprocs=200                 ; (min. avail process descriptors;default 200)
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///dev/shm/supervisor.sock
+serverurl=unix:///var/run/supervisor.sock
 
 [eventlistener:stdout]
 command = supervisor_stdout


### PR DESCRIPTION
### Issues associated with this PR

May cause conflict in different containers,
since /dev/shm is the shared volume between different containers in the single pod.

to make the basic image works in this case:
https://mosn.io/blog/posts/mosn-sidecarset-hotupgrade/