### PR TITLE
Upstream/master cloud tp continue

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -169,6 +169,10 @@ func (p *proxy) OnData(buf buffer.IoBuffer) api.FilterStatus {
 		proto, err := stream.SelectStreamFactoryProtocol(p.context, prot, buf.Bytes(), scopes)
 
 		if err == stream.EAGAIN {
+			if p.config.FallbackForUnknownProtocol {
+				p.fallback = true
+				return api.Continue
+			}
 			return api.Stop
 		}
 		if err == stream.FAILED {


### PR DESCRIPTION
透明劫持+行方自定义协议mosn无法探测场景下，希望mosn能够作为一个纯代理，直接透传所有数据。

此需求常见于行方要求做tcp私有协议mosn透明劫持性能压测。