### PR TITLE
[Feature] pprof debug server support endpoint configure

### DIFF
--- a/pkg/config/v2/config.go
+++ b/pkg/config/v2/config.go
@@ -49,8 +49,9 @@ type MOSNConfig struct {
 
 // PProfConfig is used to start a pprof server for debug
 type PProfConfig struct {
-	StartDebug bool `json:"debug"`      // If StartDebug is true, start a pprof, default is false
-	Port       int  `json:"port_value"` // If port value is 0, will use 9090 as default
+	StartDebug bool   `json:"debug"`      // If StartDebug is true, start a pprof, default is false
+	Port       int    `json:"port_value"` // If port value is 0, will use 9090 as default
+	Endpoint   string `json:"endpoint"`   // If endpoint is empty, will use "0.0.0.0" as default
 }
 
 // Tracing configuration for a server

--- a/pkg/mosn/init.go
+++ b/pkg/mosn/init.go
@@ -44,10 +44,14 @@ import (
 func InitDebugServe(c *v2.MOSNConfig) {
 	if c.Debug.StartDebug {
 		port := 9090 //default use 9090
+		endpoint := "0.0.0.0"
 		if c.Debug.Port != 0 {
 			port = c.Debug.Port
 		}
-		addr := fmt.Sprintf("0.0.0.0:%d", port)
+		if c.Debug.Endpoint != "" {
+			endpoint = c.Debug.Endpoint
+		}
+		addr := fmt.Sprintf("%s:%d", endpoint, port)
 		s := &http.Server{Addr: addr, Handler: nil}
 		store.AddService(s, "pprof", nil, nil)
 	}


### PR DESCRIPTION
### Issues associated with this PR

Support to configure debug server endpoint when we don't want to export debug server to user when using HostNetwork
