### PR TITLE
Downgrade log level

### DIFF
--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -593,7 +593,7 @@ func (s *downStream) receive(ctx context.Context, id uint32, phase types.Phase) 
 				return p
 			}
 
-			if log.Proxy.GetLogLevel() >= log.DEBUG {
+			if log.Proxy.GetLogLevel() >= log.TRACE {
 				log.Proxy.Debugf(s.context, "[proxy] [downstream] OnReceive send downstream response %+v", s.downstreamRespHeaders)
 			}
 

--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -376,7 +376,7 @@ func (s *downStream) OnReceive(ctx context.Context, headers types.HeaderMap, dat
 	s.downstreamReqTrailers = trailers
 	s.tracks = track.TrackBufferByContext(ctx).Tracks
 
-	if log.Proxy.GetLogLevel() >= log.DEBUG {
+	if log.Proxy.GetLogLevel() >= log.TRACE {
 		log.Proxy.Debugf(s.context, "[proxy] [downstream] OnReceive headers:%+v, data:%+v, trailers:%+v", headers, data, trailers)
 	}
 

--- a/pkg/proxy/upstream.go
+++ b/pkg/proxy/upstream.go
@@ -114,7 +114,7 @@ func (r *upstreamRequest) OnReceive(ctx context.Context, headers types.HeaderMap
 	r.downStream.downstreamRespDataBuf = data
 	r.downStream.downstreamRespTrailers = trailers
 
-	if log.Proxy.GetLogLevel() >= log.DEBUG {
+	if log.Proxy.GetLogLevel() >= log.TRACE {
 		log.Proxy.Debugf(r.downStream.context, "[proxy] [upstream] OnReceive headers: %+v, data: %+v, trailers: %+v", headers, data, trailers)
 	}
 
@@ -157,7 +157,7 @@ func (r *upstreamRequest) appendHeaders(endStream bool) {
 	if r.downStream.processDone() {
 		return
 	}
-	if log.Proxy.GetLogLevel() >= log.DEBUG {
+	if log.Proxy.GetLogLevel() >= log.TRACE {
 		log.Proxy.Debugf(r.downStream.context, "[proxy] [upstream] append headers: %+v", r.downStream.downstreamReqHeaders)
 	}
 	r.sendComplete = endStream

--- a/pkg/router/routers_impl.go
+++ b/pkg/router/routers_impl.go
@@ -109,7 +109,7 @@ func (ri *routersImpl) MatchAllRoutes(ctx context.Context, headers api.HeaderMap
 }
 
 func (ri *routersImpl) MatchRouteFromHeaderKV(ctx context.Context, headers api.HeaderMap, key string, value string) api.Route {
-	if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
+	if log.DefaultLogger.GetLogLevel() >= log.TRACE {
 		log.DefaultLogger.Debugf(RouterLogFormat, "routers", "MatchRouteFromHeaderKV", headers)
 	}
 	virtualHost := ri.findVirtualHost(ctx)


### PR DESCRIPTION
### Issues associated with this PR
debug级别日志打印协议头和body 导致日志量太大
### Solutions
降低日志级别从debug到trace，这些大的数据在需要是设置日志级别为trace来看

