### PR TITLE
fix: update all hosts in strict dns cluster mode(#1994).

### DIFF
--- a/pkg/upstream/cluster/strict_dns_cluster.go
+++ b/pkg/upstream/cluster/strict_dns_cluster.go
@@ -224,7 +224,7 @@ func (sdc *strictDnsCluster) updateDynamicHosts(newHosts []types.Host, rt *Resol
 				log.DefaultLogger.Infof("[upstream] [strict dns cluster] resolve dns new address:%s", h.AddressString())
 			}
 		}
-		sdc.simpleCluster.UpdateHosts(newHosts)
+		sdc.simpleCluster.UpdateHosts(allHosts)
 		if log.DefaultLogger.GetLogLevel() >= log.INFO {
 			log.DefaultLogger.Infof("[upstream] [strict dns cluster] resolve dns result updated, cluster_name:%s, address:%s", sdc.simpleCluster.info.name, rt.dnsAddress)
 		}


### PR DESCRIPTION
### Issues associated with this PR
#1994

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, details and the changes. At this time, Chinese is allowed to describe these.

### UT result

2022-04-07 11:04:41,274 [INFO] [network] [ register pool factory] register protocol: mock factory
=== RUN   TestMultipleDnsHostsInOneCluster
2022-04-07 11:04:41,333 [ERROR] [upstream] resolve addr host1:80 failed: lookup host1: no such host
2022-04-07 11:04:41,404 [ERROR] [upstream] resolve addr host2:80 failed: lookup host2: no such host
--- PASS: TestMultipleDnsHostsInOneCluster (3.13s)
PASS

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
