### PR TITLE
Disable over strict linters in workflow

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,7 +15,7 @@ jobs:
         uses: reviewdog/action-golangci-lint@v2
         if: github.event_name == 'pull_request'
         with:
-          golangci_lint_flags: "--skip-dirs=mtls/crypto,module/http2 --enable-all --timeout=10m --exclude-use-default=false --tests=false --disable=gochecknoinits,gochecknoglobals,exhaustive,nakedret,exhaustivestruct,ireturn"
+          golangci_lint_flags: "--skip-dirs=mtls/crypto,module/http2 --enable-all --timeout=10m --exclude-use-default=false --tests=false --disable=gochecknoinits,gochecknoglobals,exhaustive,exhaustruct,nakedret,ireturn,interfacer,tagliatelle,varnamelen"
           workdir: pkg
 
   test:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,7 +15,7 @@ jobs:
         uses: reviewdog/action-golangci-lint@v2
         if: github.event_name == 'pull_request'
         with:
-          golangci_lint_flags: "--skip-dirs=mtls/crypto,module/http2 --enable-all --timeout=10m --exclude-use-default=false --tests=false --disable=gochecknoinits,gochecknoglobals,exhaustive,nakedret,exhaustivestruct"
+          golangci_lint_flags: "--skip-dirs=mtls/crypto,module/http2 --enable-all --timeout=10m --exclude-use-default=false --tests=false --disable=gochecknoinits,gochecknoglobals,exhaustive,nakedret,exhaustivestruct,ireturn"
           workdir: pkg
 
   test:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,7 +15,7 @@ jobs:
         uses: reviewdog/action-golangci-lint@v2
         if: github.event_name == 'pull_request'
         with:
-          golangci_lint_flags: "--skip-dirs=mtls/crypto,module/http2 --enable-all --timeout=10m --exclude-use-default=false --tests=false --disable=gochecknoinits,gochecknoglobals,exhaustive,exhaustruct,nakedret,ireturn,interfacer,tagliatelle,varnamelen"
+          golangci_lint_flags: "--skip-dirs=mtls/crypto,module/http2 --enable-all --timeout=10m --exclude-use-default=false --tests=false --disable=gochecknoinits,gochecknoglobals,exhaustive,exhaustruct,exhaustivestruct,nakedret,ireturn,interfacer,tagliatelle,varnamelen"
           workdir: pkg
 
   test:


### PR DESCRIPTION
### Issues associated with this PR

#2256 

### Solutions
Disable `ireturn` in workflow file
