### PR TITLE
修复协议转换的 panic 问题

### DIFF
--- a/pkg/filter/stream/transcoder/README.md
+++ b/pkg/filter/stream/transcoder/README.md
@@ -1,0 +1,31 @@
+##  Api 介绍
+
+- 实现Transcoder接口
+
+```go
+type Transcoder interface {
+	// Accept
+	Accept(ctx context.Context, headers api.HeaderMap, buf api.IoBuffer, trailers api.HeaderMap) bool
+	// TranscodingRequest
+	TranscodingRequest(ctx context.Context, headers api.HeaderMap, buf api.IoBuffer, trailers api.HeaderMap) (api.HeaderMap, api.IoBuffer, api.HeaderMap, error)
+	// TranscodingResponse
+	TranscodingResponse(ctx context.Context, headers api.HeaderMap, buf api.IoBuffer, trailers api.HeaderMap) (api.HeaderMap, api.IoBuffer, api.HeaderMap, error)
+}
+```
+
+Transcoder的接口实现如上，包含三方面内容：<br />
+一、实现Accept方法，要求返回一个bool类型，表示是否进行协议转换，false表示不进行协议转换。<br />
+二、实现TranscodingRequest方法，对请求报文的headers、buf、trailers做转换，返回新协议报文的headers、buf、trailers。<br />
+三、实现TranscodingResponse方法，对响应报文的headers、buf、trailers做转换，返回新协议报文的headers、buf、trailers。
+
+- 实现 LoadTranscoderFactory 方法
+```go
+func LoadTranscoderFactory(cfg map[string]interface{}) transcoder.Transcoder {
+	return &xr2sp{cfg: cfg}
+}
+```
+
+- TranscodingResponse 异常状态返回规范
+   在协议转换失败会存在两类场景，场景一 :下游不健康，导致没有收到响应;场景二 :收到响应解码转换失败。开发者都需要反馈对应协议的异常报文结构返回。如果返回的为 nil，nil，nil，err。可能会导致客户端无法收到响应。
+
+## 综上所述：TranscodingResponse 返回的结果为与请求相同协议的响应包

--- a/pkg/filter/stream/transcoder/README.md
+++ b/pkg/filter/stream/transcoder/README.md
@@ -16,7 +16,8 @@ type Transcoder interface {
 Transcoder的接口实现如上，包含三方面内容：<br />
 一、实现Accept方法，要求返回一个bool类型，表示是否进行协议转换，false表示不进行协议转换。<br />
 二、实现TranscodingRequest方法，对请求报文的headers、buf、trailers做转换，返回新协议报文的headers、buf、trailers。<br />
-三、实现TranscodingResponse方法，对响应报文的headers、buf、trailers做转换，返回新协议报文的headers、buf、trailers。
+三、实现TranscodingResponse方法，对响应报文的headers、buf、trailers做转换，返回新协议报文的headers、buf、trailers。在协议转换失败会存在两类场景，场景一 :下游不健康，导致没有收到响应;场景二 :收到响应解码转换失败。开发者都需要反馈对应协议的异常报文结构返回。如果返回的为 nil，nil，nil，err。可能会导致客户端无法收到响应。
+
 
 - 实现 LoadTranscoderFactory 方法
 ```go
@@ -25,7 +26,3 @@ func LoadTranscoderFactory(cfg map[string]interface{}) transcoder.Transcoder {
 }
 ```
 
-- TranscodingResponse 异常状态返回规范
-   在协议转换失败会存在两类场景，场景一 :下游不健康，导致没有收到响应;场景二 :收到响应解码转换失败。开发者都需要反馈对应协议的异常报文结构返回。如果返回的为 nil，nil，nil，err。可能会导致客户端无法收到响应。
-
-## 综上所述：TranscodingResponse 返回的结果为与请求相同协议的响应包


### PR DESCRIPTION
bolt 转 springcloud 场景

情况一：请求转换成功，mosn 处理失败报 404， 服务panic。 原因 请求报文 已经从 bolt 转位 springcloud，失败处理流程无法处理 springcloud 请求报文。正确的报文应该为 bolt 请求体。 

情况一：请求转换成功，收到对端响应，协议转换失败， 服务panic。 原因 请求报文 已经从 bolt 转位 springcloud，失败处理流程无法处理 springcloud 响应报文。正确的报文应该为 bolt 请求体/或者 bolt 的响应体。



针对上述情况处理流程为

协议转换 无论是处理成功还是失败，返回的 outHeaders, outBuf, outTrailers 数据不为空，需要更新到 receiveHandler 结构中。


保持开源兼容性：
判断返回数据不为空，才会生效。