### PR TITLE
bugfix: return error when get cookie value of not-exist-key

### DIFF
--- a/pkg/stream/http/var.go
+++ b/pkg/stream/http/var.go
@@ -19,6 +19,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"strconv"
 
 	"mosn.io/api"
@@ -159,9 +160,9 @@ func httpCookieGetter(ctx context.Context, value *variable.IndexedValue, data in
 
 	cookieName := data.(string)
 	cookieValue := request.Header.Cookie(cookieName[cookieIndex:])
-	// nil means no kv exists, "" means kv exists, but value is ""
+	// error not nil means that no kv exists
 	if cookieValue == nil {
-		return variable.ValueNotFound, nil
+		return variable.ValueNotFound, errors.New("not found cookie value")
 	}
 
 	return string(cookieValue), nil

--- a/pkg/stream/http/var_test.go
+++ b/pkg/stream/http/var_test.go
@@ -125,13 +125,25 @@ func Test_get_cookie(t *testing.T) {
 	ctx := prepareRequest(t, getRequestBytes)
 
 	actual, err := variable.GetString(ctx,
-		fmt.Sprintf("%s_%s%s", protocol.HTTP1, types.VarProtocolCookie, "zone"))
+		fmt.Sprintf("%s%s", types.VarPrefixHttpCookie, "zone"))
 	if err != nil {
 		t.Error("get variable failed:", err)
 	}
 
 	if actual != "shanghai" {
 		t.Error("request cookie assert failed, expected: shanghai, actual is: ", actual)
+	}
+
+	_, err = variable.GetString(
+		ctx,
+		fmt.Sprintf("%s%s", types.VarPrefixHttpCookie, "env"),
+	)
+
+	if err == nil {
+		t.Error("request cookie assert failed, should get an err, actually get a nil")
+	}
+	if err.Error() != "not found cookie value" {
+		t.Error(`request cookie assert failed, the err message should be "not found cookie value"`)
 	}
 }
 


### PR DESCRIPTION
### Issues associated with this PR

no issues associated

### Solutions

when get a cookie value of a key, if the key not exists, return `variable.ValueNotFound` and an error 


### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
