### PR TITLE
optimize build subset loadbalancer by bitmap

### DIFF
--- a/pkg/mock/upstream.go
+++ b/pkg/mock/upstream.go
@@ -1453,3 +1453,17 @@ func (mr *MockLBOriDstInfoMockRecorder) IsEnabled() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEnabled", reflect.TypeOf((*MockLBOriDstInfo)(nil).IsEnabled))
 }
+
+// IsReplaceLocal mocks base method.
+func (m *MockLBOriDstInfo) IsReplaceLocal() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsReplaceLocal")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsReplaceLocal indicates an expected call of IsReplaceLocal.
+func (mr *MockLBOriDstInfoMockRecorder) IsReplaceLocal() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsReplaceLocal", reflect.TypeOf((*MockLBOriDstInfo)(nil).IsReplaceLocal))
+}

--- a/pkg/upstream/cluster/cluster.go
+++ b/pkg/upstream/cluster/cluster.go
@@ -127,7 +127,11 @@ func (sc *simpleCluster) UpdateHosts(newHosts []types.Host) {
 	// load balance
 	var lb types.LoadBalancer
 	if info.lbSubsetInfo.IsEnabled() {
-		lb = NewSubsetLoadBalancer(info, hostSet)
+		if getSubsetBuildMode() == SubsetPreIndexBuildMode {
+			lb = NewSubsetLoadBalancerPreIndex(info, hostSet)
+		} else {
+			lb = NewSubsetLoadBalancer(info, hostSet)
+		}
 	} else {
 		lb = NewLoadBalancer(info, hostSet)
 	}
@@ -143,7 +147,6 @@ func (sc *simpleCluster) UpdateHosts(newHosts []types.Host) {
 	if sc.healthChecker != nil {
 		sc.healthChecker.SetHealthCheckerHostSet(hostSet)
 	}
-
 }
 
 func (sc *simpleCluster) Snapshot() types.ClusterSnapshot {

--- a/pkg/upstream/cluster/lb_register_test.go
+++ b/pkg/upstream/cluster/lb_register_test.go
@@ -110,27 +110,28 @@ func TestRegisterNewLB(t *testing.T) {
 	// subset is also valid
 	//  reuse subset test config
 	subsetInfo := NewLBSubsetInfo(exampleSubsetConfig())
-	sublb := newSubsetLoadBalancer(headerKey, hs, newClusterStats("test"), subsetInfo)
-	// choose host is valid
-	// 1. ctx contains subset matched config
-	// 2. ctx contains header with key "hostname"
-	// should choose e1 only
-	for i := 0; i < 100; i++ {
-		host := sublb.ChooseHost(ctx)
-		if host == nil || host.Hostname() != "e1" {
-			t.Fatal("choose host not expected, get: ", host)
+	for name, sublb := range newSubsetLoadBalancers(headerKey, hs, newClusterStats("test"), subsetInfo){
+		// choose host is valid
+		// 1. ctx contains subset matched config
+		// 2. ctx contains header with key "hostname"
+		// should choose e1 only
+		for i := 0; i < 100; i++ {
+			host := sublb.ChooseHost(ctx)
+			if host == nil || host.Hostname() != "e1" {
+				t.Fatalf("[%s] choose host not expected, get: %s", name, host)
+			}
 		}
-	}
-	// choose e1,e2,e5
-	for i := 0; i < 100; i++ {
-		host := sublb.ChooseHost(ctx2)
-		if host == nil {
-			t.Fatal("choose host failed")
-		}
-		switch host.Hostname() {
-		case "e1", "e2", "e5":
-		default:
-			t.Fatal("choose host not expected, get: ", host)
+		// choose e1,e2,e5
+		for i := 0; i < 100; i++ {
+			host := sublb.ChooseHost(ctx2)
+			if host == nil {
+				t.Fatalf("[%s] choose host failed", name)
+			}
+			switch host.Hostname() {
+			case "e1", "e2", "e5":
+			default:
+				t.Fatalf("[%s] choose host not expected, get: %s", name, host)
+			}
 		}
 	}
 }

--- a/pkg/upstream/cluster/subset_loadbalancer_builder.go
+++ b/pkg/upstream/cluster/subset_loadbalancer_builder.go
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"golang.org/x/tools/container/intsets"
+	"mosn.io/mosn/pkg/log"
+	"mosn.io/mosn/pkg/types"
+)
+
+type SubsetBuildMode uint8
+
+const (
+	SubsetPreIndexBuildMode SubsetBuildMode = iota
+	SubsetFilterBuildMode
+)
+
+var subsetBuildMode = SubsetPreIndexBuildMode
+
+func SetSubsetBuildMode(mode SubsetBuildMode) {
+	subsetBuildMode = mode
+}
+func getSubsetBuildMode() SubsetBuildMode {
+	return subsetBuildMode
+}
+
+func NewSubsetLoadBalancerPreIndex(info types.ClusterInfo, hostSet types.HostSet) types.LoadBalancer {
+	builder := newSubsetLoadBalancerBuilder(info, hostSet)
+	return builder.Build()
+}
+
+type subsetLoadBalancerBuilder struct {
+	info        types.ClusterInfo
+	indexer     map[string]map[string]*intsets.Sparse
+	hostSet     types.HostSet
+	subSetCount int64
+}
+
+func newSubsetLoadBalancerBuilder(info types.ClusterInfo, hs types.HostSet) *subsetLoadBalancerBuilder {
+	b := &subsetLoadBalancerBuilder{
+		hostSet: hs,
+		info:    info,
+	}
+	b.initIndex()
+	return b
+}
+
+func (b *subsetLoadBalancerBuilder) Build() *subsetLoadBalancer {
+
+	fullLb := NewLoadBalancer(b.info, &hostSet{allHosts: b.filterHosts(nil)})
+	fallbackSubset := b.createFallbackSubset(fullLb)
+	subsets := b.createSubsets()
+	sslb := &subsetLoadBalancer{
+		lbType:         b.info.LbType(),
+		stats:          b.info.Stats(),
+		hostSet:        b.hostSet,
+		fullLb:         fullLb,
+		fallbackSubset: fallbackSubset,
+		subSets:        subsets,
+	}
+	sslb.stats.LBSubsetsCreated.Update(b.subSetCount)
+	return sslb
+}
+
+func (b *subsetLoadBalancerBuilder) initIndex() {
+	subsetInfo := b.info.LbSubsetInfo()
+	keys := subsetMergeKeys(subsetInfo.SubsetKeys(), subsetInfo.DefaultSubset())
+	hosts := b.hostSet.Hosts()
+	indexer := make(map[string]map[string]*intsets.Sparse)
+	for _, key := range keys {
+		valueMap := make(map[string]*intsets.Sparse)
+		indexer[key] = valueMap
+		for i, host := range hosts {
+			value, ok := host.Metadata()[key]
+			if !ok {
+				continue
+			}
+			s, ok := valueMap[value]
+			if !ok {
+				s = &intsets.Sparse{}
+				valueMap[value] = s
+			}
+			s.Insert(i)
+		}
+	}
+	b.indexer = indexer
+}
+
+func (b *subsetLoadBalancerBuilder) createSubsets() types.LbSubsetMap {
+	subSetKeys := b.info.LbSubsetInfo().SubsetKeys()
+	subSets := make(types.LbSubsetMap)
+	for _, subSetKey := range subSetKeys {
+		for _, kvs := range b.metadataCombinations(subSetKey.Keys()) {
+			entry := b.findOrCreateSubset(subSets, kvs, 0)
+			hosts := b.filterHosts(kvs)
+			if len(hosts) > 0 {
+				entry.CreateLoadBalancer(b.info, &hostSet{allHosts: hosts})
+				b.subSetCount++
+			}
+		}
+	}
+	return subSets
+}
+
+func (b *subsetLoadBalancerBuilder) selectHosts(s *intsets.Sparse) []types.Host {
+	if s == nil {
+		return nil
+	}
+	hosts := b.hostSet.Hosts()
+	offsets := make([]int, 0, s.Len())
+	offsets = s.AppendTo(offsets)
+	ret := make([]types.Host, len(offsets))
+	for i, n := range offsets {
+		ret[i] = hosts[n]
+	}
+	return ret
+}
+
+func (b *subsetLoadBalancerBuilder) filterHosts(kvs types.SubsetMetadata) []types.Host {
+	hosts := b.hostSet.Hosts()
+	if len(kvs) == 0 {
+		ret := make([]types.Host, len(hosts))
+		copy(ret, hosts)
+		return ret
+	}
+	var curSet *intsets.Sparse
+	for _, kv := range kvs {
+		key := kv.T1
+		val := kv.T2
+		valueMap, ok := b.indexer[key]
+		if !ok {
+			return make([]types.Host, 0)
+		}
+		set, ok := valueMap[val]
+		if !ok {
+			return make([]types.Host, 0)
+		}
+		if curSet == nil {
+			curSet = &intsets.Sparse{}
+			curSet.Copy(set)
+		} else {
+			curSet.IntersectionWith(set)
+		}
+	}
+	return b.selectHosts(curSet)
+}
+
+func (b *subsetLoadBalancerBuilder) createFallbackSubset(fullLb types.LoadBalancer) *LBSubsetEntryImpl {
+	policy := b.info.LbSubsetInfo().FallbackPolicy()
+	switch policy {
+	case types.NoFallBack:
+		if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
+			log.DefaultLogger.Debugf("[upstream] [subset lb] subset load balancer: fallback is disabled")
+		}
+		return nil
+	case types.AnyEndPoint:
+		return &LBSubsetEntryImpl{
+			children: nil,
+			lb:       fullLb,
+			hostSet:  b.hostSet,
+		}
+	case types.DefaultSubset:
+		subset := &LBSubsetEntryImpl{
+			children: nil,
+		}
+		subset.CreateLoadBalancer(b.info, &hostSet{allHosts: b.filterHosts(b.info.LbSubsetInfo().DefaultSubset())})
+		return subset
+	}
+	return nil
+}
+
+func (b *subsetLoadBalancerBuilder) findOrCreateSubset(subsets types.LbSubsetMap, kvs types.SubsetMetadata, idx uint32) types.LBSubsetEntry {
+	name := kvs[idx].T1
+	value := kvs[idx].T2
+	var entry types.LBSubsetEntry
+
+	if vsMap, ok := subsets[name]; ok {
+		lbEntry, ok := vsMap[value]
+		if !ok {
+			lbEntry = &LBSubsetEntryImpl{
+				children: make(map[string]types.ValueSubsetMap),
+			}
+			vsMap[value] = lbEntry
+			subsets[name] = vsMap
+		}
+		entry = lbEntry
+	} else {
+		entry = &LBSubsetEntryImpl{
+			children: make(map[string]types.ValueSubsetMap),
+		}
+		subsets[name] = types.ValueSubsetMap{
+			value: entry,
+		}
+	}
+	idx++
+	if idx == uint32(len(kvs)) {
+		return entry
+	}
+	return b.findOrCreateSubset(entry.Children(), kvs, idx)
+}
+
+func (b *subsetLoadBalancerBuilder) metadataCombinations(keys []string) []types.SubsetMetadata {
+	/**
+	recursion iter every values to extract kv pairs (full combination)
+	indexer:
+	{
+	    k1: {v1, v2},
+	    k2: {v3},
+	    k3: {v4, v5}
+	    k4: {v6, v7, v8}
+	}
+	keys:
+	[k1, k2, k3]
+	return:
+	[{k1, v1}, {k2, v3}, {k3, v4}]
+	[{k1, v1}, {k2, v3}, {k3, v5}]
+	[{k1, v2}, {k2, v3}, {k3, v4}]
+	[{k1, v2}, {k2, v3}, {k3, v5}]
+	*/
+
+	return b.doMetadataCombination(keys, 0, nil)
+}
+
+func (b *subsetLoadBalancerBuilder) doMetadataCombination(keys []string, idx int, kvs types.SubsetMetadata) []types.SubsetMetadata {
+	key := keys[idx]
+	var ret []types.SubsetMetadata
+	for value := range b.indexer[key] {
+		newkvs := make(types.SubsetMetadata, len(kvs), len(kvs)+1)
+		copy(newkvs, kvs)
+		newkvs = append(newkvs, types.Pair{T1: key, T2: value})
+		if idx+1 < len(keys) {
+			ret = append(ret, b.doMetadataCombination(keys, idx+1, newkvs)...)
+		} else {
+			ret = append(ret, newkvs)
+		}
+	}
+	return ret
+}
+
+func subsetMergeKeys(subSetKeys []types.SortedStringSetType, defaultSubset types.SubsetMetadata) []string {
+	m := make(map[string]struct{})
+	for _, keys := range subSetKeys {
+		for _, key := range keys.Keys() {
+			m[key] = struct{}{}
+		}
+	}
+	for _, pair := range defaultSubset {
+		m[pair.T1] = struct{}{}
+	}
+	ret := make([]string, 0, len(m))
+	for k := range m {
+		ret = append(ret, k)
+	}
+	return ret
+}

--- a/pkg/upstream/cluster/subset_loadbalancer_builder_test.go
+++ b/pkg/upstream/cluster/subset_loadbalancer_builder_test.go
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"mosn.io/mosn/pkg/types"
+)
+
+func TestSubsetLbBuilder_InitIndex(t *testing.T) {
+	subsetInfo := NewLBSubsetInfo(exampleSubsetConfig())
+	hosts := exampleHostConfigs()
+	builder := newSubsetLoadBalancerBuilder(&clusterInfo{lbSubsetInfo: subsetInfo, stats: newClusterStats("test")}, createHostset(hosts))
+	merged := make(map[string]map[string][]int)
+	for i, host := range hosts {
+		for _, key := range subsetMergeKeys(subsetInfo.SubsetKeys(), subsetInfo.DefaultSubset()) {
+			val, ok := host.MetaData[key]
+			if !ok {
+				continue
+			}
+			if _, ok := merged[key]; !ok {
+				merged[key] = make(map[string][]int)
+			}
+			merged[key][val] = append(merged[key][val], i)
+		}
+	}
+	require.Len(t, builder.indexer, len(merged))
+	for key, vals := range merged {
+		require.Len(t, builder.indexer[key], len(vals))
+		for val, hosts := range vals {
+			indexArray := builder.indexer[key][val].AppendTo(nil)
+			require.Equal(t, hosts, indexArray)
+		}
+	}
+}
+
+func TestSubsetLbBuilder_MetadataCombinations(t *testing.T) {
+	subsetInfo := NewLBSubsetInfo(exampleSubsetConfig())
+	builder := newSubsetLoadBalancerBuilder(&clusterInfo{lbSubsetInfo: subsetInfo}, createHostset(exampleHostConfigs()))
+	var kvList []types.SubsetMetadata
+	kvList = builder.metadataCombinations([]string{"version"})
+	// [[{version 1.0}] [{version 1.1}] [{version 1.2-pre}]]
+	require.Len(t, kvList, 3)
+	for _, kvs := range kvList {
+		require.Len(t, kvs, 1)
+	}
+	kvList = builder.metadataCombinations([]string{"stage", "type"})
+	// [[{stage prod} {type bigmem}] [{stage prod} {type std}] [{stage dev} {type std}] [{stage dev} {type bigmem}]]
+	require.Len(t, kvList, 4)
+	for _, kvs := range kvList {
+		require.Len(t, kvs, 2)
+	}
+
+	kvList = builder.metadataCombinations([]string{"stage", "version"})
+	// [[{stage prod} {version 1.0}] [{stage prod} {version 1.1}] [{stage prod} {version 1.2-pre}] [{stage dev} {version 1.0}] [{stage dev} {version 1.1}] [{stage dev} {version 1.2-pre}]]
+	require.Len(t, kvList, 6)
+	for _, kvs := range kvList {
+		require.Len(t, kvs, 2)
+	}
+}
+
+func TestSubsetMergeKeys(t *testing.T) {
+	keys := subsetMergeKeys([]types.SortedStringSetType{
+		types.InitSet([]string{"1", "2", "3"}),
+		types.InitSet([]string{"2", "3", "4"}),
+	}, []types.Pair{
+		{
+			T1: "5",
+			T2: "6",
+		},
+	})
+	require.Len(t, keys, 5)
+}


### PR DESCRIPTION
### Issues associated with this PR

https://github.com/mosn/mosn/issues/2008

### Solutions

https://github.com/mosn/mosn/issues/2008#issuecomment-1097844372

### Benchmark

```go

func BenchmarkSubsetLoadBalancer(b *testing.B) {
	ps := createHostset(benchHostConfigs(8000, 3))
	subsetConfig := benchSubsetConfig()
	b.Run("subsetLoadBalancer", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			newSubsetLoadBalancer(types.RoundRobin, ps, newClusterStats("BenchmarkSubsetLoadBalancer"), NewLBSubsetInfo(subsetConfig))
		}
	})
	b.Run("subsetLoadBalancerPreIndex", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			newSubsetLoadBalancerPreIndex(types.RoundRobin, ps, newClusterStats("BenchmarkSubsetLoadBalancer"), NewLBSubsetInfo(subsetConfig))
		}
	})
}
```

```bash
 dzdx@B-QBDRMD6M-0201  ~/Documents/mosn-open/pkg/upstream/cluster   perf/subsetlb ±✚  go test -bench=^BenchmarkSubsetLoadBalancer . -run=^$ -benchmem 
2022-04-14 18:55:42,662 [INFO] [network] [ register pool factory] register protocol: mock factory
goos: darwin
goarch: amd64
pkg: mosn.io/mosn/pkg/upstream/cluster
BenchmarkSubsetLoadBalancer/subsetLoadBalancer-12                      9         118816550 ns/op        10105291 B/op       7217 allocs/op
BenchmarkSubsetLoadBalancer/subsetLoadBalancerPreIndex-12            246           5452478 ns/op         2427298 B/op      11463 allocs/op
PASS
ok      mosn.io/mosn/pkg/upstream/cluster       4.993s

```


<img width="1579" alt="image" src="https://user-images.githubusercontent.com/7933207/163155137-c6b72ed7-6cf3-4043-b257-ec989d8f216b.png">

|   endpoints | cpu (before) | cpu (after) |  alloc (before) | alloc (after) |
|---|---|---|---|---|
| 20 | 0.23ms | 0.35ms | 65KB | 189KB | 
| 100 | 0.93ms  |  0.38ms | 154KB | 214KB |
|  500 | 8.1ms  | 0.56ms  | 632KB | 322KB |
|  2000 |  27ms | 1.3ms |2.4MB | 738KB |
|  8000 |  102ms | 5.1ms  | 10MB | 2.4MB |


### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
