### PR TITLE
[imp]set GO111MODULE=on in the Makefile by default

### DIFF
--- a/build/contrib/builder/binary/Dockerfile
+++ b/build/contrib/builder/binary/Dockerfile
@@ -1,5 +1,0 @@
-FROM golang:1.14.13
-MAINTAINER xiaodong.dxd@alibaba-inc.com,zewen.pzw@alibaba-inc.com,linzhengchun.lzc@alibaba-inc.com
-
-# use go mod vendor mode for build and test
-ENV GO111MODULE=off

--- a/etc/script/report.sh
+++ b/etc/script/report.sh
@@ -5,7 +5,7 @@ echo "" > coverage.txt
 
 for d in $(go list ./pkg/...  | grep -v pkg/networkextention); do
     echo "--------Run test package: $d"
-    GO111MODULE=off go test -gcflags="all=-N -l" -v -coverprofile=profile.out -covermode=atomic $d
+    GO111MODULE=on go test -mod=vendor -gcflags="all=-N -l" -v -coverprofile=profile.out -covermode=atomic $d
     echo "--------Finish test package: $d"
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt
@@ -15,7 +15,7 @@ done
 
 for d in $(go list ./istio/istio152/...); do
     echo "--------Run test package: $d"
-    GO111MODULE=off go test -gcflags="all=-N -l" -v -coverprofile=profile.out -covermode=atomic $d
+    GO111MODULE=on go test -mod=vendor -gcflags="all=-N -l" -v -coverprofile=profile.out -covermode=atomic $d
     echo "--------Finish test package: $d"
     if [ -f profile.out ]; then
 	cat profile.out >> coverage.txt

--- a/test/cases/run_all.sh
+++ b/test/cases/run_all.sh
@@ -21,7 +21,7 @@ function makebuild {
 echo "build mosn binary"
 bin=$(makebuild)
 echo "run test cases"
-GO111MODULE=off go test -tags MOSNTest -failfast -v -p 1 ./... -args -m=$bin
+GO111MODULE=on go test -mod=vendor -tags MOSNTest -failfast -v -p 1 ./... -args -m=$bin
 code=$?
 rm -f ./test_mosn
 if [[ $code -eq 0 ]]; then


### PR DESCRIPTION
### Issues associated with this PR

Your PR should present related issues you want to solve.
#1720
### Solutions
在Makefile中全部启用`GO111MODULE=on`，同时选择使用`golang`镜像，跳过构建中间层的`godep-builder`镜像，`godep-builder`的存在，只是为了在默认`golang`镜像中将`GO111MODULE`设置为`off`，全部启用`GO111MODULE=on`后，就不需要这层中间镜像。

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
