### PR TITLE
feat: add process time duration in variables

### DIFF
--- a/pkg/proxy/var.go
+++ b/pkg/proxy/var.go
@@ -37,6 +37,7 @@ var (
 		variable.NewStringVariable(types.VarRequestReceivedDuration, nil, receivedDurationGetter, nil, 0),
 		variable.NewStringVariable(types.VarResponseReceivedDuration, nil, responseReceivedDurationGetter, nil, 0),
 		variable.NewStringVariable(types.VarRequestFinishedDuration, nil, requestFinishedDurationGetter, nil, 0),
+		variable.NewStringVariable(types.VarProcessTimeDuration, nil, processTimeDurationGetter, nil, 0),
 		variable.NewStringVariable(types.VarBytesSent, nil, bytesSentGetter, nil, 0),
 		variable.NewStringVariable(types.VarBytesReceived, nil, bytesReceivedGetter, nil, 0),
 		variable.NewStringVariable(types.VarProtocol, nil, protocolGetter, nil, 0),
@@ -113,6 +114,14 @@ func requestFinishedDurationGetter(ctx context.Context, value *variable.IndexedV
 	info := proxyBuffers.info
 
 	return info.RequestFinishedDuration().String(), nil
+}
+
+// ProcessTimeDurationGetter gets the duration between request arriving and request request forwarding, plus the duration between resposne arriving and response sending
+func processTimeDurationGetter(ctx context.Context, value *variable.IndexedValue, data interface{}) (string, error) {
+	proxyBuffers := proxyBuffersByContext(ctx)
+	info := proxyBuffers.info
+
+	return info.ProcessTimeDuration().String(), nil
 }
 
 // BytesSentGetter

--- a/pkg/types/variable.go
+++ b/pkg/types/variable.go
@@ -31,6 +31,7 @@ const (
 	VarRequestReceivedDuration        string = "request_received_duration"
 	VarResponseReceivedDuration       string = "response_received_duration"
 	VarRequestFinishedDuration        string = "request_finished_duration"
+	VarProcessTimeDuration            string = "process_time_duration"
 	VarBytesSent                      string = "bytes_sent"
 	VarBytesReceived                  string = "bytes_received"
 	VarProtocol                       string = "protocol"


### PR DESCRIPTION
### Issues associated with this PR

Add the process_time_duration field to the variables to print the additional time taken by mosn in the log

