### PR TITLE
feat: fix bugfix stream

### DIFF
--- a/pkg/stream/http/stream.go
+++ b/pkg/stream/http/stream.go
@@ -548,6 +548,7 @@ func (conn *serverStreamConnection) serve() {
 		s := &buffers.serverStream
 
 		// 4. request processing
+		ctx = mosnctx.WithValue(ctx, types.ContextKeyDownStreamProtocol, protocol.HTTP1)
 		s.stream = stream{
 			id:       id,
 			ctx:      mosnctx.WithValue(ctx, types.ContextKeyStreamID, id),
@@ -567,7 +568,6 @@ func (conn *serverStreamConnection) serve() {
 		if trace.IsEnabled() {
 			tracer := trace.Tracer(protocol.HTTP1)
 			if tracer != nil {
-				ctx = mosnctx.WithValue(ctx, types.ContextKeyDownStreamProtocol, protocol.HTTP1)
 				span = tracer.Start(ctx, s.header, time.Now())
 			}
 		}

--- a/pkg/stream/http/stream.go
+++ b/pkg/stream/http/stream.go
@@ -567,6 +567,7 @@ func (conn *serverStreamConnection) serve() {
 		if trace.IsEnabled() {
 			tracer := trace.Tracer(protocol.HTTP1)
 			if tracer != nil {
+				ctx = mosnctx.WithValue(ctx, types.ContextKeyDownStreamProtocol, protocol.HTTP1)
 				span = tracer.Start(ctx, s.header, time.Now())
 			}
 		}

--- a/pkg/stream/http2/stream.go
+++ b/pkg/stream/http2/stream.go
@@ -460,6 +460,7 @@ func (conn *serverStreamConnection) handleError(ctx context.Context, f http2.Fra
 func (conn *serverStreamConnection) onNewStreamDetect(ctx context.Context, h2s *http2.MStream, endStream bool) (*serverStream, error) {
 	stream := &serverStream{}
 	stream.id = h2s.ID()
+	stream.ctx = mosnctx.WithValue(ctx, types.ContextKeyDownStreamProtocol, protocol.HTTP2)
 	stream.ctx = mosnctx.WithValue(ctx, types.ContextKeyStreamID, stream.id)
 	stream.sc = conn
 	stream.h2s = h2s
@@ -474,7 +475,6 @@ func (conn *serverStreamConnection) onNewStreamDetect(ctx context.Context, h2s *
 		// try build trace span
 		tracer := trace.Tracer(protocol.HTTP2)
 		if tracer != nil {
-			ctx = mosnctx.WithValue(ctx, types.ContextKeyDownStreamProtocol, protocol.HTTP2)
 			span = tracer.Start(ctx, h2s.Request, time.Now())
 		}
 	}

--- a/pkg/stream/http2/stream.go
+++ b/pkg/stream/http2/stream.go
@@ -473,8 +473,8 @@ func (conn *serverStreamConnection) onNewStreamDetect(ctx context.Context, h2s *
 	if trace.IsEnabled() {
 		// try build trace span
 		tracer := trace.Tracer(protocol.HTTP2)
-
 		if tracer != nil {
+			ctx = mosnctx.WithValue(ctx, types.ContextKeyDownStreamProtocol, protocol.HTTP2)
 			span = tracer.Start(ctx, h2s.Request, time.Now())
 		}
 	}


### PR DESCRIPTION
### Issues associated with this PR
当 tracer 支持 HTTP2&HTTP1&xprotocol ，创建 tracer 无法通过 ctx 获取正确的 protocol 协议导致panic。


### Solutions
本质问题 在创建stream 到 prxoy 之前，由于 ctx 中的 downstream 没有初始化，导致期间无法通过 ctx 获取协议。
参考 xprotocol 实现，在创建 ctx 时候进行 初始化协议名称。


