### PR TITLE
Update example server and client config file in README

### DIFF
--- a/examples/en_readme/http-sample/README.md
+++ b/examples/en_readme/http-sample/README.md
@@ -40,6 +40,7 @@ server_config.json // Configure without TLS
 tls_client_config.json    // Configure with TLS
 tls_server_config.json    // Configure with TLS
 ```
+> example configs: 📑 [server_config.json](https://github.com/mosn/mosn/blob/master/examples/codes/http-sample/server_config.json) and  📑 [client_config.json](https://github.com/mosn/mosn/blob/master/examples/codes/http-sample/client_config.json)
 
 ## Operation instructions
 


### PR DESCRIPTION
### Issues associated with this PR

While users are attempting to up and running the MOSN project, document enrichment would be extremely crucial to controlling the slope of learning curve. De facto clear addressing of config files in educational documents could be open floor to aspiring developers having more engaged to the project and enjoy the capabilities.

### Solutions

In the `/examples/en_readme/http-sample` we can feel the gap of recommended config file in term of easy-mode using project. To achieve this purpose the address of **current** and **stable** config file of **server** and **client** added to documentation.

