### PR TITLE
[bugfix]: metrics exclusionLabels and exclusionKeys not working for static config

### DIFF
--- a/pkg/mosn/default_stages.go
+++ b/pkg/mosn/default_stages.go
@@ -41,10 +41,6 @@ func DefaultInitStage(c *v2.MOSNConfig) {
 func DefaultPreStartStage(mosn stagemanager.Application) {
 	m := mosn.(*Mosn)
 
-	// after inherit config,
-	// since metrics need the isFromUpgrade flag in Mosn
-	InitializeMetrics(m)
-
 	// start xds client
 	_ = m.StartXdsClient()
 	featuregate.FinallyInitFunc()

--- a/pkg/mosn/init.go
+++ b/pkg/mosn/init.go
@@ -28,9 +28,6 @@ import (
 	v2 "mosn.io/mosn/pkg/config/v2"
 	"mosn.io/mosn/pkg/configmanager"
 	"mosn.io/mosn/pkg/log"
-	"mosn.io/mosn/pkg/metrics"
-	"mosn.io/mosn/pkg/metrics/shm"
-	"mosn.io/mosn/pkg/metrics/sink"
 	"mosn.io/mosn/pkg/plugin"
 	"mosn.io/mosn/pkg/protocol/xprotocol"
 	xwasm "mosn.io/mosn/pkg/protocol/xprotocol/wasm"
@@ -78,30 +75,6 @@ func initializeTracing(config v2.TracingConfig) {
 	}
 }
 
-func InitializeMetrics(m *Mosn) {
-	metrics.FlushMosnMetrics = true
-	config := m.Config.Metrics
-
-	// init shm zone
-	if config.ShmZone != "" && config.ShmSize > 0 {
-		shm.InitDefaultMetricsZone(config.ShmZone, int(config.ShmSize), !m.IsFromUpgrade())
-	}
-
-	// set metrics package
-	statsMatcher := config.StatsMatcher
-	metrics.SetStatsMatcher(statsMatcher.RejectAll, statsMatcher.ExclusionLabels, statsMatcher.ExclusionKeys)
-	metrics.SetMetricsFeature(config.FlushMosn, config.LazyFlush)
-	// create sinks
-	for _, cfg := range config.SinkConfigs {
-		_, err := sink.CreateMetricsSink(cfg.Type, cfg.Config)
-		// abort
-		if err != nil {
-			log.StartLogger.Errorf("[mosn] [init metrics] %s. %v metrics sink is turned off", err, cfg.Type)
-			return
-		}
-		log.StartLogger.Infof("[mosn] [init metrics] create metrics sink: %v", cfg.Type)
-	}
-}
 
 func InitDefaultPath(c *v2.MOSNConfig) {
 	types.InitDefaultPath(configmanager.GetConfigPath(), c.UDSDir)

--- a/pkg/mosn/mosn.go
+++ b/pkg/mosn/mosn.go
@@ -27,6 +27,9 @@ import (
 	"mosn.io/mosn/pkg/configmanager"
 	"mosn.io/mosn/pkg/istio"
 	"mosn.io/mosn/pkg/log"
+	"mosn.io/mosn/pkg/metrics"
+	"mosn.io/mosn/pkg/metrics/shm"
+	"mosn.io/mosn/pkg/metrics/sink"
 	"mosn.io/mosn/pkg/network"
 	"mosn.io/mosn/pkg/router"
 	"mosn.io/mosn/pkg/server"
@@ -80,6 +83,9 @@ func (m *Mosn) Init(c *v2.MOSNConfig) error {
 
 	log.StartLogger.Infof("[mosn start] init the members of the mosn")
 
+	// after inherit config,
+	// since metrics need the isFromUpgrade flag in Mosn
+	m.initializeMetrics()
 	m.initClusterManager()
 	m.initServer()
 
@@ -140,6 +146,31 @@ func (m *Mosn) inheritConfig(c *v2.MOSNConfig) (err error) {
 		log.StartLogger.Errorf("[mosn] [NewMosn] start service failed: %v, exit", err)
 	}
 	return
+}
+
+func (m *Mosn) initializeMetrics() {
+	metrics.FlushMosnMetrics = true
+	config := m.Config.Metrics
+
+	// init shm zone
+	if config.ShmZone != "" && config.ShmSize > 0 {
+		shm.InitDefaultMetricsZone(config.ShmZone, int(config.ShmSize), !m.IsFromUpgrade())
+	}
+
+	// set metrics package
+	statsMatcher := config.StatsMatcher
+	metrics.SetStatsMatcher(statsMatcher.RejectAll, statsMatcher.ExclusionLabels, statsMatcher.ExclusionKeys)
+	metrics.SetMetricsFeature(config.FlushMosn, config.LazyFlush)
+	// create sinks
+	for _, cfg := range config.SinkConfigs {
+		_, err := sink.CreateMetricsSink(cfg.Type, cfg.Config)
+		// abort
+		if err != nil {
+			log.StartLogger.Errorf("[mosn] [init metrics] %s. %v metrics sink is turned off", err, cfg.Type)
+			return
+		}
+		log.StartLogger.Infof("[mosn] [init metrics] create metrics sink: %v", cfg.Type)
+	}
 }
 
 type clusterManagerFilter struct {


### PR DESCRIPTION
### Issues associated with this PR

```InitializeMetrics``` is called after ```initClusterManager``` and ```initServer```
cluster and host stats will be initialized before statsMatcher.ExclusionLabels and statsMatcher.ExclusionKeys set

