### PR TITLE
支持 connpool_binding 的 GoAway

### DIFF
--- a/pkg/stream/xprotocol/connpool_binding.go
+++ b/pkg/stream/xprotocol/connpool_binding.go
@@ -309,9 +309,11 @@ func (ac *activeClientBinding) OnEvent(event api.ConnectionEvent) {
 
 	if communicationFailure && ac.downstreamConn != nil {
 		// if connection go away and all requests are handled ,we do not need to close the downstream
-		if atomic.LoadUint32(&ac.goaway) != GoAway || ac.codecClient.ActiveRequestsNum() > 0 {
-			ac.downstreamConn.Close(api.NoFlush, api.LocalClose)
+		if atomic.LoadUint32(&ac.goaway) == GoAway && ac.codecClient.ActiveRequestsNum() == 0 {
+			return
 		}
+
+		ac.downstreamConn.Close(api.NoFlush, api.LocalClose)
 	}
 }
 

--- a/pkg/stream/xprotocol/connpool_binding_test.go
+++ b/pkg/stream/xprotocol/connpool_binding_test.go
@@ -177,3 +177,72 @@ func TestUpperClose(t *testing.T) {
 	// close the connpool should not panic
 	pInst.Close()
 }
+
+func TestUpperGoAway(t *testing.T) {
+
+	ctx := variable.NewVariableContext(context.Background())
+
+	var addr = "127.0.0.1:10086"
+	go server.start(t, addr)
+	defer server.stop(t)
+	// wait for server to start
+	time.Sleep(time.Second * 2)
+
+	cl := basicCluster(addr, []string{addr})
+	host := cluster.NewSimpleHost(cl.Hosts[0], cluster.NewCluster(cl).Snapshot().ClusterInfo())
+
+	p := &connpool{
+		protocol: api.ProtocolName(dubbo.ProtocolName),
+		tlsHash:  &types.HashValue{},
+		codec:    &dubbo.XCodec{},
+	}
+	p.host.Store(host)
+
+	var pool = NewPoolBinding(p)
+	var pInst = pool.(*poolBinding)
+
+	sConn, err := net.Dial("tcp4", addr)
+	assert.Nil(t, err)
+
+	var sstopChan = make(chan struct{})
+	sConnI := network.NewServerConnection(context.Background(), sConn, sstopChan)
+
+	ctx = mosnctx.WithValue(ctx, types.ContextKeyConnection, sConnI)
+	ctx = mosnctx.WithValue(ctx, types.ContextKeyConnectionID, sConnI.ID())
+
+	host, _, failReason := pInst.NewStream(ctx, nil)
+	assert.Equal(t, failReason, types.PoolFailureReason(""))
+	assert.NotNil(t, pInst.idleClients[sConnI.ID()])
+
+	cb1 := pInst.idleClients[sConnI.ID()]
+
+	// upstream goaway and downstream should be active
+	pInst.idleClients[sConnI.ID()].OnGoAway()
+	assert.Nil(t, pInst.idleClients[sConnI.ID()])
+	assert.Equal(t, sConnI.State(), api.ConnActive)
+
+	// after goaway , upstream close will not affect the downstream
+	cb1.Close(errors.New("closeclose"))
+	assert.Equal(t, sConnI.State(), api.ConnActive)
+
+	// after goaway , we can choose another upstream
+	ctx = variable.NewVariableContext(context.Background())
+	ctx = mosnctx.WithValue(ctx, types.ContextKeyConnection, sConnI)
+	ctx = mosnctx.WithValue(ctx, types.ContextKeyConnectionID, sConnI.ID())
+
+	host, _, failReason = pInst.NewStream(ctx, nil)
+	assert.Equal(t, failReason, types.PoolFailureReason(""))
+	assert.NotNil(t, pInst.idleClients[sConnI.ID()])
+	cb2 := pInst.idleClients[sConnI.ID()]
+
+	assert.NotEqual(t, cb1.host.Connection.ID(), cb2.host.Connection.ID())
+
+	// upstream close should close the downstream conn
+	pInst.idleClients[sConnI.ID()].Close(errors.New("closeclose"))
+	assert.Nil(t, pInst.idleClients[sConnI.ID()])
+	assert.Equal(t, sConnI.State(), api.ConnClosed)
+
+	// client has already closed
+	// close the connpool should not panic
+	pInst.Close()
+}


### PR DESCRIPTION
   1.1 在 upstream 收到了 GoAway 请求后会将自己从 conn_pool 里面删除掉，这样下次就会用到新的链接
   1.2 在 upstream 收到了 GoAway 标记自己已经从 upstream 删除了，下次收到关链接的 event 不再删除 downstream 的链接

### Issues associated with this PR

Your PR should present related issues you want to solve.

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, details and the changes. At this time, Chinese is allowed to describe these.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
