### PR TITLE
Fix spelling error for `matcher` #2069

### DIFF
--- a/pkg/filter/stream/transcoder/config.go
+++ b/pkg/filter/stream/transcoder/config.go
@@ -58,14 +58,14 @@ func parseConfig(cfg interface{}) (*config, error) {
 	}
 	for _, rc := range filterConfig.RuleConfigs {
 		filterConfig.Rules = append(filterConfig.Rules, &matcher.TransferRule{
-			Macther:  matcher.NewMatcher(rc.MatcherConfig),
+			Matcher:  matcher.NewMatcher(rc.MatcherConfig),
 			RuleInfo: rc.RuleInfo,
 		})
 	}
 
 	if filterConfig.Type != "" {
 		filterConfig.Rules = append(filterConfig.Rules, &matcher.TransferRule{
-			Macther: &simplematcher.SimpleRuleMatcher{},
+			Matcher: &simplematcher.SimpleRuleMatcher{},
 			RuleInfo: &matcher.RuleInfo{
 				Type: filterConfig.Type,
 			},

--- a/pkg/filter/stream/transcoder/http2bolt/http2bolt_simple_test.go
+++ b/pkg/filter/stream/transcoder/http2bolt/http2bolt_simple_test.go
@@ -156,7 +156,7 @@ func Test_http2bolt_TranscodingResponse(t1 *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "normal_nternal_server_error",
+			name: "normal_internal_server_error",
 			args: args{
 				ctx:      context.Background(),
 				headers:  bolt.NewRpcResponse(0, bolt.ResponseStatusServerException, protocol.CommonHeader(map[string]string{"service": "test", "scene": "ut"}), buffer.NewIoBufferString("Test_http2bolt_TranscodingResponse")),

--- a/pkg/filter/stream/transcoder/matcher/config.go
+++ b/pkg/filter/stream/transcoder/matcher/config.go
@@ -28,7 +28,7 @@ type RuleMatcher interface {
 }
 
 type TransferRuleConfig struct {
-	MatcherConfig *MatcherConfig `json:"macther_config,omitempty"`
+	MatcherConfig *MatcherConfig `json:"matcher_config,omitempty"`
 	RuleInfo      *RuleInfo      `json:"rule_info,omitempty"`
 }
 
@@ -52,6 +52,6 @@ func (ri *RuleInfo) GetType(srcPro api.ProtocolName) string {
 }
 
 type TransferRule struct {
-	Macther  RuleMatcher
+	Matcher  RuleMatcher
 	RuleInfo *RuleInfo
 }

--- a/pkg/filter/stream/transcoder/matcher/factory.go
+++ b/pkg/filter/stream/transcoder/matcher/factory.go
@@ -23,18 +23,18 @@ import (
 
 type MatcherFactory func(config interface{}) RuleMatcher
 
-// macther factory
-var mactherFactoryMaps = make(map[string]MatcherFactory)
+// matcher factory
+var matcherFactoryMaps = make(map[string]MatcherFactory)
 
 func RegisterMatcherFatcory(typ string, factory MatcherFactory) {
-	if mactherFactoryMaps[typ] != nil {
+	if matcherFactoryMaps[typ] != nil {
 		log.DefaultLogger.Fatalf("[stream filter][transcoder][matcher]target stream matcher already exists: %s", typ)
 	}
-	mactherFactoryMaps[typ] = factory
+	matcherFactoryMaps[typ] = factory
 }
 
 func NewMatcher(cfg *MatcherConfig) RuleMatcher {
-	mf := mactherFactoryMaps[cfg.MatcherType]
+	mf := matcherFactoryMaps[cfg.MatcherType]
 	if mf == nil {
 		log.DefaultLogger.Errorf("[stream filter][transcoder][matcher]target stream matcher not exists: %s", cfg.MatcherType)
 		return nil

--- a/pkg/filter/stream/transcoder/matcher/transcoder_matches.go
+++ b/pkg/filter/stream/transcoder/matcher/transcoder_matches.go
@@ -37,10 +37,10 @@ func MustRegister(matches TransCoderMatchesFunc) {
 
 func DefaultMatches(ctx context.Context, header api.HeaderMap, rules []*TransferRule) (*RuleInfo, bool) {
 	for _, rule := range rules {
-		if rule.Macther == nil {
+		if rule.Matcher == nil {
 			continue
 		}
-		if rule.Macther.Matches(ctx, header) {
+		if rule.Matcher.Matches(ctx, header) {
 			return rule.RuleInfo, true
 		}
 	}

--- a/pkg/filter/stream/transcoder/simplematcher/simple_matcher_test.go
+++ b/pkg/filter/stream/transcoder/simplematcher/simple_matcher_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestSimpleMatcher(t *testing.T) {
 	type fields struct {
-		Macther matcher.RuleMatcher
+		Matcher matcher.RuleMatcher
 	}
 	type args struct {
 		ctx     context.Context
@@ -46,7 +46,7 @@ func TestSimpleMatcher(t *testing.T) {
 		{
 			name: "TestSimpleMatcher_match",
 			fields: fields{
-				Macther: matcher.NewMatcher(&matcher.MatcherConfig{
+				Matcher: matcher.NewMatcher(&matcher.MatcherConfig{
 					MatcherType: "simpleMatcher",
 				}),
 			},
@@ -60,7 +60,7 @@ func TestSimpleMatcher(t *testing.T) {
 		{
 			name: "TestSimpleMatcher_no_match",
 			fields: fields{
-				Macther: matcher.NewMatcher(&matcher.MatcherConfig{
+				Matcher: matcher.NewMatcher(&matcher.MatcherConfig{
 					MatcherType: "simpleMatcher2",
 				}),
 			},
@@ -73,12 +73,12 @@ func TestSimpleMatcher(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.fields.Macther
+			got := tt.fields.Matcher
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Matches() got = %v, want %v", tt.fields.Macther, tt.want)
+				t.Errorf("Matches() got = %v, want %v", tt.fields.Matcher, tt.want)
 			}
-			if tt.fields.Macther != nil {
-				got1 := tt.fields.Macther.Matches(tt.args.ctx, tt.args.headers)
+			if tt.fields.Matcher != nil {
+				got1 := tt.fields.Matcher.Matches(tt.args.ctx, tt.args.headers)
 				if !reflect.DeepEqual(got1, tt.want1) {
 					t.Errorf("Matches() got = %v, want %v", got1, tt.want1)
 				}
@@ -102,7 +102,7 @@ func TestDefaultMatches(t *testing.T) {
 		{
 			name: "TestDefaultMatches_no_header_match",
 			rules: []*matcher.TransferRule{{
-				Macther: matcher.NewMatcher(&matcher.MatcherConfig{
+				Matcher: matcher.NewMatcher(&matcher.MatcherConfig{
 					MatcherType: "simpleMatcher",
 				}),
 				RuleInfo: &matcher.RuleInfo{
@@ -122,7 +122,7 @@ func TestDefaultMatches(t *testing.T) {
 		{
 			name: "TestDefaultMatches_header_match",
 			rules: []*matcher.TransferRule{{
-				Macther: matcher.NewMatcher(&matcher.MatcherConfig{
+				Matcher: matcher.NewMatcher(&matcher.MatcherConfig{
 					MatcherType: "simpleMatcher",
 					Config: map[string]interface{}{
 						"name":  "serviceCode",
@@ -146,7 +146,7 @@ func TestDefaultMatches(t *testing.T) {
 		{
 			name: "TestDefaultMatches_header_no_match",
 			rules: []*matcher.TransferRule{{
-				Macther: matcher.NewMatcher(&matcher.MatcherConfig{
+				Matcher: matcher.NewMatcher(&matcher.MatcherConfig{
 					MatcherType: "simpleMatcher",
 					Config: map[string]interface{}{
 						"name":  "serviceCode",

--- a/pkg/router/configutility.go
+++ b/pkg/router/configutility.go
@@ -81,7 +81,7 @@ func NewKeyValueData(header v2.HeaderMatcher) (*KeyValueData, error) {
 	if header.Regex {
 		p, err := regexp.Compile(header.Value)
 		if err != nil {
-			log.DefaultLogger.Errorf("parse route header macther config failed, ignore it, error: %v", err)
+			log.DefaultLogger.Errorf("parse route header matcher config failed, ignore it, error: %v", err)
 			return nil, err
 		}
 		kvData.Value.RegexPattern = p
@@ -89,7 +89,7 @@ func NewKeyValueData(header v2.HeaderMatcher) (*KeyValueData, error) {
 	return kvData, nil
 }
 
-// commonHeaderMatcherImpl implements a simple types.HeaderMacther
+// commonHeaderMatcherImpl implements a simple types.HeaderMatcher
 type commonHeaderMatcherImpl []*KeyValueData
 
 func (m commonHeaderMatcherImpl) Get(i int) api.KeyValueMatchCriterion {

--- a/pkg/router/routers_impl_test.go
+++ b/pkg/router/routers_impl_test.go
@@ -415,9 +415,9 @@ func TestAddRouter(t *testing.T) {
 	if err != nil {
 		t.Fatal("create routers failed")
 	}
-	macther := rm.(*routersImpl)
-	vh := macther.virtualHosts[0].(*VirtualHostImpl)
-	defaultVh := macther.virtualHosts[1].(*VirtualHostImpl)
+	matcher := rm.(*routersImpl)
+	vh := matcher.virtualHosts[0].(*VirtualHostImpl)
+	defaultVh := matcher.virtualHosts[1].(*VirtualHostImpl)
 	if len(vh.routes) != 0 || len(defaultVh.routes) != 0 {
 		t.Fatal("expected a no routes matcher")
 	}
@@ -481,9 +481,9 @@ func TestRemoveAllRoutes(t *testing.T) {
 	if err != nil {
 		t.Fatal("create routers failed")
 	}
-	macther := rm.(*routersImpl)
-	vh := macther.virtualHosts[0].(*VirtualHostImpl)
-	defaultVh := macther.virtualHosts[1].(*VirtualHostImpl)
+	matcher := rm.(*routersImpl)
+	vh := matcher.virtualHosts[0].(*VirtualHostImpl)
+	defaultVh := matcher.virtualHosts[1].(*VirtualHostImpl)
 	if len(vh.routes) != 1 || len(defaultVh.routes) != 1 {
 		t.Fatal("expected exists routes matcher")
 	}

--- a/pkg/router/rpc_rule.go
+++ b/pkg/router/rpc_rule.go
@@ -76,7 +76,7 @@ func (srri *RPCRouteRuleImpl) Match(ctx context.Context, headers api.HeaderMap) 
 		}
 	}
 	if log.Proxy.GetLogLevel() >= log.DEBUG {
-		log.Proxy.Debugf(ctx, RouterLogFormat, "Match", "sofa rotue rule", fmt.Sprintf("failed to match, macther %s", srri.fastmatch))
+		log.Proxy.Debugf(ctx, RouterLogFormat, "Match", "sofa route rule", fmt.Sprintf("failed to match, matcher %s", srri.fastmatch))
 	}
 	return nil
 }


### PR DESCRIPTION
### Issues associated with this PR

Fix #2069

### Solutions
Fix spelling error

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
