### PR TITLE
proxywasm: reduces logging in benchmarks

### DIFF
--- a/test/integrate/proxywasm/proxywasm_test.go
+++ b/test/integrate/proxywasm/proxywasm_test.go
@@ -38,7 +38,12 @@ import (
 	_ "mosn.io/mosn/pkg/stream/http2"
 	_ "mosn.io/mosn/pkg/wasm/abi/proxywasm020"
 	"mosn.io/mosn/test/util/mosn"
+	"mosn.io/pkg/log"
 )
+
+func init() {
+	log.DefaultLogger.SetLogLevel(log.ERROR)
+}
 
 type testMosn struct {
 	url     string


### PR DESCRIPTION
Before there were pages full of logs, now there are still some as some logging hits before the adjustment. anyway it is readable.

```
2022-11-26 11:36:06,92 [INFO] register a new handler maker, name is default, is default: true
2022-11-26 11:36:06,92 [INFO] [config] processor added to configParsedCBMaps
2022-11-26 11:36:06,92 [INFO] [network] [ register pool factory] register protocol: Http1 factory
2022-11-26 11:36:06,92 [INFO] [network] [ register pool factory] register protocol: Http2 factory
2022-11-26 11:36:06,94 [INFO] [wasm][vm] RegisterWasmEngine engine: wasmer
2022-11-26 11:36:06,95 [INFO] [wasm][vm] RegisterWasmEngine engine: wazero
goos: darwin
goarch: amd64
pkg: mosn.io/mosn/test/integrate/proxywasm
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
Benchmark_BaseCase
2022-11-26 11:36:06,279 [ERROR] write pid file error: open /home/admin/mosn/logs/mosn.pid: no such file or directory
Benchmark_BaseCase-16              	    7986	    135776 ns/op
Benchmark_ProxyWasmV1_wasmer
Benchmark_ProxyWasmV1_wasmer-16    	    6193	    198933 ns/op
Benchmark_ProxyWasmV1_wazero
Benchmark_ProxyWasmV1_wazero-16    	    6618	    177477 ns/op
PASS
ok  	mosn.io/mosn/test/integrate/proxywasm	28.502s
```