### PR TITLE
Add api to force reconnect and send ads request

### DIFF
--- a/pkg/istio/xds.go
+++ b/pkg/istio/xds.go
@@ -199,19 +199,22 @@ func (adsClient *ADSClient) ReconnectOnce() error {
 	adsClient.stopStreamClient()
 	log.DefaultLogger.Infof("[xds] [ads client] close stream client")
 
-	if !disableReconnect {
-		err := adsClient.connect()
-		if err == nil {
-			if c := adsClient.GetStreamClient(); c != nil {
-				err := c.Send(adsClient.config.InitAdsRequest())
-				if err != nil {
-					log.DefaultLogger.Infof("[xds] [ads client] reconnectOnce and send request failed")
-					return fmt.Errorf("send request failed:%v", err)
-				}
-			}
-			log.DefaultLogger.Infof("[xds] [ads client] stream client reconnected")
-		}
-		return err
+	if disableReconnect {
+		log.DefaultLogger.Infof("[xds] [ads client] stream client reconnect disabled")
+		return nil
 	}
-	return nil
+
+	err := adsClient.connect()
+	if err == nil {
+		if c := adsClient.GetStreamClient(); c != nil {
+			err := c.Send(adsClient.config.InitAdsRequest())
+			if err != nil {
+				log.DefaultLogger.Infof("[xds] [ads client] reconnectOnce and send request failed")
+				return fmt.Errorf("send request failed:%v", err)
+			}
+		}
+		log.DefaultLogger.Infof("[xds] [ads client] stream client reconnected")
+	}
+
+	return err
 }

--- a/pkg/istio/xds.go
+++ b/pkg/istio/xds.go
@@ -18,7 +18,6 @@
 package istio
 
 import (
-	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -40,6 +39,7 @@ type ADSClient struct {
 	streamClient      XdsStreamClient
 	config            XdsStreamConfig
 	stopChan          chan struct{}
+	sendTimer         *time.Timer
 }
 
 func NewAdsClient(config *v2.MOSNConfig) (*ADSClient, error) {
@@ -50,6 +50,7 @@ func NewAdsClient(config *v2.MOSNConfig) (*ADSClient, error) {
 	return &ADSClient{
 		config:   cfg,
 		stopChan: make(chan struct{}),
+		sendTimer: time.NewTimer(0),
 	}, nil
 }
 
@@ -79,15 +80,13 @@ func (adsClient *ADSClient) Start() {
 
 func (adsClient *ADSClient) sendRequestLoop() {
 	log.DefaultLogger.Debugf("[xds] [ads client] send request, start with cds")
-	// start a directly timer
-	t := time.NewTimer(0)
 	for {
 		select {
 		case <-adsClient.stopChan:
 			log.DefaultLogger.Infof("[xds] [ads client] send request loop shutdown")
 			adsClient.stopStreamClient()
 			return
-		case <-t.C:
+		case <-adsClient.sendTimer.C:
 			c := adsClient.GetStreamClient()
 			if c == nil {
 				log.DefaultLogger.Infof("[xds] [ads client] stream client closed, sleep 1s and wait for reconnect")
@@ -97,7 +96,7 @@ func (adsClient *ADSClient) sendRequestLoop() {
 				log.DefaultLogger.Infof("[xds] [ads client] send thread request cds fail!auto retry next period")
 				adsClient.reconnect()
 			}
-			t.Reset(adsClient.config.RefreshDelay())
+			adsClient.sendTimer.Reset(adsClient.config.RefreshDelay())
 		}
 	}
 }
@@ -195,26 +194,14 @@ func (adsClient *ADSClient) Stop() {
 	close(adsClient.stopChan)
 }
 
-func (adsClient *ADSClient) ReconnectOnce() error {
+// close stream client and trigger reconnect right now
+func (adsClient *ADSClient) ReconnectOnce() {
 	adsClient.stopStreamClient()
 	log.DefaultLogger.Infof("[xds] [ads client] close stream client")
 
 	if disableReconnect {
 		log.DefaultLogger.Infof("[xds] [ads client] stream client reconnect disabled")
-		return nil
 	}
 
-	err := adsClient.connect()
-	if err == nil {
-		if c := adsClient.GetStreamClient(); c != nil {
-			err := c.Send(adsClient.config.InitAdsRequest())
-			if err != nil {
-				log.DefaultLogger.Infof("[xds] [ads client] reconnectOnce and send request failed")
-				return fmt.Errorf("send request failed:%v", err)
-			}
-		}
-		log.DefaultLogger.Infof("[xds] [ads client] stream client reconnected")
-	}
-
-	return err
+	adsClient.sendTimer.Reset(0)
 }

--- a/pkg/istio/xds.go
+++ b/pkg/istio/xds.go
@@ -195,12 +195,13 @@ func (adsClient *ADSClient) Stop() {
 }
 
 // close stream client and trigger reconnect right now
-func (adsClient *ADSClient) ReconnectOnce() {
+func (adsClient *ADSClient) ReconnectStreamClient() {
 	adsClient.stopStreamClient()
 	log.DefaultLogger.Infof("[xds] [ads client] close stream client")
 
 	if disableReconnect {
 		log.DefaultLogger.Infof("[xds] [ads client] stream client reconnect disabled")
+		return
 	}
 
 	adsClient.sendTimer.Reset(0)

--- a/pkg/istio/xds_test.go
+++ b/pkg/istio/xds_test.go
@@ -170,7 +170,7 @@ func TestXdsClient(t *testing.T) {
 		client, _ := NewAdsClient(&v2.MOSNConfig{})
 		client.Start()
 		client.ReconnectStreamClient()
-		time.Sleep(2*time.Second)
+		time.Sleep(2 * time.Second)
 		_, ok := records["cds-test"]
 		require.True(t, ok)
 		waitStop(client)

--- a/pkg/istio/xds_test.go
+++ b/pkg/istio/xds_test.go
@@ -162,4 +162,17 @@ func TestXdsClient(t *testing.T) {
 		require.True(t, ok)
 		waitStop(client)
 	})
+
+	t.Run("reconnect client once", func(t *testing.T) {
+		records = map[string]struct{}{}
+		EnableReconnect()
+		cfg.failed = 1
+		client, _ := NewAdsClient(&v2.MOSNConfig{})
+		client.Start()
+		client.ReconnectOnce()
+		time.Sleep(time.Second)
+		_, ok := records["cds-test"]
+		require.True(t, ok)
+		waitStop(client)
+	})
 }

--- a/pkg/istio/xds_test.go
+++ b/pkg/istio/xds_test.go
@@ -169,8 +169,8 @@ func TestXdsClient(t *testing.T) {
 		cfg.failed = 1
 		client, _ := NewAdsClient(&v2.MOSNConfig{})
 		client.Start()
-		client.ReconnectOnce()
-		time.Sleep(time.Second)
+		client.ReconnectStreamClient()
+		time.Sleep(2*time.Second)
 		_, ok := records["cds-test"]
 		require.True(t, ok)
 		waitStop(client)

--- a/pkg/istio/xds_test.go
+++ b/pkg/istio/xds_test.go
@@ -170,7 +170,7 @@ func TestXdsClient(t *testing.T) {
 		client, _ := NewAdsClient(&v2.MOSNConfig{})
 		client.Start()
 		client.ReconnectStreamClient()
-		time.Sleep(2 * time.Second)
+		time.Sleep(3 * time.Second)
 		_, ok := records["cds-test"]
 		require.True(t, ok)
 		waitStop(client)


### PR DESCRIPTION
### Issues associated with this PR

In our case, we use a http server to cache pilot address, and this address can be changed.
We starts a task to request pilot address periodically, and if pilot address changed, we need a api to stop the current stream client, and reconnect to new server.
