### PR TITLE
[bugfix]: lb ReqRoundRobin fails to choose host when index exceeds hosts length

### DIFF
--- a/pkg/upstream/cluster/loadbalancer.go
+++ b/pkg/upstream/cluster/loadbalancer.go
@@ -508,13 +508,14 @@ func (lb *reqRoundRobinLoadBalancer) ChooseHost(context types.LoadBalancerContex
 			ind = i + 1
 		}
 	}
-	for id := ind; id < total; id++ {
-		target := hs.Get(id)
+	for id := ind; id < total+ind; id++ {
+		idx := id % total
+		target := hs.Get(idx)
 		if target.Health() {
 			if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
 				log.DefaultLogger.Debugf("[lb] [RequestRoundRobin] choose host: %s", target.AddressString())
 			}
-			variable.SetString(ctx, VarProxyUpstreamIndex, strconv.Itoa(id))
+			variable.SetString(ctx, VarProxyUpstreamIndex, strconv.Itoa(idx))
 			return target
 		}
 	}

--- a/pkg/upstream/cluster/loadbalancer.go
+++ b/pkg/upstream/cluster/loadbalancer.go
@@ -519,7 +519,6 @@ func (lb *reqRoundRobinLoadBalancer) ChooseHost(context types.LoadBalancerContex
 			return target
 		}
 	}
-	variable.SetString(ctx, VarProxyUpstreamIndex, strconv.Itoa(total))
 
 	return nil
 }

--- a/pkg/upstream/cluster/loadbalancer_test.go
+++ b/pkg/upstream/cluster/loadbalancer_test.go
@@ -431,9 +431,10 @@ func TestReqRRChooseHost(t *testing.T) {
 
 	ctx := newMockLbContextWithCtx(nil, variable.NewVariableContext(context.Background()))
 	// RR when use
-	for i := 0; i < len(hosts.allHosts); i++ {
+	for i := 0; i < 2*hosts.Size(); i++ {
+		ind := i % hosts.Size()
 		host := balancer.ChooseHost(ctx)
-		assert.Equal(t, host, hosts.allHosts[i])
+		assert.Equal(t, host, hosts.allHosts[ind])
 	}
 
 	ctx0 := newMockLbContextWithCtx(nil, variable.NewVariableContext(context.Background()))


### PR DESCRIPTION
### Issues associated with this PR
When ```ChooseHost(context types.LoadBalancerContext)```  was called more times than the length of ```lb.hosts```, it will fail to choose host