### PR TITLE
feature: add idletimeout into upstream cluster

### DIFF
--- a/istio/istio152/xds/conv/convertxds.go
+++ b/istio/istio152/xds/conv/convertxds.go
@@ -94,7 +94,7 @@ func ConvertListenerConfig(xdsListener *xdsapi.Listener, rh routeHandler) *v2.Li
 			Inspector:      true,
 			AccessLogs:     convertAccessLogs(xdsListener),
 		},
-		Addr: convertAddress(xdsListener.Address),
+		Addr:                    convertAddress(xdsListener.Address),
 		PerConnBufferLimitBytes: xdsListener.GetPerConnectionBufferLimitBytes().GetValue(),
 	}
 
@@ -172,6 +172,7 @@ func ConvertClustersConfig(xdsClusters []*xdsapi.Cluster) []*v2.Cluster {
 			HealthCheck:          convertHealthChecks(xdsCluster.GetHealthChecks()),
 			CirBreThresholds:     convertCircuitBreakers(xdsCluster.GetCircuitBreakers()),
 			ConnectTimeout:       &api.DurationConfig{Duration: convertTimeDurPoint2TimeDur(xdsCluster.GetConnectTimeout())},
+			IdleTimeout:          convertIdleTimeout(xdsCluster),
 			//OutlierDetection:     convertOutlierDetection(xdsCluster.GetOutlierDetection()),
 			Hosts:           convertClusterHosts(xdsCluster.GetHosts()),
 			Spec:            convertSpec(xdsCluster),
@@ -193,6 +194,19 @@ func ConvertClustersConfig(xdsClusters []*xdsapi.Cluster) []*v2.Cluster {
 	}
 
 	return clusters
+}
+
+func convertIdleTimeout(cluster *xdsapi.Cluster) *api.DurationConfig {
+	option := cluster.GetCommonHttpProtocolOptions()
+	if option == nil {
+		return nil
+	}
+	if option.IdleTimeout != nil {
+		return &api.DurationConfig{
+			Duration: option.IdleTimeout.AsDuration(),
+		}
+	}
+	return nil
 }
 
 func convertDnsLookupFamily(family xdsapi.Cluster_DnsLookupFamily) v2.DnsLookupFamily {

--- a/pkg/config/v2/upstream.go
+++ b/pkg/config/v2/upstream.go
@@ -99,6 +99,7 @@ type Cluster struct {
 	TLS                  TLSConfig           `json:"tls_context,omitempty"`
 	Hosts                []Host              `json:"hosts,omitempty"`
 	ConnectTimeout       *api.DurationConfig `json:"connect_timeout,omitempty"`
+	IdleTimeout          *api.DurationConfig `json:"idle_timeout,omitempty"`
 	LbConfig             IsCluster_LbConfig  `json:"lbconfig,omitempty"`
 	DnsRefreshRate       *api.DurationConfig `json:"dns_refresh_rate,omitempty"`
 	RespectDnsTTL        bool                `json:"respect_dns_ttl,omitempty"`

--- a/pkg/mock/upstream.go
+++ b/pkg/mock/upstream.go
@@ -16,44 +16,30 @@ import (
 	types "mosn.io/mosn/pkg/types"
 )
 
-// MockClusterManager is a mock of ClusterManager interface
+// MockClusterManager is a mock of ClusterManager interface.
 type MockClusterManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterManagerMockRecorder
 }
 
-// MockClusterManagerMockRecorder is the mock recorder for MockClusterManager
+// MockClusterManagerMockRecorder is the mock recorder for MockClusterManager.
 type MockClusterManagerMockRecorder struct {
 	mock *MockClusterManager
 }
 
-// NewMockClusterManager creates a new mock instance
+// NewMockClusterManager creates a new mock instance.
 func NewMockClusterManager(ctrl *gomock.Controller) *MockClusterManager {
 	mock := &MockClusterManager{ctrl: ctrl}
 	mock.recorder = &MockClusterManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClusterManager) EXPECT() *MockClusterManagerMockRecorder {
 	return m.recorder
 }
 
-// AddOrUpdatePrimaryCluster mocks base method
-func (m *MockClusterManager) AddOrUpdatePrimaryCluster(cluster v2.Cluster) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddOrUpdatePrimaryCluster", cluster)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AddOrUpdatePrimaryCluster indicates an expected call of AddOrUpdatePrimaryCluster
-func (mr *MockClusterManagerMockRecorder) AddOrUpdatePrimaryCluster(cluster interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOrUpdatePrimaryCluster", reflect.TypeOf((*MockClusterManager)(nil).AddOrUpdatePrimaryCluster), cluster)
-}
-
-// AddClusterHealthCheckCallbacks mocks base method
+// AddClusterHealthCheckCallbacks mocks base method.
 func (m *MockClusterManager) AddClusterHealthCheckCallbacks(name string, cb types.HealthCheckCb) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddClusterHealthCheckCallbacks", name, cb)
@@ -61,53 +47,27 @@ func (m *MockClusterManager) AddClusterHealthCheckCallbacks(name string, cb type
 	return ret0
 }
 
-// AddClusterHealthCheckCallbacks indicates an expected call of AddClusterHealthCheckCallbacks
+// AddClusterHealthCheckCallbacks indicates an expected call of AddClusterHealthCheckCallbacks.
 func (mr *MockClusterManagerMockRecorder) AddClusterHealthCheckCallbacks(name, cb interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddClusterHealthCheckCallbacks", reflect.TypeOf((*MockClusterManager)(nil).AddClusterHealthCheckCallbacks), name, cb)
 }
 
-// GetClusterSnapshot mocks base method
-func (m *MockClusterManager) GetClusterSnapshot(context context.Context, cluster string) types.ClusterSnapshot {
+// AddOrUpdatePrimaryCluster mocks base method.
+func (m *MockClusterManager) AddOrUpdatePrimaryCluster(cluster v2.Cluster) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterSnapshot", context, cluster)
-	ret0, _ := ret[0].(types.ClusterSnapshot)
-	return ret0
-}
-
-// GetClusterSnapshot indicates an expected call of GetClusterSnapshot
-func (mr *MockClusterManagerMockRecorder) GetClusterSnapshot(context, cluster interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterSnapshot", reflect.TypeOf((*MockClusterManager)(nil).GetClusterSnapshot), context, cluster)
-}
-
-// PutClusterSnapshot mocks base method
-func (m *MockClusterManager) PutClusterSnapshot(arg0 types.ClusterSnapshot) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "PutClusterSnapshot", arg0)
-}
-
-// PutClusterSnapshot indicates an expected call of PutClusterSnapshot
-func (mr *MockClusterManagerMockRecorder) PutClusterSnapshot(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutClusterSnapshot", reflect.TypeOf((*MockClusterManager)(nil).PutClusterSnapshot), arg0)
-}
-
-// UpdateClusterHosts mocks base method
-func (m *MockClusterManager) UpdateClusterHosts(cluster string, hosts []v2.Host) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateClusterHosts", cluster, hosts)
+	ret := m.ctrl.Call(m, "AddOrUpdatePrimaryCluster", cluster)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateClusterHosts indicates an expected call of UpdateClusterHosts
-func (mr *MockClusterManagerMockRecorder) UpdateClusterHosts(cluster, hosts interface{}) *gomock.Call {
+// AddOrUpdatePrimaryCluster indicates an expected call of AddOrUpdatePrimaryCluster.
+func (mr *MockClusterManagerMockRecorder) AddOrUpdatePrimaryCluster(cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterHosts", reflect.TypeOf((*MockClusterManager)(nil).UpdateClusterHosts), cluster, hosts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOrUpdatePrimaryCluster", reflect.TypeOf((*MockClusterManager)(nil).AddOrUpdatePrimaryCluster), cluster)
 }
 
-// AppendClusterHosts mocks base method
+// AppendClusterHosts mocks base method.
 func (m *MockClusterManager) AppendClusterHosts(clusterName string, hostConfigs []v2.Host) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppendClusterHosts", clusterName, hostConfigs)
@@ -115,41 +75,27 @@ func (m *MockClusterManager) AppendClusterHosts(clusterName string, hostConfigs 
 	return ret0
 }
 
-// AppendClusterHosts indicates an expected call of AppendClusterHosts
+// AppendClusterHosts indicates an expected call of AppendClusterHosts.
 func (mr *MockClusterManagerMockRecorder) AppendClusterHosts(clusterName, hostConfigs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendClusterHosts", reflect.TypeOf((*MockClusterManager)(nil).AppendClusterHosts), clusterName, hostConfigs)
 }
 
-// TCPConnForCluster mocks base method
-func (m *MockClusterManager) TCPConnForCluster(balancerContext types.LoadBalancerContext, snapshot types.ClusterSnapshot) types.CreateConnectionData {
+// ClusterExist mocks base method.
+func (m *MockClusterManager) ClusterExist(clusterName string) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TCPConnForCluster", balancerContext, snapshot)
-	ret0, _ := ret[0].(types.CreateConnectionData)
+	ret := m.ctrl.Call(m, "ClusterExist", clusterName)
+	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// TCPConnForCluster indicates an expected call of TCPConnForCluster
-func (mr *MockClusterManagerMockRecorder) TCPConnForCluster(balancerContext, snapshot interface{}) *gomock.Call {
+// ClusterExist indicates an expected call of ClusterExist.
+func (mr *MockClusterManagerMockRecorder) ClusterExist(clusterName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TCPConnForCluster", reflect.TypeOf((*MockClusterManager)(nil).TCPConnForCluster), balancerContext, snapshot)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterExist", reflect.TypeOf((*MockClusterManager)(nil).ClusterExist), clusterName)
 }
 
-// UDPConnForCluster mocks base method
-func (m *MockClusterManager) UDPConnForCluster(balancerContext types.LoadBalancerContext, snapshot types.ClusterSnapshot) types.CreateConnectionData {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UDPConnForCluster", balancerContext, snapshot)
-	ret0, _ := ret[0].(types.CreateConnectionData)
-	return ret0
-}
-
-// UDPConnForCluster indicates an expected call of UDPConnForCluster
-func (mr *MockClusterManagerMockRecorder) UDPConnForCluster(balancerContext, snapshot interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UDPConnForCluster", reflect.TypeOf((*MockClusterManager)(nil).UDPConnForCluster), balancerContext, snapshot)
-}
-
-// ConnPoolForCluster mocks base method
+// ConnPoolForCluster mocks base method.
 func (m *MockClusterManager) ConnPoolForCluster(balancerContext types.LoadBalancerContext, snapshot types.ClusterSnapshot, protocol api.ProtocolName) (types.ConnectionPool, types.Host) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnPoolForCluster", balancerContext, snapshot, protocol)
@@ -158,13 +104,79 @@ func (m *MockClusterManager) ConnPoolForCluster(balancerContext types.LoadBalanc
 	return ret0, ret1
 }
 
-// ConnPoolForCluster indicates an expected call of ConnPoolForCluster
+// ConnPoolForCluster indicates an expected call of ConnPoolForCluster.
 func (mr *MockClusterManagerMockRecorder) ConnPoolForCluster(balancerContext, snapshot, protocol interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnPoolForCluster", reflect.TypeOf((*MockClusterManager)(nil).ConnPoolForCluster), balancerContext, snapshot, protocol)
 }
 
-// RemovePrimaryCluster mocks base method
+// Destroy mocks base method.
+func (m *MockClusterManager) Destroy() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Destroy")
+}
+
+// Destroy indicates an expected call of Destroy.
+func (mr *MockClusterManagerMockRecorder) Destroy() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockClusterManager)(nil).Destroy))
+}
+
+// GetClusterSnapshot mocks base method.
+func (m *MockClusterManager) GetClusterSnapshot(context context.Context, cluster string) types.ClusterSnapshot {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterSnapshot", context, cluster)
+	ret0, _ := ret[0].(types.ClusterSnapshot)
+	return ret0
+}
+
+// GetClusterSnapshot indicates an expected call of GetClusterSnapshot.
+func (mr *MockClusterManagerMockRecorder) GetClusterSnapshot(context, cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterSnapshot", reflect.TypeOf((*MockClusterManager)(nil).GetClusterSnapshot), context, cluster)
+}
+
+// GetTLSManager mocks base method.
+func (m *MockClusterManager) GetTLSManager() types.TLSClientContextManager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTLSManager")
+	ret0, _ := ret[0].(types.TLSClientContextManager)
+	return ret0
+}
+
+// GetTLSManager indicates an expected call of GetTLSManager.
+func (mr *MockClusterManagerMockRecorder) GetTLSManager() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLSManager", reflect.TypeOf((*MockClusterManager)(nil).GetTLSManager))
+}
+
+// PutClusterSnapshot mocks base method.
+func (m *MockClusterManager) PutClusterSnapshot(arg0 types.ClusterSnapshot) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "PutClusterSnapshot", arg0)
+}
+
+// PutClusterSnapshot indicates an expected call of PutClusterSnapshot.
+func (mr *MockClusterManagerMockRecorder) PutClusterSnapshot(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutClusterSnapshot", reflect.TypeOf((*MockClusterManager)(nil).PutClusterSnapshot), arg0)
+}
+
+// RemoveClusterHosts mocks base method.
+func (m *MockClusterManager) RemoveClusterHosts(clusterName string, hosts []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveClusterHosts", clusterName, hosts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveClusterHosts indicates an expected call of RemoveClusterHosts.
+func (mr *MockClusterManagerMockRecorder) RemoveClusterHosts(clusterName, hosts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveClusterHosts", reflect.TypeOf((*MockClusterManager)(nil).RemoveClusterHosts), clusterName, hosts)
+}
+
+// RemovePrimaryCluster mocks base method.
 func (m *MockClusterManager) RemovePrimaryCluster(clusters ...string) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -176,128 +188,102 @@ func (m *MockClusterManager) RemovePrimaryCluster(clusters ...string) error {
 	return ret0
 }
 
-// RemovePrimaryCluster indicates an expected call of RemovePrimaryCluster
+// RemovePrimaryCluster indicates an expected call of RemovePrimaryCluster.
 func (mr *MockClusterManagerMockRecorder) RemovePrimaryCluster(clusters ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePrimaryCluster", reflect.TypeOf((*MockClusterManager)(nil).RemovePrimaryCluster), clusters...)
 }
 
-// ClusterExist mocks base method
-func (m *MockClusterManager) ClusterExist(clusterName string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClusterExist", clusterName)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// ClusterExist indicates an expected call of ClusterExist
-func (mr *MockClusterManagerMockRecorder) ClusterExist(clusterName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterExist", reflect.TypeOf((*MockClusterManager)(nil).ClusterExist), clusterName)
-}
-
-// RemoveClusterHosts mocks base method
-func (m *MockClusterManager) RemoveClusterHosts(clusterName string, hosts []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveClusterHosts", clusterName, hosts)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveClusterHosts indicates an expected call of RemoveClusterHosts
-func (mr *MockClusterManagerMockRecorder) RemoveClusterHosts(clusterName, hosts interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveClusterHosts", reflect.TypeOf((*MockClusterManager)(nil).RemoveClusterHosts), clusterName, hosts)
-}
-
-// GetTLSManager mocks base method
-func (m *MockClusterManager) GetTLSManager() types.TLSClientContextManager {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTLSManager")
-	ret0, _ := ret[0].(types.TLSClientContextManager)
-	return ret0
-}
-
-// GetTLSManager indicates an expected call of GetTLSManager
-func (mr *MockClusterManagerMockRecorder) GetTLSManager() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLSManager", reflect.TypeOf((*MockClusterManager)(nil).GetTLSManager))
-}
-
-// UpdateTLSManager mocks base method
-func (m *MockClusterManager) UpdateTLSManager(arg0 *v2.TLSConfig) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateTLSManager", arg0)
-}
-
-// UpdateTLSManager indicates an expected call of UpdateTLSManager
-func (mr *MockClusterManagerMockRecorder) UpdateTLSManager(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTLSManager", reflect.TypeOf((*MockClusterManager)(nil).UpdateTLSManager), arg0)
-}
-
-// ShutdownConnectionPool mocks base method
+// ShutdownConnectionPool mocks base method.
 func (m *MockClusterManager) ShutdownConnectionPool(proto types.ProtocolName, addr string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ShutdownConnectionPool", proto, addr)
 }
 
-// ShutdownConnectionPool indicates an expected call of ShutdownConnectionPool
+// ShutdownConnectionPool indicates an expected call of ShutdownConnectionPool.
 func (mr *MockClusterManagerMockRecorder) ShutdownConnectionPool(proto, addr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShutdownConnectionPool", reflect.TypeOf((*MockClusterManager)(nil).ShutdownConnectionPool), proto, addr)
 }
 
-// Destroy mocks base method
-func (m *MockClusterManager) Destroy() {
+// TCPConnForCluster mocks base method.
+func (m *MockClusterManager) TCPConnForCluster(balancerContext types.LoadBalancerContext, snapshot types.ClusterSnapshot) types.CreateConnectionData {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Destroy")
+	ret := m.ctrl.Call(m, "TCPConnForCluster", balancerContext, snapshot)
+	ret0, _ := ret[0].(types.CreateConnectionData)
+	return ret0
 }
 
-// Destroy indicates an expected call of Destroy
-func (mr *MockClusterManagerMockRecorder) Destroy() *gomock.Call {
+// TCPConnForCluster indicates an expected call of TCPConnForCluster.
+func (mr *MockClusterManagerMockRecorder) TCPConnForCluster(balancerContext, snapshot interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockClusterManager)(nil).Destroy))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TCPConnForCluster", reflect.TypeOf((*MockClusterManager)(nil).TCPConnForCluster), balancerContext, snapshot)
 }
 
-// MockClusterSnapshot is a mock of ClusterSnapshot interface
+// UDPConnForCluster mocks base method.
+func (m *MockClusterManager) UDPConnForCluster(balancerContext types.LoadBalancerContext, snapshot types.ClusterSnapshot) types.CreateConnectionData {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UDPConnForCluster", balancerContext, snapshot)
+	ret0, _ := ret[0].(types.CreateConnectionData)
+	return ret0
+}
+
+// UDPConnForCluster indicates an expected call of UDPConnForCluster.
+func (mr *MockClusterManagerMockRecorder) UDPConnForCluster(balancerContext, snapshot interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UDPConnForCluster", reflect.TypeOf((*MockClusterManager)(nil).UDPConnForCluster), balancerContext, snapshot)
+}
+
+// UpdateClusterHosts mocks base method.
+func (m *MockClusterManager) UpdateClusterHosts(cluster string, hosts []v2.Host) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateClusterHosts", cluster, hosts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateClusterHosts indicates an expected call of UpdateClusterHosts.
+func (mr *MockClusterManagerMockRecorder) UpdateClusterHosts(cluster, hosts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterHosts", reflect.TypeOf((*MockClusterManager)(nil).UpdateClusterHosts), cluster, hosts)
+}
+
+// UpdateTLSManager mocks base method.
+func (m *MockClusterManager) UpdateTLSManager(arg0 *v2.TLSConfig) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateTLSManager", arg0)
+}
+
+// UpdateTLSManager indicates an expected call of UpdateTLSManager.
+func (mr *MockClusterManagerMockRecorder) UpdateTLSManager(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTLSManager", reflect.TypeOf((*MockClusterManager)(nil).UpdateTLSManager), arg0)
+}
+
+// MockClusterSnapshot is a mock of ClusterSnapshot interface.
 type MockClusterSnapshot struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterSnapshotMockRecorder
 }
 
-// MockClusterSnapshotMockRecorder is the mock recorder for MockClusterSnapshot
+// MockClusterSnapshotMockRecorder is the mock recorder for MockClusterSnapshot.
 type MockClusterSnapshotMockRecorder struct {
 	mock *MockClusterSnapshot
 }
 
-// NewMockClusterSnapshot creates a new mock instance
+// NewMockClusterSnapshot creates a new mock instance.
 func NewMockClusterSnapshot(ctrl *gomock.Controller) *MockClusterSnapshot {
 	mock := &MockClusterSnapshot{ctrl: ctrl}
 	mock.recorder = &MockClusterSnapshotMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClusterSnapshot) EXPECT() *MockClusterSnapshotMockRecorder {
 	return m.recorder
 }
 
-// HostSet mocks base method
-func (m *MockClusterSnapshot) HostSet() types.HostSet {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HostSet")
-	ret0, _ := ret[0].(types.HostSet)
-	return ret0
-}
-
-// HostSet indicates an expected call of HostSet
-func (mr *MockClusterSnapshotMockRecorder) HostSet() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostSet", reflect.TypeOf((*MockClusterSnapshot)(nil).HostSet))
-}
-
-// ClusterInfo mocks base method
+// ClusterInfo mocks base method.
 func (m *MockClusterSnapshot) ClusterInfo() types.ClusterInfo {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClusterInfo")
@@ -305,41 +291,13 @@ func (m *MockClusterSnapshot) ClusterInfo() types.ClusterInfo {
 	return ret0
 }
 
-// ClusterInfo indicates an expected call of ClusterInfo
+// ClusterInfo indicates an expected call of ClusterInfo.
 func (mr *MockClusterSnapshotMockRecorder) ClusterInfo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterInfo", reflect.TypeOf((*MockClusterSnapshot)(nil).ClusterInfo))
 }
 
-// LoadBalancer mocks base method
-func (m *MockClusterSnapshot) LoadBalancer() types.LoadBalancer {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadBalancer")
-	ret0, _ := ret[0].(types.LoadBalancer)
-	return ret0
-}
-
-// LoadBalancer indicates an expected call of LoadBalancer
-func (mr *MockClusterSnapshotMockRecorder) LoadBalancer() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBalancer", reflect.TypeOf((*MockClusterSnapshot)(nil).LoadBalancer))
-}
-
-// IsExistsHosts mocks base method
-func (m *MockClusterSnapshot) IsExistsHosts(metadata api.MetadataMatchCriteria) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsExistsHosts", metadata)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsExistsHosts indicates an expected call of IsExistsHosts
-func (mr *MockClusterSnapshotMockRecorder) IsExistsHosts(metadata interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsExistsHosts", reflect.TypeOf((*MockClusterSnapshot)(nil).IsExistsHosts), metadata)
-}
-
-// HostNum mocks base method
+// HostNum mocks base method.
 func (m *MockClusterSnapshot) HostNum(metadata api.MetadataMatchCriteria) int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HostNum", metadata)
@@ -347,36 +305,90 @@ func (m *MockClusterSnapshot) HostNum(metadata api.MetadataMatchCriteria) int {
 	return ret0
 }
 
-// HostNum indicates an expected call of HostNum
+// HostNum indicates an expected call of HostNum.
 func (mr *MockClusterSnapshotMockRecorder) HostNum(metadata interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostNum", reflect.TypeOf((*MockClusterSnapshot)(nil).HostNum), metadata)
 }
 
-// MockCluster is a mock of Cluster interface
+// HostSet mocks base method.
+func (m *MockClusterSnapshot) HostSet() types.HostSet {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HostSet")
+	ret0, _ := ret[0].(types.HostSet)
+	return ret0
+}
+
+// HostSet indicates an expected call of HostSet.
+func (mr *MockClusterSnapshotMockRecorder) HostSet() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostSet", reflect.TypeOf((*MockClusterSnapshot)(nil).HostSet))
+}
+
+// IsExistsHosts mocks base method.
+func (m *MockClusterSnapshot) IsExistsHosts(metadata api.MetadataMatchCriteria) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsExistsHosts", metadata)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsExistsHosts indicates an expected call of IsExistsHosts.
+func (mr *MockClusterSnapshotMockRecorder) IsExistsHosts(metadata interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsExistsHosts", reflect.TypeOf((*MockClusterSnapshot)(nil).IsExistsHosts), metadata)
+}
+
+// LoadBalancer mocks base method.
+func (m *MockClusterSnapshot) LoadBalancer() types.LoadBalancer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadBalancer")
+	ret0, _ := ret[0].(types.LoadBalancer)
+	return ret0
+}
+
+// LoadBalancer indicates an expected call of LoadBalancer.
+func (mr *MockClusterSnapshotMockRecorder) LoadBalancer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBalancer", reflect.TypeOf((*MockClusterSnapshot)(nil).LoadBalancer))
+}
+
+// MockCluster is a mock of Cluster interface.
 type MockCluster struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterMockRecorder
 }
 
-// MockClusterMockRecorder is the mock recorder for MockCluster
+// MockClusterMockRecorder is the mock recorder for MockCluster.
 type MockClusterMockRecorder struct {
 	mock *MockCluster
 }
 
-// NewMockCluster creates a new mock instance
+// NewMockCluster creates a new mock instance.
 func NewMockCluster(ctrl *gomock.Controller) *MockCluster {
 	mock := &MockCluster{ctrl: ctrl}
 	mock.recorder = &MockClusterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCluster) EXPECT() *MockClusterMockRecorder {
 	return m.recorder
 }
 
-// Snapshot mocks base method
+// AddHealthCheckCallbacks mocks base method.
+func (m *MockCluster) AddHealthCheckCallbacks(cb types.HealthCheckCb) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddHealthCheckCallbacks", cb)
+}
+
+// AddHealthCheckCallbacks indicates an expected call of AddHealthCheckCallbacks.
+func (mr *MockClusterMockRecorder) AddHealthCheckCallbacks(cb interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddHealthCheckCallbacks", reflect.TypeOf((*MockCluster)(nil).AddHealthCheckCallbacks), cb)
+}
+
+// Snapshot mocks base method.
 func (m *MockCluster) Snapshot() types.ClusterSnapshot {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Snapshot")
@@ -384,72 +396,60 @@ func (m *MockCluster) Snapshot() types.ClusterSnapshot {
 	return ret0
 }
 
-// Snapshot indicates an expected call of Snapshot
+// Snapshot indicates an expected call of Snapshot.
 func (mr *MockClusterMockRecorder) Snapshot() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Snapshot", reflect.TypeOf((*MockCluster)(nil).Snapshot))
 }
 
-// UpdateHosts mocks base method
-func (m *MockCluster) UpdateHosts(arg0 []types.Host) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateHosts", arg0)
-}
-
-// UpdateHosts indicates an expected call of UpdateHosts
-func (mr *MockClusterMockRecorder) UpdateHosts(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHosts", reflect.TypeOf((*MockCluster)(nil).UpdateHosts), arg0)
-}
-
-// AddHealthCheckCallbacks mocks base method
-func (m *MockCluster) AddHealthCheckCallbacks(cb types.HealthCheckCb) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddHealthCheckCallbacks", cb)
-}
-
-// AddHealthCheckCallbacks indicates an expected call of AddHealthCheckCallbacks
-func (mr *MockClusterMockRecorder) AddHealthCheckCallbacks(cb interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddHealthCheckCallbacks", reflect.TypeOf((*MockCluster)(nil).AddHealthCheckCallbacks), cb)
-}
-
-// StopHealthChecking mocks base method
+// StopHealthChecking mocks base method.
 func (m *MockCluster) StopHealthChecking() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "StopHealthChecking")
 }
 
-// StopHealthChecking indicates an expected call of StopHealthChecking
+// StopHealthChecking indicates an expected call of StopHealthChecking.
 func (mr *MockClusterMockRecorder) StopHealthChecking() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopHealthChecking", reflect.TypeOf((*MockCluster)(nil).StopHealthChecking))
 }
 
-// MockHostSet is a mock of HostSet interface
+// UpdateHosts mocks base method.
+func (m *MockCluster) UpdateHosts(arg0 []types.Host) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateHosts", arg0)
+}
+
+// UpdateHosts indicates an expected call of UpdateHosts.
+func (mr *MockClusterMockRecorder) UpdateHosts(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHosts", reflect.TypeOf((*MockCluster)(nil).UpdateHosts), arg0)
+}
+
+// MockHostSet is a mock of HostSet interface.
 type MockHostSet struct {
 	ctrl     *gomock.Controller
 	recorder *MockHostSetMockRecorder
 }
 
-// MockHostSetMockRecorder is the mock recorder for MockHostSet
+// MockHostSetMockRecorder is the mock recorder for MockHostSet.
 type MockHostSetMockRecorder struct {
 	mock *MockHostSet
 }
 
-// NewMockHostSet creates a new mock instance
+// NewMockHostSet creates a new mock instance.
 func NewMockHostSet(ctrl *gomock.Controller) *MockHostSet {
 	mock := &MockHostSet{ctrl: ctrl}
 	mock.recorder = &MockHostSetMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHostSet) EXPECT() *MockHostSetMockRecorder {
 	return m.recorder
 }
 
-// Hosts mocks base method
+// Hosts mocks base method.
 func (m *MockHostSet) Hosts() []types.Host {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Hosts")
@@ -457,254 +457,36 @@ func (m *MockHostSet) Hosts() []types.Host {
 	return ret0
 }
 
-// Hosts indicates an expected call of Hosts
+// Hosts indicates an expected call of Hosts.
 func (mr *MockHostSetMockRecorder) Hosts() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Hosts", reflect.TypeOf((*MockHostSet)(nil).Hosts))
 }
 
-// MockHost is a mock of Host interface
+// MockHost is a mock of Host interface.
 type MockHost struct {
 	ctrl     *gomock.Controller
 	recorder *MockHostMockRecorder
 }
 
-// MockHostMockRecorder is the mock recorder for MockHost
+// MockHostMockRecorder is the mock recorder for MockHost.
 type MockHostMockRecorder struct {
 	mock *MockHost
 }
 
-// NewMockHost creates a new mock instance
+// NewMockHost creates a new mock instance.
 func NewMockHost(ctrl *gomock.Controller) *MockHost {
 	mock := &MockHost{ctrl: ctrl}
 	mock.recorder = &MockHostMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHost) EXPECT() *MockHostMockRecorder {
 	return m.recorder
 }
 
-// Hostname mocks base method
-func (m *MockHost) Hostname() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Hostname")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// Hostname indicates an expected call of Hostname
-func (mr *MockHostMockRecorder) Hostname() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Hostname", reflect.TypeOf((*MockHost)(nil).Hostname))
-}
-
-// Metadata mocks base method
-func (m *MockHost) Metadata() api.Metadata {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Metadata")
-	ret0, _ := ret[0].(api.Metadata)
-	return ret0
-}
-
-// Metadata indicates an expected call of Metadata
-func (mr *MockHostMockRecorder) Metadata() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metadata", reflect.TypeOf((*MockHost)(nil).Metadata))
-}
-
-// AddressString mocks base method
-func (m *MockHost) AddressString() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddressString")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// AddressString indicates an expected call of AddressString
-func (mr *MockHostMockRecorder) AddressString() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddressString", reflect.TypeOf((*MockHost)(nil).AddressString))
-}
-
-// Weight mocks base method
-func (m *MockHost) Weight() uint32 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Weight")
-	ret0, _ := ret[0].(uint32)
-	return ret0
-}
-
-// Weight indicates an expected call of Weight
-func (mr *MockHostMockRecorder) Weight() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Weight", reflect.TypeOf((*MockHost)(nil).Weight))
-}
-
-// SupportTLS mocks base method
-func (m *MockHost) SupportTLS() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SupportTLS")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// SupportTLS indicates an expected call of SupportTLS
-func (mr *MockHostMockRecorder) SupportTLS() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportTLS", reflect.TypeOf((*MockHost)(nil).SupportTLS))
-}
-
-// ClearHealthFlag mocks base method
-func (m *MockHost) ClearHealthFlag(flag api.HealthFlag) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ClearHealthFlag", flag)
-}
-
-// ClearHealthFlag indicates an expected call of ClearHealthFlag
-func (mr *MockHostMockRecorder) ClearHealthFlag(flag interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearHealthFlag", reflect.TypeOf((*MockHost)(nil).ClearHealthFlag), flag)
-}
-
-// ContainHealthFlag mocks base method
-func (m *MockHost) ContainHealthFlag(flag api.HealthFlag) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContainHealthFlag", flag)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// ContainHealthFlag indicates an expected call of ContainHealthFlag
-func (mr *MockHostMockRecorder) ContainHealthFlag(flag interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainHealthFlag", reflect.TypeOf((*MockHost)(nil).ContainHealthFlag), flag)
-}
-
-// SetHealthFlag mocks base method
-func (m *MockHost) SetHealthFlag(flag api.HealthFlag) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetHealthFlag", flag)
-}
-
-// SetHealthFlag indicates an expected call of SetHealthFlag
-func (mr *MockHostMockRecorder) SetHealthFlag(flag interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHealthFlag", reflect.TypeOf((*MockHost)(nil).SetHealthFlag), flag)
-}
-
-// HealthFlag mocks base method
-func (m *MockHost) HealthFlag() api.HealthFlag {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HealthFlag")
-	ret0, _ := ret[0].(api.HealthFlag)
-	return ret0
-}
-
-// HealthFlag indicates an expected call of HealthFlag
-func (mr *MockHostMockRecorder) HealthFlag() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HealthFlag", reflect.TypeOf((*MockHost)(nil).HealthFlag))
-}
-
-// Health mocks base method
-func (m *MockHost) Health() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Health")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// Health indicates an expected call of Health
-func (mr *MockHostMockRecorder) Health() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Health", reflect.TypeOf((*MockHost)(nil).Health))
-}
-
-// HostStats mocks base method
-func (m *MockHost) HostStats() types.HostStats {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HostStats")
-	ret0, _ := ret[0].(types.HostStats)
-	return ret0
-}
-
-// HostStats indicates an expected call of HostStats
-func (mr *MockHostMockRecorder) HostStats() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostStats", reflect.TypeOf((*MockHost)(nil).HostStats))
-}
-
-// ClusterInfo mocks base method
-func (m *MockHost) ClusterInfo() types.ClusterInfo {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClusterInfo")
-	ret0, _ := ret[0].(types.ClusterInfo)
-	return ret0
-}
-
-// ClusterInfo indicates an expected call of ClusterInfo
-func (mr *MockHostMockRecorder) ClusterInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterInfo", reflect.TypeOf((*MockHost)(nil).ClusterInfo))
-}
-
-// SetClusterInfo mocks base method
-func (m *MockHost) SetClusterInfo(info types.ClusterInfo) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetClusterInfo", info)
-}
-
-// SetClusterInfo indicates an expected call of SetClusterInfo
-func (mr *MockHostMockRecorder) SetClusterInfo(info interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClusterInfo", reflect.TypeOf((*MockHost)(nil).SetClusterInfo), info)
-}
-
-// TLSHashValue mocks base method
-func (m *MockHost) TLSHashValue() *types.HashValue {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TLSHashValue")
-	ret0, _ := ret[0].(*types.HashValue)
-	return ret0
-}
-
-// TLSHashValue indicates an expected call of TLSHashValue
-func (mr *MockHostMockRecorder) TLSHashValue() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TLSHashValue", reflect.TypeOf((*MockHost)(nil).TLSHashValue))
-}
-
-// CreateConnection mocks base method
-func (m *MockHost) CreateConnection(context context.Context) types.CreateConnectionData {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateConnection", context)
-	ret0, _ := ret[0].(types.CreateConnectionData)
-	return ret0
-}
-
-// CreateConnection indicates an expected call of CreateConnection
-func (mr *MockHostMockRecorder) CreateConnection(context interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateConnection", reflect.TypeOf((*MockHost)(nil).CreateConnection), context)
-}
-
-// CreateUDPConnection mocks base method
-func (m *MockHost) CreateUDPConnection(context context.Context) types.CreateConnectionData {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateUDPConnection", context)
-	ret0, _ := ret[0].(types.CreateConnectionData)
-	return ret0
-}
-
-// CreateUDPConnection indicates an expected call of CreateUDPConnection
-func (mr *MockHostMockRecorder) CreateUDPConnection(context interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUDPConnection", reflect.TypeOf((*MockHost)(nil).CreateUDPConnection), context)
-}
-
-// Address mocks base method
+// Address mocks base method.
 func (m *MockHost) Address() net.Addr {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Address")
@@ -712,13 +494,53 @@ func (m *MockHost) Address() net.Addr {
 	return ret0
 }
 
-// Address indicates an expected call of Address
+// Address indicates an expected call of Address.
 func (mr *MockHostMockRecorder) Address() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Address", reflect.TypeOf((*MockHost)(nil).Address))
 }
 
-// Config mocks base method
+// AddressString mocks base method.
+func (m *MockHost) AddressString() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddressString")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// AddressString indicates an expected call of AddressString.
+func (mr *MockHostMockRecorder) AddressString() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddressString", reflect.TypeOf((*MockHost)(nil).AddressString))
+}
+
+// ClearHealthFlag mocks base method.
+func (m *MockHost) ClearHealthFlag(flag api.HealthFlag) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ClearHealthFlag", flag)
+}
+
+// ClearHealthFlag indicates an expected call of ClearHealthFlag.
+func (mr *MockHostMockRecorder) ClearHealthFlag(flag interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearHealthFlag", reflect.TypeOf((*MockHost)(nil).ClearHealthFlag), flag)
+}
+
+// ClusterInfo mocks base method.
+func (m *MockHost) ClusterInfo() types.ClusterInfo {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClusterInfo")
+	ret0, _ := ret[0].(types.ClusterInfo)
+	return ret0
+}
+
+// ClusterInfo indicates an expected call of ClusterInfo.
+func (mr *MockHostMockRecorder) ClusterInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterInfo", reflect.TypeOf((*MockHost)(nil).ClusterInfo))
+}
+
+// Config mocks base method.
 func (m *MockHost) Config() v2.Host {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Config")
@@ -726,50 +548,214 @@ func (m *MockHost) Config() v2.Host {
 	return ret0
 }
 
-// Config indicates an expected call of Config
+// Config indicates an expected call of Config.
 func (mr *MockHostMockRecorder) Config() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockHost)(nil).Config))
 }
 
-// MockClusterInfo is a mock of ClusterInfo interface
+// ContainHealthFlag mocks base method.
+func (m *MockHost) ContainHealthFlag(flag api.HealthFlag) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContainHealthFlag", flag)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ContainHealthFlag indicates an expected call of ContainHealthFlag.
+func (mr *MockHostMockRecorder) ContainHealthFlag(flag interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainHealthFlag", reflect.TypeOf((*MockHost)(nil).ContainHealthFlag), flag)
+}
+
+// CreateConnection mocks base method.
+func (m *MockHost) CreateConnection(context context.Context) types.CreateConnectionData {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateConnection", context)
+	ret0, _ := ret[0].(types.CreateConnectionData)
+	return ret0
+}
+
+// CreateConnection indicates an expected call of CreateConnection.
+func (mr *MockHostMockRecorder) CreateConnection(context interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateConnection", reflect.TypeOf((*MockHost)(nil).CreateConnection), context)
+}
+
+// CreateUDPConnection mocks base method.
+func (m *MockHost) CreateUDPConnection(context context.Context) types.CreateConnectionData {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateUDPConnection", context)
+	ret0, _ := ret[0].(types.CreateConnectionData)
+	return ret0
+}
+
+// CreateUDPConnection indicates an expected call of CreateUDPConnection.
+func (mr *MockHostMockRecorder) CreateUDPConnection(context interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUDPConnection", reflect.TypeOf((*MockHost)(nil).CreateUDPConnection), context)
+}
+
+// Health mocks base method.
+func (m *MockHost) Health() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Health")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Health indicates an expected call of Health.
+func (mr *MockHostMockRecorder) Health() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Health", reflect.TypeOf((*MockHost)(nil).Health))
+}
+
+// HealthFlag mocks base method.
+func (m *MockHost) HealthFlag() api.HealthFlag {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HealthFlag")
+	ret0, _ := ret[0].(api.HealthFlag)
+	return ret0
+}
+
+// HealthFlag indicates an expected call of HealthFlag.
+func (mr *MockHostMockRecorder) HealthFlag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HealthFlag", reflect.TypeOf((*MockHost)(nil).HealthFlag))
+}
+
+// HostStats mocks base method.
+func (m *MockHost) HostStats() types.HostStats {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HostStats")
+	ret0, _ := ret[0].(types.HostStats)
+	return ret0
+}
+
+// HostStats indicates an expected call of HostStats.
+func (mr *MockHostMockRecorder) HostStats() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostStats", reflect.TypeOf((*MockHost)(nil).HostStats))
+}
+
+// Hostname mocks base method.
+func (m *MockHost) Hostname() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Hostname")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Hostname indicates an expected call of Hostname.
+func (mr *MockHostMockRecorder) Hostname() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Hostname", reflect.TypeOf((*MockHost)(nil).Hostname))
+}
+
+// Metadata mocks base method.
+func (m *MockHost) Metadata() api.Metadata {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Metadata")
+	ret0, _ := ret[0].(api.Metadata)
+	return ret0
+}
+
+// Metadata indicates an expected call of Metadata.
+func (mr *MockHostMockRecorder) Metadata() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metadata", reflect.TypeOf((*MockHost)(nil).Metadata))
+}
+
+// SetClusterInfo mocks base method.
+func (m *MockHost) SetClusterInfo(info types.ClusterInfo) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetClusterInfo", info)
+}
+
+// SetClusterInfo indicates an expected call of SetClusterInfo.
+func (mr *MockHostMockRecorder) SetClusterInfo(info interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClusterInfo", reflect.TypeOf((*MockHost)(nil).SetClusterInfo), info)
+}
+
+// SetHealthFlag mocks base method.
+func (m *MockHost) SetHealthFlag(flag api.HealthFlag) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetHealthFlag", flag)
+}
+
+// SetHealthFlag indicates an expected call of SetHealthFlag.
+func (mr *MockHostMockRecorder) SetHealthFlag(flag interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHealthFlag", reflect.TypeOf((*MockHost)(nil).SetHealthFlag), flag)
+}
+
+// SupportTLS mocks base method.
+func (m *MockHost) SupportTLS() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SupportTLS")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SupportTLS indicates an expected call of SupportTLS.
+func (mr *MockHostMockRecorder) SupportTLS() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportTLS", reflect.TypeOf((*MockHost)(nil).SupportTLS))
+}
+
+// TLSHashValue mocks base method.
+func (m *MockHost) TLSHashValue() *types.HashValue {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TLSHashValue")
+	ret0, _ := ret[0].(*types.HashValue)
+	return ret0
+}
+
+// TLSHashValue indicates an expected call of TLSHashValue.
+func (mr *MockHostMockRecorder) TLSHashValue() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TLSHashValue", reflect.TypeOf((*MockHost)(nil).TLSHashValue))
+}
+
+// Weight mocks base method.
+func (m *MockHost) Weight() uint32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Weight")
+	ret0, _ := ret[0].(uint32)
+	return ret0
+}
+
+// Weight indicates an expected call of Weight.
+func (mr *MockHostMockRecorder) Weight() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Weight", reflect.TypeOf((*MockHost)(nil).Weight))
+}
+
+// MockClusterInfo is a mock of ClusterInfo interface.
 type MockClusterInfo struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterInfoMockRecorder
 }
 
-// MockClusterInfoMockRecorder is the mock recorder for MockClusterInfo
+// MockClusterInfoMockRecorder is the mock recorder for MockClusterInfo.
 type MockClusterInfoMockRecorder struct {
 	mock *MockClusterInfo
 }
 
-// NewMockClusterInfo creates a new mock instance
+// NewMockClusterInfo creates a new mock instance.
 func NewMockClusterInfo(ctrl *gomock.Controller) *MockClusterInfo {
 	mock := &MockClusterInfo{ctrl: ctrl}
 	mock.recorder = &MockClusterInfoMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClusterInfo) EXPECT() *MockClusterInfoMockRecorder {
 	return m.recorder
 }
 
-// Name mocks base method
-func (m *MockClusterInfo) Name() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Name")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// Name indicates an expected call of Name
-func (mr *MockClusterInfoMockRecorder) Name() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockClusterInfo)(nil).Name))
-}
-
-// ClusterType mocks base method
+// ClusterType mocks base method.
 func (m *MockClusterInfo) ClusterType() v2.ClusterType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClusterType")
@@ -777,27 +763,13 @@ func (m *MockClusterInfo) ClusterType() v2.ClusterType {
 	return ret0
 }
 
-// ClusterType indicates an expected call of ClusterType
+// ClusterType indicates an expected call of ClusterType.
 func (mr *MockClusterInfoMockRecorder) ClusterType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterType", reflect.TypeOf((*MockClusterInfo)(nil).ClusterType))
 }
 
-// LbType mocks base method
-func (m *MockClusterInfo) LbType() types.LoadBalancerType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LbType")
-	ret0, _ := ret[0].(types.LoadBalancerType)
-	return ret0
-}
-
-// LbType indicates an expected call of LbType
-func (mr *MockClusterInfoMockRecorder) LbType() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LbType", reflect.TypeOf((*MockClusterInfo)(nil).LbType))
-}
-
-// ConnBufferLimitBytes mocks base method
+// ConnBufferLimitBytes mocks base method.
 func (m *MockClusterInfo) ConnBufferLimitBytes() uint32 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnBufferLimitBytes")
@@ -805,83 +777,13 @@ func (m *MockClusterInfo) ConnBufferLimitBytes() uint32 {
 	return ret0
 }
 
-// ConnBufferLimitBytes indicates an expected call of ConnBufferLimitBytes
+// ConnBufferLimitBytes indicates an expected call of ConnBufferLimitBytes.
 func (mr *MockClusterInfoMockRecorder) ConnBufferLimitBytes() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnBufferLimitBytes", reflect.TypeOf((*MockClusterInfo)(nil).ConnBufferLimitBytes))
 }
 
-// MaxRequestsPerConn mocks base method
-func (m *MockClusterInfo) MaxRequestsPerConn() uint32 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MaxRequestsPerConn")
-	ret0, _ := ret[0].(uint32)
-	return ret0
-}
-
-// MaxRequestsPerConn indicates an expected call of MaxRequestsPerConn
-func (mr *MockClusterInfoMockRecorder) MaxRequestsPerConn() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxRequestsPerConn", reflect.TypeOf((*MockClusterInfo)(nil).MaxRequestsPerConn))
-}
-
-// Stats mocks base method
-func (m *MockClusterInfo) Stats() types.ClusterStats {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Stats")
-	ret0, _ := ret[0].(types.ClusterStats)
-	return ret0
-}
-
-// Stats indicates an expected call of Stats
-func (mr *MockClusterInfoMockRecorder) Stats() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stats", reflect.TypeOf((*MockClusterInfo)(nil).Stats))
-}
-
-// ResourceManager mocks base method
-func (m *MockClusterInfo) ResourceManager() types.ResourceManager {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResourceManager")
-	ret0, _ := ret[0].(types.ResourceManager)
-	return ret0
-}
-
-// ResourceManager indicates an expected call of ResourceManager
-func (mr *MockClusterInfoMockRecorder) ResourceManager() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceManager", reflect.TypeOf((*MockClusterInfo)(nil).ResourceManager))
-}
-
-// TLSMng mocks base method
-func (m *MockClusterInfo) TLSMng() types.TLSClientContextManager {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TLSMng")
-	ret0, _ := ret[0].(types.TLSClientContextManager)
-	return ret0
-}
-
-// TLSMng indicates an expected call of TLSMng
-func (mr *MockClusterInfoMockRecorder) TLSMng() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TLSMng", reflect.TypeOf((*MockClusterInfo)(nil).TLSMng))
-}
-
-// LbSubsetInfo mocks base method
-func (m *MockClusterInfo) LbSubsetInfo() types.LBSubsetInfo {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LbSubsetInfo")
-	ret0, _ := ret[0].(types.LBSubsetInfo)
-	return ret0
-}
-
-// LbSubsetInfo indicates an expected call of LbSubsetInfo
-func (mr *MockClusterInfoMockRecorder) LbSubsetInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LbSubsetInfo", reflect.TypeOf((*MockClusterInfo)(nil).LbSubsetInfo))
-}
-
-// ConnectTimeout mocks base method
+// ConnectTimeout mocks base method.
 func (m *MockClusterInfo) ConnectTimeout() time.Duration {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectTimeout")
@@ -889,27 +791,27 @@ func (m *MockClusterInfo) ConnectTimeout() time.Duration {
 	return ret0
 }
 
-// ConnectTimeout indicates an expected call of ConnectTimeout
+// ConnectTimeout indicates an expected call of ConnectTimeout.
 func (mr *MockClusterInfoMockRecorder) ConnectTimeout() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectTimeout", reflect.TypeOf((*MockClusterInfo)(nil).ConnectTimeout))
 }
 
-// LbOriDstInfo mocks base method
-func (m *MockClusterInfo) LbOriDstInfo() types.LBOriDstInfo {
+// IdleTimeout mocks base method.
+func (m *MockClusterInfo) IdleTimeout() time.Duration {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LbOriDstInfo")
-	ret0, _ := ret[0].(types.LBOriDstInfo)
+	ret := m.ctrl.Call(m, "IdleTimeout")
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
-// LbOriDstInfo indicates an expected call of LbOriDstInfo
-func (mr *MockClusterInfoMockRecorder) LbOriDstInfo() *gomock.Call {
+// IdleTimeout indicates an expected call of IdleTimeout.
+func (mr *MockClusterInfoMockRecorder) IdleTimeout() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LbOriDstInfo", reflect.TypeOf((*MockClusterInfo)(nil).LbOriDstInfo))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IdleTimeout", reflect.TypeOf((*MockClusterInfo)(nil).IdleTimeout))
 }
 
-// LbConfig mocks base method
+// LbConfig mocks base method.
 func (m *MockClusterInfo) LbConfig() v2.IsCluster_LbConfig {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LbConfig")
@@ -917,13 +819,111 @@ func (m *MockClusterInfo) LbConfig() v2.IsCluster_LbConfig {
 	return ret0
 }
 
-// LbConfig indicates an expected call of LbConfig
+// LbConfig indicates an expected call of LbConfig.
 func (mr *MockClusterInfoMockRecorder) LbConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LbConfig", reflect.TypeOf((*MockClusterInfo)(nil).LbConfig))
 }
 
-// SubType mocks base method
+// LbOriDstInfo mocks base method.
+func (m *MockClusterInfo) LbOriDstInfo() types.LBOriDstInfo {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LbOriDstInfo")
+	ret0, _ := ret[0].(types.LBOriDstInfo)
+	return ret0
+}
+
+// LbOriDstInfo indicates an expected call of LbOriDstInfo.
+func (mr *MockClusterInfoMockRecorder) LbOriDstInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LbOriDstInfo", reflect.TypeOf((*MockClusterInfo)(nil).LbOriDstInfo))
+}
+
+// LbSubsetInfo mocks base method.
+func (m *MockClusterInfo) LbSubsetInfo() types.LBSubsetInfo {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LbSubsetInfo")
+	ret0, _ := ret[0].(types.LBSubsetInfo)
+	return ret0
+}
+
+// LbSubsetInfo indicates an expected call of LbSubsetInfo.
+func (mr *MockClusterInfoMockRecorder) LbSubsetInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LbSubsetInfo", reflect.TypeOf((*MockClusterInfo)(nil).LbSubsetInfo))
+}
+
+// LbType mocks base method.
+func (m *MockClusterInfo) LbType() types.LoadBalancerType {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LbType")
+	ret0, _ := ret[0].(types.LoadBalancerType)
+	return ret0
+}
+
+// LbType indicates an expected call of LbType.
+func (mr *MockClusterInfoMockRecorder) LbType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LbType", reflect.TypeOf((*MockClusterInfo)(nil).LbType))
+}
+
+// MaxRequestsPerConn mocks base method.
+func (m *MockClusterInfo) MaxRequestsPerConn() uint32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MaxRequestsPerConn")
+	ret0, _ := ret[0].(uint32)
+	return ret0
+}
+
+// MaxRequestsPerConn indicates an expected call of MaxRequestsPerConn.
+func (mr *MockClusterInfoMockRecorder) MaxRequestsPerConn() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxRequestsPerConn", reflect.TypeOf((*MockClusterInfo)(nil).MaxRequestsPerConn))
+}
+
+// Name mocks base method.
+func (m *MockClusterInfo) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockClusterInfoMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockClusterInfo)(nil).Name))
+}
+
+// ResourceManager mocks base method.
+func (m *MockClusterInfo) ResourceManager() types.ResourceManager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResourceManager")
+	ret0, _ := ret[0].(types.ResourceManager)
+	return ret0
+}
+
+// ResourceManager indicates an expected call of ResourceManager.
+func (mr *MockClusterInfoMockRecorder) ResourceManager() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceManager", reflect.TypeOf((*MockClusterInfo)(nil).ResourceManager))
+}
+
+// Stats mocks base method.
+func (m *MockClusterInfo) Stats() types.ClusterStats {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stats")
+	ret0, _ := ret[0].(types.ClusterStats)
+	return ret0
+}
+
+// Stats indicates an expected call of Stats.
+func (mr *MockClusterInfoMockRecorder) Stats() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stats", reflect.TypeOf((*MockClusterInfo)(nil).Stats))
+}
+
+// SubType mocks base method.
 func (m *MockClusterInfo) SubType() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubType")
@@ -931,36 +931,50 @@ func (m *MockClusterInfo) SubType() string {
 	return ret0
 }
 
-// SubType indicates an expected call of SubType
+// SubType indicates an expected call of SubType.
 func (mr *MockClusterInfoMockRecorder) SubType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubType", reflect.TypeOf((*MockClusterInfo)(nil).SubType))
 }
 
-// MockResourceManager is a mock of ResourceManager interface
+// TLSMng mocks base method.
+func (m *MockClusterInfo) TLSMng() types.TLSClientContextManager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TLSMng")
+	ret0, _ := ret[0].(types.TLSClientContextManager)
+	return ret0
+}
+
+// TLSMng indicates an expected call of TLSMng.
+func (mr *MockClusterInfoMockRecorder) TLSMng() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TLSMng", reflect.TypeOf((*MockClusterInfo)(nil).TLSMng))
+}
+
+// MockResourceManager is a mock of ResourceManager interface.
 type MockResourceManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockResourceManagerMockRecorder
 }
 
-// MockResourceManagerMockRecorder is the mock recorder for MockResourceManager
+// MockResourceManagerMockRecorder is the mock recorder for MockResourceManager.
 type MockResourceManagerMockRecorder struct {
 	mock *MockResourceManager
 }
 
-// NewMockResourceManager creates a new mock instance
+// NewMockResourceManager creates a new mock instance.
 func NewMockResourceManager(ctrl *gomock.Controller) *MockResourceManager {
 	mock := &MockResourceManager{ctrl: ctrl}
 	mock.recorder = &MockResourceManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResourceManager) EXPECT() *MockResourceManagerMockRecorder {
 	return m.recorder
 }
 
-// Connections mocks base method
+// Connections mocks base method.
 func (m *MockResourceManager) Connections() types.Resource {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Connections")
@@ -968,13 +982,13 @@ func (m *MockResourceManager) Connections() types.Resource {
 	return ret0
 }
 
-// Connections indicates an expected call of Connections
+// Connections indicates an expected call of Connections.
 func (mr *MockResourceManagerMockRecorder) Connections() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connections", reflect.TypeOf((*MockResourceManager)(nil).Connections))
 }
 
-// PendingRequests mocks base method
+// PendingRequests mocks base method.
 func (m *MockResourceManager) PendingRequests() types.Resource {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PendingRequests")
@@ -982,13 +996,13 @@ func (m *MockResourceManager) PendingRequests() types.Resource {
 	return ret0
 }
 
-// PendingRequests indicates an expected call of PendingRequests
+// PendingRequests indicates an expected call of PendingRequests.
 func (mr *MockResourceManagerMockRecorder) PendingRequests() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PendingRequests", reflect.TypeOf((*MockResourceManager)(nil).PendingRequests))
 }
 
-// Requests mocks base method
+// Requests mocks base method.
 func (m *MockResourceManager) Requests() types.Resource {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Requests")
@@ -996,13 +1010,13 @@ func (m *MockResourceManager) Requests() types.Resource {
 	return ret0
 }
 
-// Requests indicates an expected call of Requests
+// Requests indicates an expected call of Requests.
 func (mr *MockResourceManagerMockRecorder) Requests() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Requests", reflect.TypeOf((*MockResourceManager)(nil).Requests))
 }
 
-// Retries mocks base method
+// Retries mocks base method.
 func (m *MockResourceManager) Retries() types.Resource {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Retries")
@@ -1010,36 +1024,36 @@ func (m *MockResourceManager) Retries() types.Resource {
 	return ret0
 }
 
-// Retries indicates an expected call of Retries
+// Retries indicates an expected call of Retries.
 func (mr *MockResourceManagerMockRecorder) Retries() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Retries", reflect.TypeOf((*MockResourceManager)(nil).Retries))
 }
 
-// MockResource is a mock of Resource interface
+// MockResource is a mock of Resource interface.
 type MockResource struct {
 	ctrl     *gomock.Controller
 	recorder *MockResourceMockRecorder
 }
 
-// MockResourceMockRecorder is the mock recorder for MockResource
+// MockResourceMockRecorder is the mock recorder for MockResource.
 type MockResourceMockRecorder struct {
 	mock *MockResource
 }
 
-// NewMockResource creates a new mock instance
+// NewMockResource creates a new mock instance.
 func NewMockResource(ctrl *gomock.Controller) *MockResource {
 	mock := &MockResource{ctrl: ctrl}
 	mock.recorder = &MockResourceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResource) EXPECT() *MockResourceMockRecorder {
 	return m.recorder
 }
 
-// CanCreate mocks base method
+// CanCreate mocks base method.
 func (m *MockResource) CanCreate() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CanCreate")
@@ -1047,51 +1061,13 @@ func (m *MockResource) CanCreate() bool {
 	return ret0
 }
 
-// CanCreate indicates an expected call of CanCreate
+// CanCreate indicates an expected call of CanCreate.
 func (mr *MockResourceMockRecorder) CanCreate() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanCreate", reflect.TypeOf((*MockResource)(nil).CanCreate))
 }
 
-// Increase mocks base method
-func (m *MockResource) Increase() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Increase")
-}
-
-// Increase indicates an expected call of Increase
-func (mr *MockResourceMockRecorder) Increase() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Increase", reflect.TypeOf((*MockResource)(nil).Increase))
-}
-
-// Decrease mocks base method
-func (m *MockResource) Decrease() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Decrease")
-}
-
-// Decrease indicates an expected call of Decrease
-func (mr *MockResourceMockRecorder) Decrease() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Decrease", reflect.TypeOf((*MockResource)(nil).Decrease))
-}
-
-// Max mocks base method
-func (m *MockResource) Max() uint64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Max")
-	ret0, _ := ret[0].(uint64)
-	return ret0
-}
-
-// Max indicates an expected call of Max
-func (mr *MockResourceMockRecorder) Max() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Max", reflect.TypeOf((*MockResource)(nil).Max))
-}
-
-// Cur mocks base method
+// Cur mocks base method.
 func (m *MockResource) Cur() int64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Cur")
@@ -1099,83 +1075,121 @@ func (m *MockResource) Cur() int64 {
 	return ret0
 }
 
-// Cur indicates an expected call of Cur
+// Cur indicates an expected call of Cur.
 func (mr *MockResourceMockRecorder) Cur() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cur", reflect.TypeOf((*MockResource)(nil).Cur))
 }
 
-// UpdateCur mocks base method
+// Decrease mocks base method.
+func (m *MockResource) Decrease() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Decrease")
+}
+
+// Decrease indicates an expected call of Decrease.
+func (mr *MockResourceMockRecorder) Decrease() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Decrease", reflect.TypeOf((*MockResource)(nil).Decrease))
+}
+
+// Increase mocks base method.
+func (m *MockResource) Increase() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Increase")
+}
+
+// Increase indicates an expected call of Increase.
+func (mr *MockResourceMockRecorder) Increase() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Increase", reflect.TypeOf((*MockResource)(nil).Increase))
+}
+
+// Max mocks base method.
+func (m *MockResource) Max() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Max")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// Max indicates an expected call of Max.
+func (mr *MockResourceMockRecorder) Max() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Max", reflect.TypeOf((*MockResource)(nil).Max))
+}
+
+// UpdateCur mocks base method.
 func (m *MockResource) UpdateCur(arg0 int64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateCur", arg0)
 }
 
-// UpdateCur indicates an expected call of UpdateCur
+// UpdateCur indicates an expected call of UpdateCur.
 func (mr *MockResourceMockRecorder) UpdateCur(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCur", reflect.TypeOf((*MockResource)(nil).UpdateCur), arg0)
 }
 
-// MockSimpleCluster is a mock of SimpleCluster interface
+// MockSimpleCluster is a mock of SimpleCluster interface.
 type MockSimpleCluster struct {
 	ctrl     *gomock.Controller
 	recorder *MockSimpleClusterMockRecorder
 }
 
-// MockSimpleClusterMockRecorder is the mock recorder for MockSimpleCluster
+// MockSimpleClusterMockRecorder is the mock recorder for MockSimpleCluster.
 type MockSimpleClusterMockRecorder struct {
 	mock *MockSimpleCluster
 }
 
-// NewMockSimpleCluster creates a new mock instance
+// NewMockSimpleCluster creates a new mock instance.
 func NewMockSimpleCluster(ctrl *gomock.Controller) *MockSimpleCluster {
 	mock := &MockSimpleCluster{ctrl: ctrl}
 	mock.recorder = &MockSimpleClusterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSimpleCluster) EXPECT() *MockSimpleClusterMockRecorder {
 	return m.recorder
 }
 
-// UpdateHosts mocks base method
+// UpdateHosts mocks base method.
 func (m *MockSimpleCluster) UpdateHosts(newHosts []types.Host) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateHosts", newHosts)
 }
 
-// UpdateHosts indicates an expected call of UpdateHosts
+// UpdateHosts indicates an expected call of UpdateHosts.
 func (mr *MockSimpleClusterMockRecorder) UpdateHosts(newHosts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHosts", reflect.TypeOf((*MockSimpleCluster)(nil).UpdateHosts), newHosts)
 }
 
-// MockClusterConfigFactoryCb is a mock of ClusterConfigFactoryCb interface
+// MockClusterConfigFactoryCb is a mock of ClusterConfigFactoryCb interface.
 type MockClusterConfigFactoryCb struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterConfigFactoryCbMockRecorder
 }
 
-// MockClusterConfigFactoryCbMockRecorder is the mock recorder for MockClusterConfigFactoryCb
+// MockClusterConfigFactoryCbMockRecorder is the mock recorder for MockClusterConfigFactoryCb.
 type MockClusterConfigFactoryCbMockRecorder struct {
 	mock *MockClusterConfigFactoryCb
 }
 
-// NewMockClusterConfigFactoryCb creates a new mock instance
+// NewMockClusterConfigFactoryCb creates a new mock instance.
 func NewMockClusterConfigFactoryCb(ctrl *gomock.Controller) *MockClusterConfigFactoryCb {
 	mock := &MockClusterConfigFactoryCb{ctrl: ctrl}
 	mock.recorder = &MockClusterConfigFactoryCbMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClusterConfigFactoryCb) EXPECT() *MockClusterConfigFactoryCbMockRecorder {
 	return m.recorder
 }
 
-// UpdateClusterConfig mocks base method
+// UpdateClusterConfig mocks base method.
 func (m *MockClusterConfigFactoryCb) UpdateClusterConfig(configs []v2.Cluster) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateClusterConfig", configs)
@@ -1183,36 +1197,36 @@ func (m *MockClusterConfigFactoryCb) UpdateClusterConfig(configs []v2.Cluster) e
 	return ret0
 }
 
-// UpdateClusterConfig indicates an expected call of UpdateClusterConfig
+// UpdateClusterConfig indicates an expected call of UpdateClusterConfig.
 func (mr *MockClusterConfigFactoryCbMockRecorder) UpdateClusterConfig(configs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterConfig", reflect.TypeOf((*MockClusterConfigFactoryCb)(nil).UpdateClusterConfig), configs)
 }
 
-// MockClusterHostFactoryCb is a mock of ClusterHostFactoryCb interface
+// MockClusterHostFactoryCb is a mock of ClusterHostFactoryCb interface.
 type MockClusterHostFactoryCb struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterHostFactoryCbMockRecorder
 }
 
-// MockClusterHostFactoryCbMockRecorder is the mock recorder for MockClusterHostFactoryCb
+// MockClusterHostFactoryCbMockRecorder is the mock recorder for MockClusterHostFactoryCb.
 type MockClusterHostFactoryCbMockRecorder struct {
 	mock *MockClusterHostFactoryCb
 }
 
-// NewMockClusterHostFactoryCb creates a new mock instance
+// NewMockClusterHostFactoryCb creates a new mock instance.
 func NewMockClusterHostFactoryCb(ctrl *gomock.Controller) *MockClusterHostFactoryCb {
 	mock := &MockClusterHostFactoryCb{ctrl: ctrl}
 	mock.recorder = &MockClusterHostFactoryCbMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClusterHostFactoryCb) EXPECT() *MockClusterHostFactoryCbMockRecorder {
 	return m.recorder
 }
 
-// UpdateClusterHost mocks base method
+// UpdateClusterHost mocks base method.
 func (m *MockClusterHostFactoryCb) UpdateClusterHost(cluster string, hosts []v2.Host) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateClusterHost", cluster, hosts)
@@ -1220,83 +1234,71 @@ func (m *MockClusterHostFactoryCb) UpdateClusterHost(cluster string, hosts []v2.
 	return ret0
 }
 
-// UpdateClusterHost indicates an expected call of UpdateClusterHost
+// UpdateClusterHost indicates an expected call of UpdateClusterHost.
 func (mr *MockClusterHostFactoryCbMockRecorder) UpdateClusterHost(cluster, hosts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterHost", reflect.TypeOf((*MockClusterHostFactoryCb)(nil).UpdateClusterHost), cluster, hosts)
 }
 
-// MockClusterManagerFilter is a mock of ClusterManagerFilter interface
+// MockClusterManagerFilter is a mock of ClusterManagerFilter interface.
 type MockClusterManagerFilter struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterManagerFilterMockRecorder
 }
 
-// MockClusterManagerFilterMockRecorder is the mock recorder for MockClusterManagerFilter
+// MockClusterManagerFilterMockRecorder is the mock recorder for MockClusterManagerFilter.
 type MockClusterManagerFilterMockRecorder struct {
 	mock *MockClusterManagerFilter
 }
 
-// NewMockClusterManagerFilter creates a new mock instance
+// NewMockClusterManagerFilter creates a new mock instance.
 func NewMockClusterManagerFilter(ctrl *gomock.Controller) *MockClusterManagerFilter {
 	mock := &MockClusterManagerFilter{ctrl: ctrl}
 	mock.recorder = &MockClusterManagerFilterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClusterManagerFilter) EXPECT() *MockClusterManagerFilterMockRecorder {
 	return m.recorder
 }
 
-// OnCreated mocks base method
+// OnCreated mocks base method.
 func (m *MockClusterManagerFilter) OnCreated(cccb types.ClusterConfigFactoryCb, chcb types.ClusterHostFactoryCb) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnCreated", cccb, chcb)
 }
 
-// OnCreated indicates an expected call of OnCreated
+// OnCreated indicates an expected call of OnCreated.
 func (mr *MockClusterManagerFilterMockRecorder) OnCreated(cccb, chcb interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnCreated", reflect.TypeOf((*MockClusterManagerFilter)(nil).OnCreated), cccb, chcb)
 }
 
-// MockRegisterUpstreamUpdateMethodCb is a mock of RegisterUpstreamUpdateMethodCb interface
+// MockRegisterUpstreamUpdateMethodCb is a mock of RegisterUpstreamUpdateMethodCb interface.
 type MockRegisterUpstreamUpdateMethodCb struct {
 	ctrl     *gomock.Controller
 	recorder *MockRegisterUpstreamUpdateMethodCbMockRecorder
 }
 
-// MockRegisterUpstreamUpdateMethodCbMockRecorder is the mock recorder for MockRegisterUpstreamUpdateMethodCb
+// MockRegisterUpstreamUpdateMethodCbMockRecorder is the mock recorder for MockRegisterUpstreamUpdateMethodCb.
 type MockRegisterUpstreamUpdateMethodCbMockRecorder struct {
 	mock *MockRegisterUpstreamUpdateMethodCb
 }
 
-// NewMockRegisterUpstreamUpdateMethodCb creates a new mock instance
+// NewMockRegisterUpstreamUpdateMethodCb creates a new mock instance.
 func NewMockRegisterUpstreamUpdateMethodCb(ctrl *gomock.Controller) *MockRegisterUpstreamUpdateMethodCb {
 	mock := &MockRegisterUpstreamUpdateMethodCb{ctrl: ctrl}
 	mock.recorder = &MockRegisterUpstreamUpdateMethodCbMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRegisterUpstreamUpdateMethodCb) EXPECT() *MockRegisterUpstreamUpdateMethodCbMockRecorder {
 	return m.recorder
 }
 
-// TriggerClusterUpdate mocks base method
-func (m *MockRegisterUpstreamUpdateMethodCb) TriggerClusterUpdate(clusterName string, hosts []v2.Host) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "TriggerClusterUpdate", clusterName, hosts)
-}
-
-// TriggerClusterUpdate indicates an expected call of TriggerClusterUpdate
-func (mr *MockRegisterUpstreamUpdateMethodCbMockRecorder) TriggerClusterUpdate(clusterName, hosts interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerClusterUpdate", reflect.TypeOf((*MockRegisterUpstreamUpdateMethodCb)(nil).TriggerClusterUpdate), clusterName, hosts)
-}
-
-// GetClusterNameByServiceName mocks base method
+// GetClusterNameByServiceName mocks base method.
 func (m *MockRegisterUpstreamUpdateMethodCb) GetClusterNameByServiceName(serviceName string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClusterNameByServiceName", serviceName)
@@ -1304,64 +1306,48 @@ func (m *MockRegisterUpstreamUpdateMethodCb) GetClusterNameByServiceName(service
 	return ret0
 }
 
-// GetClusterNameByServiceName indicates an expected call of GetClusterNameByServiceName
+// GetClusterNameByServiceName indicates an expected call of GetClusterNameByServiceName.
 func (mr *MockRegisterUpstreamUpdateMethodCbMockRecorder) GetClusterNameByServiceName(serviceName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterNameByServiceName", reflect.TypeOf((*MockRegisterUpstreamUpdateMethodCb)(nil).GetClusterNameByServiceName), serviceName)
 }
 
-// MockLBSubsetInfo is a mock of LBSubsetInfo interface
+// TriggerClusterUpdate mocks base method.
+func (m *MockRegisterUpstreamUpdateMethodCb) TriggerClusterUpdate(clusterName string, hosts []v2.Host) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "TriggerClusterUpdate", clusterName, hosts)
+}
+
+// TriggerClusterUpdate indicates an expected call of TriggerClusterUpdate.
+func (mr *MockRegisterUpstreamUpdateMethodCbMockRecorder) TriggerClusterUpdate(clusterName, hosts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerClusterUpdate", reflect.TypeOf((*MockRegisterUpstreamUpdateMethodCb)(nil).TriggerClusterUpdate), clusterName, hosts)
+}
+
+// MockLBSubsetInfo is a mock of LBSubsetInfo interface.
 type MockLBSubsetInfo struct {
 	ctrl     *gomock.Controller
 	recorder *MockLBSubsetInfoMockRecorder
 }
 
-// MockLBSubsetInfoMockRecorder is the mock recorder for MockLBSubsetInfo
+// MockLBSubsetInfoMockRecorder is the mock recorder for MockLBSubsetInfo.
 type MockLBSubsetInfoMockRecorder struct {
 	mock *MockLBSubsetInfo
 }
 
-// NewMockLBSubsetInfo creates a new mock instance
+// NewMockLBSubsetInfo creates a new mock instance.
 func NewMockLBSubsetInfo(ctrl *gomock.Controller) *MockLBSubsetInfo {
 	mock := &MockLBSubsetInfo{ctrl: ctrl}
 	mock.recorder = &MockLBSubsetInfoMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLBSubsetInfo) EXPECT() *MockLBSubsetInfoMockRecorder {
 	return m.recorder
 }
 
-// IsEnabled mocks base method
-func (m *MockLBSubsetInfo) IsEnabled() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsEnabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsEnabled indicates an expected call of IsEnabled
-func (mr *MockLBSubsetInfoMockRecorder) IsEnabled() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEnabled", reflect.TypeOf((*MockLBSubsetInfo)(nil).IsEnabled))
-}
-
-// FallbackPolicy mocks base method
-func (m *MockLBSubsetInfo) FallbackPolicy() types.FallBackPolicy {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FallbackPolicy")
-	ret0, _ := ret[0].(types.FallBackPolicy)
-	return ret0
-}
-
-// FallbackPolicy indicates an expected call of FallbackPolicy
-func (mr *MockLBSubsetInfoMockRecorder) FallbackPolicy() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FallbackPolicy", reflect.TypeOf((*MockLBSubsetInfo)(nil).FallbackPolicy))
-}
-
-// DefaultSubset mocks base method
+// DefaultSubset mocks base method.
 func (m *MockLBSubsetInfo) DefaultSubset() types.SubsetMetadata {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DefaultSubset")
@@ -1369,13 +1355,41 @@ func (m *MockLBSubsetInfo) DefaultSubset() types.SubsetMetadata {
 	return ret0
 }
 
-// DefaultSubset indicates an expected call of DefaultSubset
+// DefaultSubset indicates an expected call of DefaultSubset.
 func (mr *MockLBSubsetInfoMockRecorder) DefaultSubset() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultSubset", reflect.TypeOf((*MockLBSubsetInfo)(nil).DefaultSubset))
 }
 
-// SubsetKeys mocks base method
+// FallbackPolicy mocks base method.
+func (m *MockLBSubsetInfo) FallbackPolicy() types.FallBackPolicy {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FallbackPolicy")
+	ret0, _ := ret[0].(types.FallBackPolicy)
+	return ret0
+}
+
+// FallbackPolicy indicates an expected call of FallbackPolicy.
+func (mr *MockLBSubsetInfoMockRecorder) FallbackPolicy() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FallbackPolicy", reflect.TypeOf((*MockLBSubsetInfo)(nil).FallbackPolicy))
+}
+
+// IsEnabled mocks base method.
+func (m *MockLBSubsetInfo) IsEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsEnabled indicates an expected call of IsEnabled.
+func (mr *MockLBSubsetInfoMockRecorder) IsEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEnabled", reflect.TypeOf((*MockLBSubsetInfo)(nil).IsEnabled))
+}
+
+// SubsetKeys mocks base method.
 func (m *MockLBSubsetInfo) SubsetKeys() []types.SortedStringSetType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubsetKeys")
@@ -1383,50 +1397,36 @@ func (m *MockLBSubsetInfo) SubsetKeys() []types.SortedStringSetType {
 	return ret0
 }
 
-// SubsetKeys indicates an expected call of SubsetKeys
+// SubsetKeys indicates an expected call of SubsetKeys.
 func (mr *MockLBSubsetInfoMockRecorder) SubsetKeys() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubsetKeys", reflect.TypeOf((*MockLBSubsetInfo)(nil).SubsetKeys))
 }
 
-// MockLBOriDstInfo is a mock of LBOriDstInfo interface
+// MockLBOriDstInfo is a mock of LBOriDstInfo interface.
 type MockLBOriDstInfo struct {
 	ctrl     *gomock.Controller
 	recorder *MockLBOriDstInfoMockRecorder
 }
 
-// MockLBOriDstInfoMockRecorder is the mock recorder for MockLBOriDstInfo
+// MockLBOriDstInfoMockRecorder is the mock recorder for MockLBOriDstInfo.
 type MockLBOriDstInfoMockRecorder struct {
 	mock *MockLBOriDstInfo
 }
 
-// NewMockLBOriDstInfo creates a new mock instance
+// NewMockLBOriDstInfo creates a new mock instance.
 func NewMockLBOriDstInfo(ctrl *gomock.Controller) *MockLBOriDstInfo {
 	mock := &MockLBOriDstInfo{ctrl: ctrl}
 	mock.recorder = &MockLBOriDstInfoMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLBOriDstInfo) EXPECT() *MockLBOriDstInfoMockRecorder {
 	return m.recorder
 }
 
-// IsEnabled mocks base method
-func (m *MockLBOriDstInfo) IsEnabled() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsEnabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsEnabled indicates an expected call of IsEnabled
-func (mr *MockLBOriDstInfoMockRecorder) IsEnabled() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEnabled", reflect.TypeOf((*MockLBOriDstInfo)(nil).IsEnabled))
-}
-
-// GetHeader mocks base method
+// GetHeader mocks base method.
 func (m *MockLBOriDstInfo) GetHeader() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHeader")
@@ -1434,8 +1434,22 @@ func (m *MockLBOriDstInfo) GetHeader() string {
 	return ret0
 }
 
-// GetHeader indicates an expected call of GetHeader
+// GetHeader indicates an expected call of GetHeader.
 func (mr *MockLBOriDstInfoMockRecorder) GetHeader() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeader", reflect.TypeOf((*MockLBOriDstInfo)(nil).GetHeader))
+}
+
+// IsEnabled mocks base method.
+func (m *MockLBOriDstInfo) IsEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsEnabled indicates an expected call of IsEnabled.
+func (mr *MockLBOriDstInfoMockRecorder) IsEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEnabled", reflect.TypeOf((*MockLBOriDstInfo)(nil).IsEnabled))
 }

--- a/pkg/proxy/retrystate_test.go
+++ b/pkg/proxy/retrystate_test.go
@@ -24,7 +24,7 @@ import (
 
 	metrics "github.com/rcrowley/go-metrics"
 	"mosn.io/api"
-	"mosn.io/mosn/pkg/config/v2"
+	v2 "mosn.io/mosn/pkg/config/v2"
 	"mosn.io/mosn/pkg/protocol"
 	"mosn.io/mosn/pkg/router"
 	"mosn.io/mosn/pkg/types"

--- a/pkg/stream/http/connpool_test.go
+++ b/pkg/stream/http/connpool_test.go
@@ -67,6 +67,10 @@ func (ci *fakeClusterInfo) ConnectTimeout() time.Duration {
 	return network.DefaultConnectTimeout
 }
 
+func (ci *fakeClusterInfo) IdleTimeout() time.Duration {
+	return 0
+}
+
 func (ci *fakeClusterInfo) ConnBufferLimitBytes() uint32 {
 	return 0
 }

--- a/pkg/stream/xprotocol/mock_test.go
+++ b/pkg/stream/xprotocol/mock_test.go
@@ -160,3 +160,7 @@ func (ci *mockClusterInfo) SourceAddress() net.Addr {
 func (ci *mockClusterInfo) ConnectTimeout() time.Duration {
 	return network.DefaultConnectTimeout
 }
+
+func (ci *mockClusterInfo) IdleTimeout() time.Duration {
+	return 0
+}

--- a/pkg/types/upstream.go
+++ b/pkg/types/upstream.go
@@ -185,6 +185,9 @@ type ClusterInfo interface {
 	// ConectTimeout returns the connect timeout
 	ConnectTimeout() time.Duration
 
+	// IdleTimeout returns the idle timeout
+	IdleTimeout() time.Duration
+
 	// LbOriDstInfo returns the load balancer oridst config
 	LbOriDstInfo() LBOriDstInfo
 

--- a/pkg/upstream/cluster/cluster.go
+++ b/pkg/upstream/cluster/cluster.go
@@ -88,6 +88,11 @@ func newSimpleCluster(clusterConfig v2.Cluster) types.Cluster {
 		info.connectTimeout = network.DefaultConnectTimeout
 	}
 
+	// set IdleTimeout
+	if clusterConfig.IdleTimeout != nil {
+		info.idleTimeout = clusterConfig.IdleTimeout.Duration
+	}
+
 	// tls mng
 	if !info.clusterManagerTLS {
 		mgr, err := mtls.NewTLSClientContextManager(&clusterConfig.TLS)
@@ -179,6 +184,7 @@ type clusterInfo struct {
 	clusterManagerTLS    bool
 	tlsMng               types.TLSClientContextManager
 	connectTimeout       time.Duration
+	idleTimeout          time.Duration
 	lbConfig             v2.IsCluster_LbConfig
 }
 
@@ -229,6 +235,10 @@ func (ci *clusterInfo) LbSubsetInfo() types.LBSubsetInfo {
 
 func (ci *clusterInfo) ConnectTimeout() time.Duration {
 	return ci.connectTimeout
+}
+
+func (ci *clusterInfo) IdleTimeout() time.Duration {
+	return ci.idleTimeout
 }
 
 func (ci *clusterInfo) LbOriDstInfo() types.LBOriDstInfo {

--- a/pkg/upstream/cluster/host.go
+++ b/pkg/upstream/cluster/host.go
@@ -30,6 +30,7 @@ import (
 	"mosn.io/mosn/pkg/log"
 	"mosn.io/mosn/pkg/network"
 	"mosn.io/mosn/pkg/types"
+	"mosn.io/pkg/buffer"
 	"mosn.io/pkg/utils"
 )
 
@@ -138,6 +139,10 @@ func (sh *simpleHost) CreateConnection(context context.Context) types.CreateConn
 	}
 	clientConn := network.NewClientConnection(sh.ClusterInfo().ConnectTimeout(), tlsMng, sh.Address(), nil)
 	clientConn.SetBufferLimit(sh.ClusterInfo().ConnBufferLimitBytes())
+
+	if sh.ClusterInfo().IdleTimeout() > 0 {
+		clientConn.SetIdleTimeout(buffer.ConnReadTimeout, sh.ClusterInfo().IdleTimeout())
+	}
 
 	return types.CreateConnectionData{
 		Connection: clientConn,

--- a/pkg/upstream/cluster/host_test.go
+++ b/pkg/upstream/cluster/host_test.go
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
+	"mosn.io/api"
+	v2 "mosn.io/mosn/pkg/config/v2"
+	"mosn.io/pkg/buffer"
+	"mosn.io/pkg/utils"
+)
+
+// TestCreateConnectionIdleTimeout test the connection idle timeout feature
+func TestCreateConnectionIdleTimeout(t *testing.T) {
+	assert := assert.New(t)
+
+	// create host
+	ctx := context.Background()
+	clusterConf := v2.Cluster{
+		Name:        "mock",
+		ClusterType: v2.SIMPLE_CLUSTER,
+		LbType:      v2.LB_ROUNDROBIN,
+		Hosts: []v2.Host{
+			{
+				HostConfig: v2.HostConfig{
+					Address: "127.0.0.1:10086",
+				},
+			},
+		},
+		IdleTimeout: &api.DurationConfig{
+			Duration: 2 * time.Second,
+		},
+	}
+
+	host := NewSimpleHost(clusterConf.Hosts[0], NewCluster(clusterConf).Snapshot().ClusterInfo())
+	assert.NotNil(host)
+
+	// start mock server
+	server := &countConnServer{
+		address: "127.0.0.1:10086",
+	}
+
+	server.start()
+	defer server.stop()
+
+	// reset read timeout
+	oldConnReadTimeout := buffer.ConnReadTimeout
+	buffer.ConnReadTimeout = 300 * time.Millisecond
+	defer func() {
+		buffer.ConnReadTimeout = oldConnReadTimeout
+	}()
+
+	// create connection
+	checkCountOne := func() bool {
+		count := server.getCount()
+		return count == 1
+	}
+	conn := host.CreateConnection(ctx)
+	conn.Connection.Connect()
+	conn.Connection.Start(ctx)
+
+	// we create a connection to port 10086, so there should be only one connection on server
+	assert.Eventually(checkCountOne, 1*time.Second, 500*time.Millisecond, "expect one connection")
+
+	checkCountZero := func() bool {
+		count := server.getCount()
+		return count == 0
+	}
+	// the connection we created should be closed by idle timeout checker
+	// so there should be no connection on server
+	assert.Eventually(checkCountZero, 3*time.Second, 500*time.Millisecond, "expect non connection")
+}
+
+type countConnServer struct {
+	address  string
+	count    atomic.Int64
+	listener net.Listener
+	stopChan chan struct{}
+}
+
+func newCountConnServer(address string) *countConnServer {
+	return &countConnServer{
+		address:  address,
+		stopChan: make(chan struct{}),
+	}
+}
+
+func (c *countConnServer) start() error {
+	c.stopChan = make(chan struct{})
+	listener, err := net.Listen("tcp4", c.address)
+	if err != nil {
+		return err
+	}
+	c.listener = listener
+
+	utils.GoWithRecover(func() {
+		for {
+			conn, err := c.listener.Accept()
+			if err != nil {
+				break
+			}
+			c.count.Inc()
+			utils.GoWithRecover(func() {
+				defer c.count.Dec()
+				for {
+					conn.SetReadDeadline(time.Now().Add(time.Second * 15))
+
+					var buf = make([]byte, 1024)
+					_, err := conn.Read(buf)
+					if err != nil {
+						return
+					}
+
+					select {
+					case <-c.stopChan:
+						return
+					default:
+					}
+				}
+			}, nil)
+		}
+	}, nil)
+
+	return nil
+}
+
+func (c *countConnServer) getCount() int64 {
+	return c.count.Load()
+}
+
+func (c *countConnServer) stop() {
+	c.listener.Close()
+	close(c.stopChan)
+}


### PR DESCRIPTION
### Issues associated with this PR
Issues: #1904 

### Solutions
按照 Issues 的讨论，需要做的事情主要分为两块

1. 支持在 upstream 上配置 idle timeout
2. idle checker 关闭链接的时候需要修改掉 client 的状态，connpool 在选择 client 的时候，也需要做状态的检查

这个 PR 仅针对第一点做出改动，不涉及第二点，第二点单独拉 PR 进行修改

### UT result
本地通过 make unit-test 跑了单测，所有用例都通过了

### Benchmark
这个 PR 是增加配置设置连接超时断开时间，非核心链路，因此应该不涉及性能这方面

### Code Style
已经确保 go format 执行过了
