### PR TITLE
bugfix: avoid the deletion of reconfig.sock when the old process stops

### DIFF
--- a/pkg/server/reconfigure.go
+++ b/pkg/server/reconfigure.go
@@ -141,6 +141,13 @@ func StopReconfigureHandler() {
 	if stagemanager.GetState() == stagemanager.Upgrading {
 		return
 	}
+
+	// When the old process stops after smooth upgrade, reconfig.sock is created by the new process.
+	// It should not be removed by the old process.
+	if stagemanager.GetStopAction() == stagemanager.Upgrade {
+		return
+	}
+
 	syscall.Unlink(types.ReconfigureDomainSocket)
 }
 

--- a/pkg/stagemanager/stage_manager.go
+++ b/pkg/stagemanager/stage_manager.go
@@ -505,6 +505,10 @@ func GetState() State {
 	return stm.state
 }
 
+func GetStopAction() StopAction {
+	return stm.stopAction
+}
+
 // expose this method just make UT easier,
 // should not use it directly.
 func SetState(s State) {


### PR DESCRIPTION
### Issues associated with this PR

#2128 

### Solutions
Another fix suggestion for #2128. Avoid the deletion of reconfig.sock by judging StopAction and make smooth upgrade can run continuously.

### UT result
Not involved.

### Benchmark
Not involved.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
