### PR TITLE
[bugfix]http health check url with query string will be unescaped

### DIFF
--- a/pkg/upstream/healthcheck/httpdial.go
+++ b/pkg/upstream/healthcheck/httpdial.go
@@ -114,12 +114,14 @@ func (f *HTTPDialSessionFactory) NewSession(cfg map[string]interface{}, host typ
 		uri.Host = host.AddressString()
 	}
 
-	strs := strings.Split(httpCheckConfig.Path, "?")
-	if len(strs) == 2 {
-		uri.Path = strs[0]
-		uri.RawQuery = strs[0]
+	ind := strings.IndexByte(httpCheckConfig.Path, '?')
+	if ind < 0 {
+		uri.Path = httpCheckConfig.Path
 	} else {
-		uri.Path = strs[0]
+		uri.Path = httpCheckConfig.Path[:ind]
+		if len(httpCheckConfig.Path) > ind+1 {
+			uri.RawQuery = httpCheckConfig.Path[ind+1:]
+		}
 	}
 
 	if httpCheckConfig.Timeout.Duration > 0 {

--- a/pkg/upstream/healthcheck/httpdial.go
+++ b/pkg/upstream/healthcheck/httpdial.go
@@ -92,6 +92,11 @@ func (f *HTTPDialSessionFactory) NewSession(cfg map[string]interface{}, host typ
 	}
 
 	uri := &url.URL{}
+	uri, err := url.Parse(httpCheckConfig.Path)
+	if err != nil {
+		log.DefaultLogger.Errorf("[upstream] [health check] [httpdial session] path=%s parse error %+v", httpCheckConfig.Path, err)
+		return nil
+	}
 	if httpCheckConfig.Scheme == "" {
 		uri.Scheme = "http"
 	} else {
@@ -107,12 +112,10 @@ func (f *HTTPDialSessionFactory) NewSession(cfg map[string]interface{}, host typ
 	if httpCheckConfig.Port > 0 && httpCheckConfig.Port < 65535 {
 		// re-config http check port
 		uri.Host = hostIp + ":" + strconv.Itoa(httpCheckConfig.Port)
-		uri.Path = httpCheckConfig.Path
 	} else {
 		// use rpc port as http check port
 		log.DefaultLogger.Warnf("[upstream] [health check] [httpdial session] httpCheckConfig port config error %+v", httpCheckConfig)
 		uri.Host = host.AddressString()
-		uri.Path = httpCheckConfig.Path
 	}
 
 	if httpCheckConfig.Scheme != "" {

--- a/pkg/upstream/healthcheck/httpdial.go
+++ b/pkg/upstream/healthcheck/httpdial.go
@@ -91,7 +91,6 @@ func (f *HTTPDialSessionFactory) NewSession(cfg map[string]interface{}, host typ
 		}
 	}
 
-	uri := &url.URL{}
 	uri, err := url.Parse(httpCheckConfig.Path)
 	if err != nil {
 		log.DefaultLogger.Errorf("[upstream] [health check] [httpdial session] path=%s parse error %+v", httpCheckConfig.Path, err)

--- a/pkg/upstream/healthcheck/httpdial.go
+++ b/pkg/upstream/healthcheck/httpdial.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"mosn.io/api"
@@ -91,11 +92,7 @@ func (f *HTTPDialSessionFactory) NewSession(cfg map[string]interface{}, host typ
 		}
 	}
 
-	uri, err := url.Parse(httpCheckConfig.Path)
-	if err != nil {
-		log.DefaultLogger.Errorf("[upstream] [health check] [httpdial session] path=%s parse error %+v", httpCheckConfig.Path, err)
-		return nil
-	}
+	uri := &url.URL{}
 	if httpCheckConfig.Scheme == "" {
 		uri.Scheme = "http"
 	} else {
@@ -117,8 +114,12 @@ func (f *HTTPDialSessionFactory) NewSession(cfg map[string]interface{}, host typ
 		uri.Host = host.AddressString()
 	}
 
-	if httpCheckConfig.Scheme != "" {
-		uri.Scheme = httpCheckConfig.Scheme
+	strs := strings.Split(httpCheckConfig.Path, "?")
+	if len(strs) == 2 {
+		uri.Path = strs[0]
+		uri.RawQuery = strs[0]
+	} else {
+		uri.Path = strs[0]
 	}
 
 	if httpCheckConfig.Timeout.Duration > 0 {

--- a/pkg/upstream/healthcheck/httpdial_test.go
+++ b/pkg/upstream/healthcheck/httpdial_test.go
@@ -193,6 +193,14 @@ func Test_CheckL7Health(t *testing.T) {
 			expect: true,
 		},
 		{
+			name:       "normal_code_with_querystring",
+			hostAddr:   httpAddr,
+			config: HttpCheckConfig{
+				Path: "/200?test=foo&test1=bar",
+			},
+			expect: true,
+		},
+		{
 			name:       "abnormal_code",
 			serverCode: 500,
 			serverPath: "/500",


### PR DESCRIPTION
### Issues associated with this PR
Health check path: /a/b/c?k=v&foo=bar
What the server got:  /a/b/c%3Fk=v&foo=bar
Because if we set path with query string to url.Path ,it will be unescaped in url.String() method
