### PR TITLE
fix checksum mismatch for build error

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -145,7 +145,7 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/envoyproxy/go-control-plane v0.10.0 h1:WVt4HEPbdRbRD/PKKPbPnIVavO6gk/h673jWyIJ016k=
+github.com/envoyproxy/go-control-plane v0.10.0 h1:ZyeIGk3fCB8NNzihPKZsCNCc7oTz7IgMsEy0E2G3iu4=
 github.com/envoyproxy/go-control-plane v0.10.0/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
@@ -1079,8 +1079,8 @@ sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1
 vimagination.zapto.org/byteio v0.0.0-20200222190125-d27cba0f0b10 h1:pxt6fVJP67Hxo1qk8JalUghLlk3abYByl+3e0JYfUlE=
 vimagination.zapto.org/byteio v0.0.0-20200222190125-d27cba0f0b10/go.mod h1:fl9OF22g6MTKgvHA1hqMXe/L7+ULWofVTwbC9loGu7A=
 vimagination.zapto.org/memio v0.0.0-20200222190306-588ebc67b97d/go.mod h1:zHGDKp2tyvF4IAfLti4pKYqCJucXYmmKMb3UMrCHK/4=
-vimagination.zapto.org/memio v1.0.0 h1:r0GDf430aNuGpOAV57UTvbUzAf82UclRyGG/pBp1uvU=
-vimagination.zapto.org/memio v1.0.0/go.mod h1:zHGDKp2tyvF4IAfLti4pKYqCJucXYmmKMb3UMrCHK/4=
+vimagination.zapto.org/memio v1.0.0 h1:CLTG7CcGq4Pwv0TVmG2qG28/b/pV3Cr6b3emlHKnuwY=
+vimagination.zapto.org/memio v1.0.0/go.mod h1:RdXC+0ctULK7DykQQu6QeRJhQZVbAfYu+vOys0FNk4c=
 xorm.io/builder v0.3.6/go.mod h1:LEFAPISnRzG+zxaxj2vPicRwz67BdhFreKg8yv8/TgU=
 xorm.io/builder v0.3.9/go.mod h1:aUW0S9eb9VCaPohFCH3j7czOx1PMW3i1HrSzbLYGBSE=
 xorm.io/core v0.7.2-0.20190928055935-90aeac8d08eb/go.mod h1:jJfd0UAEzZ4t87nbQYtVjmqpIODugN6PD2D9E+dJvdM=


### PR DESCRIPTION
### Issues associated with this PR
build local error and it's happens when Go packages makes two releases with the same number.
 here is a same [issue](https://github.com/envoyproxy/go-control-plane/issues/467#issuecomment-959830223
) 
``` bash
$make build-local
GO111MODULE=on CGO_ENABLED=1 go build  \
        -ldflags "-B 0x30ac4ca9ad2ca939598de2a4f0f47330a087eefe -X main.Version=v1.3.0(4fa9b41b8) -X mosn.io/mosn/pkg/istio.IstioVersion=1.10.6" \
        -v -o mosnd \
        mosn.io/mosn/cmd/mosn/main
verifying github.com/envoyproxy/go-control-plane@v0.10.0: checksum mismatch
        downloaded: h1:ZyeIGk3fCB8NNzihPKZsCNCc7oTz7IgMsEy0E2G3iu4=
        go.sum:     h1:WVt4HEPbdRbRD/PKKPbPnIVavO6gk/h673jWyIJ016k=

SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.

For more information, see 'go help module-auth'.
make: *** [build-local] Error 1
```

