### PR TITLE
bugfix: Modify the way xds listener logs are parsed

### DIFF
--- a/istio/istio1106/xds/conv/convert_listener.go
+++ b/istio/istio1106/xds/conv/convert_listener.go
@@ -214,21 +214,20 @@ func convertAccessLogsFromFilterChain(xdsFilterChain *envoy_config_listener_v3.F
 		return nil
 	}
 
-	type FilterLogConfig interface {
-		GetAccessLog() []*envoy_config_accesslog_v3.AccessLog
-	}
-
+	var envoyAccesslogs []*envoy_config_accesslog_v3.AccessLog
 	accessLogs := make([]v2.AccessLog, 0)
+
 	for _, xdsFilter := range xdsFilterChain.GetFilters() {
-		var filterConfig FilterLogConfig
 		if value, ok := httpBaseConfig[xdsFilter.GetName()]; ok && value {
-			filterConfig = GetHTTPConnectionManager(xdsFilter)
+			filterConfig := GetHTTPConnectionManager(xdsFilter)
+			envoyAccesslogs = filterConfig.GetAccessLog()
 		} else if xdsFilter.GetName() == wellknown.TCPProxy {
-			filterConfig = GetTcpProxy(xdsFilter)
+			filterConfig := GetTcpProxy(xdsFilter)
+			envoyAccesslogs = filterConfig.GetAccessLog()
 		}
 
-		if filterConfig != nil {
-			for _, accConfig := range filterConfig.GetAccessLog() {
+		if envoyAccesslogs != nil {
+			for _, accConfig := range envoyAccesslogs {
 				if accConfig.Name == wellknown.FileAccessLog {
 					als, err := GetAccessLog(accConfig)
 					if err != nil {

--- a/istio/istio1106/xds/conv/convert_listener.go
+++ b/istio/istio1106/xds/conv/convert_listener.go
@@ -205,17 +205,6 @@ func convertAccessLogsFromListener(xdsListener *envoy_config_listener_v3.Listene
 		}
 	}
 
-	if len(accessLogs) > 0 {
-		return accessLogs
-	}
-
-	for _, xdsFilterChain := range xdsListener.GetFilterChains() {
-		accessLogs = append(accessLogs, convertAccessLogsFromFilterChain(xdsFilterChain)...)
-		if len(accessLogs) > 0 {
-			return accessLogs
-		}
-	}
-
 	return accessLogs
 }
 

--- a/istio/istio1106/xds/conv/convert_listener_test.go
+++ b/istio/istio1106/xds/conv/convert_listener_test.go
@@ -4,13 +4,16 @@ import (
 	"testing"
 
 	udpa_type_v1 "github.com/cncf/udpa/go/udpa/type/v1"
+	envoy_config_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_extensions_access_loggers_file_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
 	envoy_extensions_filters_http_fault_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/fault/v3"
 	envoy_extensions_filters_listener_original_dst_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/original_dst/v3"
 	envoy_extensions_filters_network_http_connection_manager_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_extensions_filters_network_tcp_proxy_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/require"
@@ -243,5 +246,121 @@ func TestConvertListener_UseOriginalDst(t *testing.T) {
 	require.False(t, cfg.FallbackToLocal)
 	require.Equal(t, "tcp_proxy", listeners[0].FilterChains[0].Filters[0].Type)
 	require.Equal(t, EGRESS_CLUSTER, listeners[0].FilterChains[0].Filters[0].Config["cluster"])
+}
 
+func TestConvertListener_AccessLogs(t *testing.T) {
+	virtualListener := &envoy_config_listener_v3.Listener{
+		Name: "Listener",
+		Address: &envoy_config_core_v3.Address{
+			Address: &envoy_config_core_v3.Address_SocketAddress{
+				SocketAddress: &envoy_config_core_v3.SocketAddress{
+					Address: "0.0.0.0",
+					PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+						PortValue: 15006,
+					},
+				},
+			},
+		},
+		ListenerFilters: []*envoy_config_listener_v3.ListenerFilter{
+			{
+				Name: "envoy.filters.listener.original_dst",
+				ConfigType: &envoy_config_listener_v3.ListenerFilter_TypedConfig{
+					TypedConfig: messageToAny(t, &envoy_extensions_filters_listener_original_dst_v3.OriginalDst{}),
+				},
+			},
+		},
+		FilterChains: []*envoy_config_listener_v3.FilterChain{
+			// TODO: not support yet
+			{
+				Name: "virtualInbound-blackhole",
+				FilterChainMatch: &envoy_config_listener_v3.FilterChainMatch{
+					DestinationPort: &wrappers.UInt32Value{
+						Value: 15006,
+					},
+				},
+				Filters: []*envoy_config_listener_v3.Filter{
+					{
+						Name: "envoy.filters.network.tcp_proxy",
+						ConfigType: &envoy_config_listener_v3.Filter_TypedConfig{
+							TypedConfig: messageToAny(t, &envoy_extensions_filters_network_tcp_proxy_v3.TcpProxy{
+								StatPrefix: "BlackHoleCluster",
+								ClusterSpecifier: &envoy_extensions_filters_network_tcp_proxy_v3.TcpProxy_Cluster{
+									Cluster: "BlackHoleCluster",
+								},
+								AccessLog: []*envoy_config_accesslog_v3.AccessLog{
+									{
+										Name: wellknown.FileAccessLog,
+										ConfigType: &envoy_config_accesslog_v3.AccessLog_TypedConfig{
+											TypedConfig: messageToAny(t, &envoy_extensions_access_loggers_file_v3.FileAccessLog{
+												Path: "/tcp_proxy/log_path",
+											}),
+										},
+									},
+								},
+							}),
+						},
+					},
+				},
+			},
+			{
+				Name: "0.0.0.0_9080",
+				FilterChainMatch: &envoy_config_listener_v3.FilterChainMatch{
+					DestinationPort: &wrappers.UInt32Value{
+						Value: 9080,
+					},
+				},
+				Filters: []*envoy_config_listener_v3.Filter{
+					{
+						Name: "envoy.filters.network.http_connection_manager",
+						ConfigType: &envoy_config_listener_v3.Filter_TypedConfig{
+							TypedConfig: messageToAny(t, &envoy_extensions_filters_network_http_connection_manager_v3.HttpConnectionManager{
+								StatPrefix: "inbound_0.0.0.0_9080",
+								RouteSpecifier: &envoy_extensions_filters_network_http_connection_manager_v3.HttpConnectionManager_RouteConfig{
+									RouteConfig: &envoy_config_route_v3.RouteConfiguration{
+										Name: "inbound|9080||",
+									},
+								},
+								AccessLog: []*envoy_config_accesslog_v3.AccessLog{
+									{
+										Name: wellknown.FileAccessLog,
+										ConfigType: &envoy_config_accesslog_v3.AccessLog_TypedConfig{
+											TypedConfig: messageToAny(t, &envoy_extensions_access_loggers_file_v3.FileAccessLog{
+												Path: "/http_connection_manager/log_path",
+											}),
+										},
+									},
+									{
+										Name: wellknown.FileAccessLog,
+										ConfigType: &envoy_config_accesslog_v3.AccessLog_TypedConfig{
+											TypedConfig: messageToAny(t, &envoy_extensions_access_loggers_file_v3.FileAccessLog{
+												Path: "/http_connection_manager/log_path",
+											}),
+										},
+									},
+								},
+							}),
+						},
+					},
+				},
+			},
+		},
+		AccessLog: []*envoy_config_accesslog_v3.AccessLog{
+			{
+				Name: wellknown.FileAccessLog,
+				ConfigType: &envoy_config_accesslog_v3.AccessLog_TypedConfig{
+					TypedConfig: messageToAny(t, &envoy_extensions_access_loggers_file_v3.FileAccessLog{
+						Path: "/Listener/log_path",
+					}),
+				},
+			},
+		},
+	}
+	listeners := ConvertListenerConfig(virtualListener, nil)
+
+	require.Len(t, listeners, 2)
+	require.Len(t, listeners[0].AccessLogs, 1)
+	require.Equal(t, "/Listener/log_path", listeners[0].AccessLogs[0].Path)
+	require.Len(t, listeners[1].AccessLogs, 2)
+	require.Equal(t, "/http_connection_manager/log_path", listeners[1].AccessLogs[0].Path)
+	require.Equal(t, "/http_connection_manager/log_path", listeners[1].AccessLogs[1].Path)
 }

--- a/istio/istio1106/xds/conv/convert_listener_test.go
+++ b/istio/istio1106/xds/conv/convert_listener_test.go
@@ -329,14 +329,6 @@ func TestConvertListener_AccessLogs(t *testing.T) {
 											}),
 										},
 									},
-									{
-										Name: wellknown.FileAccessLog,
-										ConfigType: &envoy_config_accesslog_v3.AccessLog_TypedConfig{
-											TypedConfig: messageToAny(t, &envoy_extensions_access_loggers_file_v3.FileAccessLog{
-												Path: "/http_connection_manager/log_path",
-											}),
-										},
-									},
 								},
 							}),
 						},
@@ -360,7 +352,6 @@ func TestConvertListener_AccessLogs(t *testing.T) {
 	require.Len(t, listeners, 2)
 	require.Len(t, listeners[0].AccessLogs, 1)
 	require.Equal(t, "/Listener/log_path", listeners[0].AccessLogs[0].Path)
-	require.Len(t, listeners[1].AccessLogs, 2)
+	require.Len(t, listeners[1].AccessLogs, 1)
 	require.Equal(t, "/http_connection_manager/log_path", listeners[1].AccessLogs[0].Path)
-	require.Equal(t, "/http_connection_manager/log_path", listeners[1].AccessLogs[1].Path)
 }


### PR DESCRIPTION
### Issues associated with this PR

#2143 

### Solutions
listener 使用的 Accesslogs 直接从 listener 配置中获取，不再遍历 FilterChain
virtualListener Accesslogs 会从对应 FilterChain 中的 filters 获取

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
