### PR TITLE
add subset lb interface

### DIFF
--- a/pkg/types/loadbalancer.go
+++ b/pkg/types/loadbalancer.go
@@ -72,6 +72,12 @@ type LoadBalancerContext interface {
 	DownstreamRoute() api.Route
 }
 
+const (
+	AllHostMetaKey  = "MOSN-Subset-All"
+	FallbackMetaKey = "MOSN-Subset-Fallback"
+	MetaKeySep      = "->"
+)
+
 // SubsetLoadBalancer is a special LoadBalancer
 // consisting of a set of LoadBalancers
 type SubsetLoadBalancer interface {
@@ -79,7 +85,8 @@ type SubsetLoadBalancer interface {
 	// LoadBalancers returns all load balancers in
 	// the subset load balancer, include load balancers
 	// in subset tree and fallback load balancers.
-	LoadBalancers() []LoadBalancer
+	// the key is metadata information string
+	LoadBalancers() map[string]LoadBalancer
 }
 
 // LBSubsetEntry is a entry that stored in the subset hierarchy.

--- a/pkg/types/loadbalancer.go
+++ b/pkg/types/loadbalancer.go
@@ -72,6 +72,16 @@ type LoadBalancerContext interface {
 	DownstreamRoute() api.Route
 }
 
+// SubsetLoadBalancer is a special LoadBalancer
+// consisting of a set of LoadBalancers
+type SubsetLoadBalancer interface {
+	LoadBalancer
+	// LoadBalancers returns all load balancers in
+	// the subset load balancer, include load balancers
+	// in subset tree and fallback load balancers.
+	LoadBalancers() []LoadBalancer
+}
+
 // LBSubsetEntry is a entry that stored in the subset hierarchy.
 type LBSubsetEntry interface {
 	// Initialized returns the entry is initialized or not.

--- a/pkg/upstream/cluster/cluster_test.go
+++ b/pkg/upstream/cluster/cluster_test.go
@@ -59,7 +59,7 @@ func TestClusterUpdateHosts(t *testing.T) {
 	// verify
 	snap := cluster.Snapshot()
 	subLb := snap.LoadBalancer().(*subsetLoadBalancer)
-	if subLb.fallbackSubset.hostSet.Size() != 40 {
+	if subLb.fallbackSubset.HostNum() != 40 {
 		t.Fatal("default fallback should be all hosts")
 	}
 	result := &subSetMapResult{
@@ -99,7 +99,7 @@ func TestClusterUpdateHosts(t *testing.T) {
 	newSnap := cluster.Snapshot()
 	newSubLb := newSnap.LoadBalancer().(*subsetLoadBalancer)
 	// verify
-	if newSubLb.fallbackSubset.hostSet.Size() != 60 {
+	if newSubLb.fallbackSubset.HostNum() != 60 {
 		t.Fatal("default fallback should be all hosts")
 	}
 	newResult := &subSetMapResult{

--- a/pkg/upstream/cluster/subset_loadbalancer.go
+++ b/pkg/upstream/cluster/subset_loadbalancer.go
@@ -251,7 +251,7 @@ func (sslb *subsetLoadBalancer) LoadBalancers() map[string]types.LoadBalancer {
 	lbs := map[string]types.LoadBalancer{
 		types.AllHostMetaKey: sslb.fullLb,
 	}
-	lbs = TraversalLbSubsetMap(lbs, "", sslb.subSets)
+	TraversalLbSubsetMap(lbs, "", sslb.subSets)
 
 	if sslb.fallbackSubset != nil {
 		lbs[types.FallbackMetaKey] = sslb.fallbackSubset.LoadBalancer()
@@ -261,21 +261,21 @@ func (sslb *subsetLoadBalancer) LoadBalancers() map[string]types.LoadBalancer {
 
 // TraversalLbSubsetMap returns all load balancers in subset tree.
 // The map key format is
-// metakey:metavalue -> metakey: metavalue...
-func TraversalLbSubsetMap(lbs map[string]types.LoadBalancer, prefix string, subsetMap types.LbSubsetMap) map[string]types.LoadBalancer {
+// metakey:metavalue->metakey:metavalue...
+func TraversalLbSubsetMap(lbs map[string]types.LoadBalancer, prefix string, subsetMap types.LbSubsetMap) {
 	for key, vm := range subsetMap {
 		for v, entry := range vm {
 			p := prefix + key + ":" + v
 			child := entry.Children()
 			if child != nil {
-				lbs = TraversalLbSubsetMap(lbs, p+types.MetaKeySep, child)
+				TraversalLbSubsetMap(lbs, p+types.MetaKeySep, child)
 			}
 			if entry.Initialized() {
 				lbs[p] = entry.LoadBalancer()
 			}
 		}
 	}
-	return lbs
+	return
 }
 
 // if subsetKeys are all contained in the host metadata

--- a/pkg/upstream/cluster/subset_loadbalancer.go
+++ b/pkg/upstream/cluster/subset_loadbalancer.go
@@ -36,7 +36,7 @@ type subsetLoadBalancer struct {
 	fullLb         types.LoadBalancer // a loadbalancer for all hosts
 }
 
-func NewSubsetLoadBalancer(info types.ClusterInfo, hostSet types.HostSet) types.LoadBalancer {
+func NewSubsetLoadBalancer(info types.ClusterInfo, hostSet types.HostSet) types.SubsetLoadBalancer {
 	subsetInfo := info.LbSubsetInfo()
 	subsetLB := &subsetLoadBalancer{
 		lbType:  info.LbType(),
@@ -243,6 +243,37 @@ func (sslb *subsetLoadBalancer) findOrCreateSubset(subsets types.LbSubsetMap, kv
 	return sslb.findOrCreateSubset(entry.Children(), kvs, idx)
 }
 
+// LoadBalancers returns all load balancers in the subset load balancer.
+// the max load balancers count equals fallback lb，full lb
+// and load balancers in subset tree.
+func (sslb *subsetLoadBalancer) LoadBalancers() []types.LoadBalancer {
+
+	lbs := []types.LoadBalancer{
+		sslb.fullLb,
+	}
+	lbs = TraversalLbSubsetMap(lbs, sslb.subSets)
+
+	if sslb.fallbackSubset != nil {
+		lbs = append(lbs, sslb.fallbackSubset.LoadBalancer())
+	}
+	return lbs
+}
+
+func TraversalLbSubsetMap(lbs []types.LoadBalancer, subsetMap types.LbSubsetMap) []types.LoadBalancer {
+	for _, vm := range subsetMap {
+		for _, entry := range vm {
+			child := entry.Children()
+			if child != nil {
+				lbs = TraversalLbSubsetMap(lbs, child)
+			}
+			if entry.Initialized() {
+				lbs = append(lbs, entry.LoadBalancer())
+			}
+		}
+	}
+	return lbs
+}
+
 // if subsetKeys are all contained in the host metadata
 func ExtractSubsetMetadata(subsetKeys []string, metadata api.Metadata, kvs types.SubsetMetadata) types.SubsetMetadata {
 	for _, key := range subsetKeys {
@@ -293,12 +324,12 @@ func (entry *LBSubsetEntryImpl) Initialized() bool {
 }
 
 func (entry *LBSubsetEntryImpl) Active() bool {
-	return entry.hostSet != nil && entry.hostSet.Size() != 0
+	return entry.HostNum() > 0
 }
 
 func (entry *LBSubsetEntryImpl) HostNum() int {
-	if entry.hostSet != nil {
-		return entry.hostSet.Size()
+	if entry.lb != nil {
+		return entry.lb.HostNum(nil)
 	}
 	return 0
 }


### PR DESCRIPTION
新增SubsetLoadBalancer的 所有LB 遍历获取的能力，包含subset 树节点、fallback的节点、默认全部机器的节点