### PR TITLE
Optimize match route logic, try to update routerWrapper when it is nil

### DIFF
--- a/istio/_istio152/xds/conv/update.go
+++ b/istio/_istio152/xds/conv/update.go
@@ -59,7 +59,6 @@ func (cvt *xdsConverter) listenerRouterHandler(isRds bool, routerConfig *v2.Rout
 	// save rds records, get router config from rds request
 	if isRds {
 		cvt.AppendRouterName(routerConfig.RouterConfigName)
-		return
 	}
 	routersMngIns := router.GetRoutersMangerInstance()
 	if routersMngIns == nil {

--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -678,10 +678,16 @@ func (s *downStream) receive(ctx context.Context, id uint32, phase types.Phase) 
 func (s *downStream) matchRoute() {
 	headers := s.downstreamReqHeaders
 	if s.proxy.routersWrapper == nil || s.proxy.routersWrapper.GetRouters() == nil {
-		log.Proxy.Alertf(s.context, types.ErrorKeyRouteMatch, "routersWrapper or routers in routersWrapper is nil while trying to get router")
-		s.requestInfo.SetResponseFlag(api.NoRouteFound)
-		s.sendHijackReply(api.RouterUnavailableCode, headers)
-		return
+		// try to update s.proxy.routersWrapper since RDS arrives after LDS in case keepalive connections are always affected
+		if routersWrapper := router.GetRoutersMangerInstance().GetRouterWrapperByName(s.proxy.config.RouterConfigName); routersWrapper != nil {
+			log.Proxy.Alertf(s.context, types.ErrorKeyRouteMatch, "routersWrapper or routers in routersWrapper is nil but updated from routerManager, router:%s", s.proxy.config.RouterConfigName)
+			s.proxy.routersWrapper = routersWrapper
+		} else {
+			log.Proxy.Alertf(s.context, types.ErrorKeyRouteMatch, "routersWrapper or routers in routersWrapper is nil while trying to get router, headers= %v", headers)
+			s.requestInfo.SetResponseFlag(api.NoRouteFound)
+			s.sendHijackReply(types.RouterUnavailableCode, headers)
+			return
+		}
 	}
 
 	// get router instance and do routing

--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -683,9 +683,9 @@ func (s *downStream) matchRoute() {
 			log.Proxy.Alertf(s.context, types.ErrorKeyRouteMatch, "routersWrapper or routers in routersWrapper is nil but updated from routerManager, router:%s", s.proxy.config.RouterConfigName)
 			s.proxy.routersWrapper = routersWrapper
 		} else {
-			log.Proxy.Alertf(s.context, types.ErrorKeyRouteMatch, "routersWrapper or routers in routersWrapper is nil while trying to get router, headers= %v", headers)
+			log.Proxy.Alertf(s.context, types.ErrorKeyRouteMatch, "routersWrapper or routers in routersWrapper is nil while trying to get router")
 			s.requestInfo.SetResponseFlag(api.NoRouteFound)
-			s.sendHijackReply(types.RouterUnavailableCode, headers)
+			s.sendHijackReply(api.RouterUnavailableCode, headers)
 			return
 		}
 	}

--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -678,16 +678,10 @@ func (s *downStream) receive(ctx context.Context, id uint32, phase types.Phase) 
 func (s *downStream) matchRoute() {
 	headers := s.downstreamReqHeaders
 	if s.proxy.routersWrapper == nil || s.proxy.routersWrapper.GetRouters() == nil {
-		// try to update s.proxy.routersWrapper since RDS arrives after LDS in case keepalive connections are always affected
-		if routersWrapper := router.GetRoutersMangerInstance().GetRouterWrapperByName(s.proxy.config.RouterConfigName); routersWrapper != nil {
-			log.Proxy.Alertf(s.context, types.ErrorKeyRouteMatch, "routersWrapper or routers in routersWrapper is nil but updated from routerManager, router:%s", s.proxy.config.RouterConfigName)
-			s.proxy.routersWrapper = routersWrapper
-		} else {
-			log.Proxy.Alertf(s.context, types.ErrorKeyRouteMatch, "routersWrapper or routers in routersWrapper is nil while trying to get router")
-			s.requestInfo.SetResponseFlag(api.NoRouteFound)
-			s.sendHijackReply(api.RouterUnavailableCode, headers)
-			return
-		}
+		log.Proxy.Alertf(s.context, types.ErrorKeyRouteMatch, "routersWrapper or routers in routersWrapper is nil while trying to get router")
+		s.requestInfo.SetResponseFlag(api.NoRouteFound)
+		s.sendHijackReply(api.RouterUnavailableCode, headers)
+		return
 	}
 
 	// get router instance and do routing


### PR DESCRIPTION
### Issues associated with this PR

Since RDS arrives after LDS, sometimes the first request will report 404 code, but keep alive connections routerWrapper will always be nil even after RDS arrives and routers updated.

current logic:
![image](https://user-images.githubusercontent.com/6399971/208099632-6b3d4e25-1a74-4e66-b4f2-5dd040de3189.png)
if "isRds", it returns directly, actually we should init routerWrapper here and update router later  to avoid the bug mentioned above
it was changed in [commit](https://github.com/mosn/mosn/commit/b7827d77d09bcab51a1b9bddbd8300f86c598995#diff-55800ee9417e08176f473dce3a40d8960a4fea5a00989b2947a56acfefe8d09e)
old logic:
![image](https://user-images.githubusercontent.com/6399971/208099660-e08018d0-aa2b-4bcd-bb98-226ffe24b58c.png)
