### PR TITLE
feat: use logical clock to make edf scheduler more stable

### DIFF
--- a/pkg/upstream/cluster/edf.go
+++ b/pkg/upstream/cluster/edf.go
@@ -19,7 +19,6 @@ package cluster
 
 import (
 	"sync"
-	"time"
 
 	"mosn.io/mosn/pkg/config/v2"
 )
@@ -28,6 +27,7 @@ type edfScheduler struct {
 	lock        sync.Mutex
 	items       *edfHeap
 	currentTime float64
+	clock       int64
 }
 
 func newEdfScheduler(cap int) *edfScheduler {
@@ -41,7 +41,7 @@ type edfEntry struct {
 	deadline   float64
 	weight     float64
 	item       WeightItem
-	queuedTime time.Time
+	queuedTime int64
 }
 
 type WeightItem interface {
@@ -57,7 +57,7 @@ func (edf *edfScheduler) Add(item WeightItem, weight float64) {
 		deadline:   edf.currentTime + 1.0/weight,
 		weight:     weight,
 		item:       item,
-		queuedTime: time.Now(),
+		queuedTime: edf.tick(),
 	}
 	edf.items.Push(&entry)
 }
@@ -77,9 +77,14 @@ func (edf *edfScheduler) NextAndPush(weightFunc func(item WeightItem) float64) i
 	// update the entry.deadline and put into priorityQueue again
 	entry.deadline = entry.deadline + 1.0/weight
 	entry.weight = weight
-	entry.queuedTime = time.Now()
+	entry.queuedTime = edf.tick()
 	edf.items.Fix(0)
 	return entry.item
+}
+
+func (edf *edfScheduler) tick() int64 {
+	edf.clock++
+	return edf.clock
 }
 
 func edfFixedWeight(weight float64) float64 {

--- a/pkg/upstream/cluster/edf_test.go
+++ b/pkg/upstream/cluster/edf_test.go
@@ -163,7 +163,9 @@ func TestEdfSchedulerDistribution(t *testing.T) {
 		}
 	}
 
-	for i := rnd(64, 512); i >= 0; i-- {
+	// number of hosts in [2*MaxHostWeight, 4*MaxHostWeight) to make sure
+	// always have two hosts with same weight
+	for i := rnd(2*int(v2.MaxHostWeight), 4*int(v2.MaxHostWeight)); i >= 0; i-- {
 		w := uint32(rnd(int(v2.MinHostWeight), int(v2.MaxHostWeight)))
 		weights = append(weights, w)
 		totalWeights += w

--- a/pkg/upstream/cluster/edf_test.go
+++ b/pkg/upstream/cluster/edf_test.go
@@ -18,7 +18,9 @@
 package cluster
 
 import (
+	"fmt"
 	"math"
+	"math/rand"
 	"strconv"
 	"testing"
 
@@ -139,5 +141,47 @@ func Benchmark_edfSchduler_NextAndPush(b *testing.B) {
 			}
 			b.StopTimer()
 		})
+	}
+}
+
+func TestEdfSchedulerDistribution(t *testing.T) {
+	var weights []uint32
+	totalWeights := uint32(0)
+
+	rnd := func(low, high int) int {
+		return rand.Intn(high-low) + low
+	}
+
+	checkDistribution := func(seq []string) {
+		dist := make(map[string]int)
+		for _, s := range seq {
+			dist[s]++
+		}
+		for i, w := range weights {
+			d := dist[fmt.Sprintf("host-%d", i)]
+			assert.Equal(t, uint32(d), w)
+		}
+	}
+
+	for i := rnd(64, 512); i >= 0; i-- {
+		w := uint32(rnd(int(v2.MinHostWeight), int(v2.MaxHostWeight)))
+		weights = append(weights, w)
+		totalWeights += w
+	}
+
+	scheduler := newEdfScheduler(len(weights))
+	for i, w := range weights {
+		scheduler.Add(&mockHost{name: fmt.Sprintf("host-%d", i), w: w}, float64(w))
+	}
+
+	for i := 0; i < 1024; i++ {
+		seq := make([]string, 0)
+		for i := uint32(0); i < totalWeights; i++ {
+			h := scheduler.NextAndPush(func(item WeightItem) float64 {
+				return float64(item.Weight())
+			}).(*mockHost)
+			seq = append(seq, h.name)
+		}
+		checkDistribution(seq)
 	}
 }

--- a/pkg/upstream/cluster/edf_test.go
+++ b/pkg/upstream/cluster/edf_test.go
@@ -176,7 +176,7 @@ func TestEdfSchedulerDistribution(t *testing.T) {
 		scheduler.Add(&mockHost{name: fmt.Sprintf("host-%d", i), w: w}, float64(w))
 	}
 
-	for i := 0; i < 1024; i++ {
+	for i := 0; i < 128; i++ {
 		seq := make([]string, 0)
 		for i := uint32(0); i < totalWeights; i++ {
 			h := scheduler.NextAndPush(func(item WeightItem) float64 {

--- a/pkg/upstream/cluster/edfheap.go
+++ b/pkg/upstream/cluster/edfheap.go
@@ -29,7 +29,7 @@ type edfHeap struct {
 
 func edfEntryLess(a, b *edfEntry) bool {
 	if a.deadline == b.deadline {
-		return a.weight < b.weight
+		return a.deadline < b.deadline
 	}
 	return a.deadline < b.deadline
 }

--- a/pkg/upstream/cluster/edfheap.go
+++ b/pkg/upstream/cluster/edfheap.go
@@ -29,7 +29,7 @@ type edfHeap struct {
 
 func edfEntryLess(a, b *edfEntry) bool {
 	if a.deadline == b.deadline {
-		return a.deadline < b.deadline
+		return a.queuedTime < b.queuedTime
 	}
 	return a.deadline < b.deadline
 }

--- a/pkg/upstream/cluster/edfheap_test.go
+++ b/pkg/upstream/cluster/edfheap_test.go
@@ -139,7 +139,7 @@ func TestEdfHeap_edfEntryLess(t *testing.T) {
 
 func BenchmarkEdfHeap_Push(b *testing.B) {
 	b.StopTimer()
-	h := newEdfHeap(16)
+	h := newEdfHeap(b.N)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		h.Push(&edfEntry{weight: rand.Float64()})
@@ -148,7 +148,7 @@ func BenchmarkEdfHeap_Push(b *testing.B) {
 
 func BenchmarkEdfHeap_Pop(b *testing.B) {
 	b.StopTimer()
-	h := newEdfHeap(16)
+	h := newEdfHeap(b.N)
 	for i := 0; i < b.N; i++ {
 		h.Push(&edfEntry{weight: rand.Float64()})
 	}
@@ -160,7 +160,7 @@ func BenchmarkEdfHeap_Pop(b *testing.B) {
 
 func BenchmarkEdfHeap_Fix(b *testing.B) {
 	b.StopTimer()
-	h := newEdfHeap(16)
+	h := newEdfHeap(b.N)
 	for i := 0; i < b.N; i++ {
 		h.Push(&edfEntry{weight: rand.Float64()})
 	}

--- a/pkg/upstream/cluster/edfheap_test.go
+++ b/pkg/upstream/cluster/edfheap_test.go
@@ -116,6 +116,27 @@ func TestEdfHeap_Fix(t *testing.T) {
 	}
 }
 
+func TestEdfHeap_edfEntryLess(t *testing.T) {
+	tests := []struct {
+		a    *edfEntry
+		b    *edfEntry
+		less bool
+	}{
+		{&edfEntry{deadline: 1.0, queuedTime: 1}, &edfEntry{deadline: 1.0, queuedTime: 2}, true},
+		{&edfEntry{deadline: 1.0, queuedTime: 2}, &edfEntry{deadline: 1.0, queuedTime: 1}, false},
+		{&edfEntry{deadline: 1.0, queuedTime: 1}, &edfEntry{deadline: 1.0, queuedTime: 1}, false},
+		{&edfEntry{deadline: 2.0, queuedTime: 1}, &edfEntry{deadline: 1.0, queuedTime: 1}, false},
+		{&edfEntry{deadline: 1.0, queuedTime: 1}, &edfEntry{deadline: 2.0, queuedTime: 1}, true},
+		{&edfEntry{deadline: 1.0, queuedTime: 2}, &edfEntry{deadline: 2.0, queuedTime: 1}, true},
+	}
+
+	for _, tst := range tests {
+		if edfEntryLess(tst.a, tst.b) != tst.less {
+			t.Fatalf("%v < %v must be %v", tst.a, tst.b, tst.less)
+		}
+	}
+}
+
 func BenchmarkEdfHeap_Push(b *testing.B) {
 	b.StopTimer()
 	h := newEdfHeap(16)


### PR DESCRIPTION
### Issues associated with this PR

#2185 

### Solutions
Use a logical clock to hold the enqueued time, to make sure FIFO order when both deadline and weight of entries are same.

As the proof in the https://github.com/mosn/mosn/issues/2185#issuecomment-1326078414, when deadline of entries are same, if entry `A` is left ordered to `B`, the weight of `A` is must less or equal to `B`, and the enqueued time is in the same order. But when fix the structure of the heap, we could not make sure left subtree is absolutely left ordered to the right, because binary heap is unstable. So here's a paradox where A and B enter the queue at the same time (since synchronization has been done), in order to avoid this paradox, we use a strictly self-increasing logical clock as the queue time.

### UT result
We generate random hosts and schedule them, checking their distribution every cycle. 

Ideally we should check that the sequence is the same every time, but because of the accumulation of floating point errors, there is no way to guarantee this, so we only check that the host distribution is as expected in a limited period.

```go
func TestEdfSchedulerDistribution(t *testing.T) {
	var weights []uint32
	totalWeights := uint32(0)

	rnd := func(low, high int) int {
		return rand.Intn(high-low) + low
	}

	checkDistribution := func(seq []string) {
		dist := make(map[string]int)
		for _, s := range seq {
			dist[s]++
		}
		for i, w := range weights {
			d := dist[fmt.Sprintf("host-%d", i)]
			assert.Equal(t, uint32(d), w)
		}
	}

	for i := rnd(64, 512); i >= 0; i-- {
		w := uint32(rnd(int(v2.MinHostWeight), int(v2.MaxHostWeight)))
		weights = append(weights, w)
		totalWeights += w
	}

	scheduler := newEdfScheduler(len(weights))
	for i, w := range weights {
		scheduler.Add(&mockHost{name: fmt.Sprintf("host-%d", i), w: w}, float64(w))
	}

	for i := 0; i < 1024; i++ {
		seq := make([]string, 0)
		for i := uint32(0); i < totalWeights; i++ {
			h := scheduler.NextAndPush(func(item WeightItem) float64 {
				return float64(item.Weight())
			}).(*mockHost)
			seq = append(seq, h.name)
		}
		checkDistribution(seq)
	}
}
```

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
