### PR TITLE
bugfix: healthcheck panic 

### DIFF
--- a/pkg/upstream/healthcheck/healthchecker.go
+++ b/pkg/upstream/healthcheck/healthchecker.go
@@ -240,8 +240,8 @@ func (hc *healthChecker) getCheckInterval() time.Duration {
 	interval := hc.intervalBase
 	if hc.intervalJitter > 0 {
 		hc.mux.Lock()
-		defer hc.mux.Unlock()
 		interval += time.Duration(hc.rander.Int63n(int64(hc.intervalJitter)))
+		hc.mux.Unlock()
 	}
 	// TODO: support jitter percentage
 	return interval

--- a/pkg/upstream/healthcheck/healthchecker.go
+++ b/pkg/upstream/healthcheck/healthchecker.go
@@ -19,6 +19,7 @@ package healthcheck
 
 import (
 	"math/rand"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -57,6 +58,7 @@ type healthChecker struct {
 	initialDelay       time.Duration
 	unhealthyThreshold uint32
 	rander             rand.Rand
+	mux                sync.Mutex
 	hostCheckCallbacks []types.HealthCheckCb
 	logger             types.HealthCheckLog
 }
@@ -237,6 +239,8 @@ func (hc *healthChecker) runCallbacks(host types.Host, changed bool, isHealthy b
 func (hc *healthChecker) getCheckInterval() time.Duration {
 	interval := hc.intervalBase
 	if hc.intervalJitter > 0 {
+		hc.mux.Lock()
+		defer hc.mux.Unlock()
 		interval += time.Duration(hc.rander.Int63n(int64(hc.intervalJitter)))
 	}
 	// TODO: support jitter percentage


### PR DESCRIPTION
### Issues associated with this PR
https://github.com/mosn/mosn/issues/2227 is not completely fixed.
The health check tasks of different hosts in the same cluster will reuse the same "rander", so calling Rand() concurrently still occasionally cause panic