### PR TITLE
optimze: reuse subset entry to optimze alloc/inuse memory

### DIFF
--- a/pkg/upstream/cluster/subset_loadbalancer_test.go
+++ b/pkg/upstream/cluster/subset_loadbalancer_test.go
@@ -19,7 +19,6 @@ package cluster
 
 import (
 	"fmt"
-	"math"
 	"math/rand"
 	"reflect"
 	"sort"
@@ -875,19 +874,16 @@ func TestSubsetLoadBalancers(t *testing.T) {
 	})
 }
 
-func benchHostConfigs(hostCount int, keyValues int) []v2.Host {
+func benchHostConfigs(hostCount int, zones int) []v2.Host {
 	ret := make([]v2.Host, 0, hostCount)
-	keyValues = int(math.Max(float64(keyValues), 1))
 	rand.Seed(time.Now().UnixNano())
-	keys := []string{"zone", "physics", "mosn_aig", "mosn_version"}
+	keys := []string{"physics", "mosn_aig", "mosn_version"}
 	for i := 0; i < hostCount; i++ {
-
 		metadata := make(map[string]string)
+		r := rand.Intn(zones)
+		metadata["zone"] = fmt.Sprintf("zone-%d", r)
 		for _, key := range keys {
-			r := rand.Intn(keyValues + 1)
-			if r < keyValues {
-				metadata[key] = fmt.Sprintf("%s-%d", key, r)
-			}
+			metadata[key] = key
 		}
 		host := v2.Host{
 			HostConfig: v2.HostConfig{


### PR DESCRIPTION
### Issues associated with this PR


issue: https://github.com/mosn/mosn/issues/2111
Your PR should present related issues you want to solve.

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, details and the changes. At this time, Chinese is allowed to describe these.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
#### before

```
  ✘ dzdx@B-QBDRMD6M-0201  ~/Documents/mosn-open/pkg/upstream/cluster   subset-lb-iface ±  go test -bench BenchmarkSubsetLoadBalancer/subsetLoadBalancerPreIndex -benchmem  -run=^$ 
2022-08-29 14:57:30,180 [INFO] [network] [ register pool factory] register protocol: mock factory
goos: darwin
goarch: amd64
pkg: mosn.io/mosn/pkg/upstream/cluster
BenchmarkSubsetLoadBalancer/subsetLoadBalancerPreIndex-12                    256           5013841 ns/op         3344313 B/op       1956 allocs/op
PASS
ok      mosn.io/mosn/pkg/upstream/cluster       2.061s
```
#### after

```
 dzdx@B-QBDRMD6M-0201  ~/Documents/mosn-open/pkg/upstream/cluster   subset-lb-iface  go test -bench BenchmarkSubsetLoadBalancer/subsetLoadBalancerPreIndex -benchmem  -run=^$ 
2022-08-29 14:57:56,611 [INFO] [network] [ register pool factory] register protocol: mock factory
goos: darwin
goarch: amd64
pkg: mosn.io/mosn/pkg/upstream/cluster
BenchmarkSubsetLoadBalancer/subsetLoadBalancerPreIndex-12                    514           2605042 ns/op          653241 B/op       1910 allocs/op
PASS
ok      mosn.io/mosn/pkg/upstream/cluster       2.026s
```




### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
