### PR TITLE
[bugfix]: if new Mosn starts from upgrade mode fails, do no unlink reconfig.sock

### DIFF
--- a/pkg/stagemanager/stage_manager.go
+++ b/pkg/stagemanager/stage_manager.go
@@ -381,7 +381,6 @@ func (stm *StageManager) Stop() {
 	if stm.state == Nil {
 		return
 	}
-	preState := stm.state
 	// graceful stop the existing connections and requests
 	if stm.stopAction == GracefulStop || stm.stopAction == Upgrade {
 		stm.runGracefulStopStage()
@@ -390,7 +389,7 @@ func (stm *StageManager) Stop() {
 	stm.SetState(Stopping)
 
 	// close application
-	stm.app.Close(preState == Upgrading)
+	stm.app.Close(stm.app.IsFromUpgrade())
 
 	// other cleanup actions
 	stm.runAfterStopStage()

--- a/pkg/stagemanager/stage_manager.go
+++ b/pkg/stagemanager/stage_manager.go
@@ -381,6 +381,7 @@ func (stm *StageManager) Stop() {
 	if stm.state == Nil {
 		return
 	}
+	preState := stm.state
 	// graceful stop the existing connections and requests
 	if stm.stopAction == GracefulStop || stm.stopAction == Upgrade {
 		stm.runGracefulStopStage()

--- a/pkg/stagemanager/stage_manager.go
+++ b/pkg/stagemanager/stage_manager.go
@@ -390,7 +390,9 @@ func (stm *StageManager) Stop() {
 	stm.SetState(Stopping)
 
 	// close application
-	stm.app.Close(stm.app.IsFromUpgrade())
+	// preState == Upgrading : old Mosn exits after new Mosn starts successfully
+	// preState < Starting && stm.app.IsFromUpgrade() : new Mosn exits when starting from upgrade mode fails
+	stm.app.Close(preState == Upgrading || preState < Starting && stm.app.IsFromUpgrade())
 
 	// other cleanup actions
 	stm.runAfterStopStage()


### PR DESCRIPTION

### Issues associated with this PR
If new Mosn start failed due to port conflict or inherit global config failure,  current pid file and reconfig.sock will be removed