### PR TITLE
fix, receiver names are different for connection object

### DIFF
--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -35,12 +35,13 @@ import (
 	"github.com/rcrowley/go-metrics"
 	"golang.org/x/sys/unix"
 	"mosn.io/api"
-	"mosn.io/mosn/pkg/log"
-	"mosn.io/mosn/pkg/mtls"
-	"mosn.io/mosn/pkg/types"
 	"mosn.io/pkg/buffer"
 	"mosn.io/pkg/utils"
 	"mosn.io/pkg/variable"
+
+	"mosn.io/mosn/pkg/log"
+	"mosn.io/mosn/pkg/mtls"
+	"mosn.io/mosn/pkg/types"
 )
 
 // Network related const
@@ -257,11 +258,11 @@ func (c *connection) SetIdleTimeout(readTimeout time.Duration, idleTimeout time.
 	c.newIdleChecker(readTimeout, idleTimeout)
 }
 
-func (conn *connection) OnConnectionEvent(event api.ConnectionEvent) {
+func (c *connection) OnConnectionEvent(event api.ConnectionEvent) {
 	if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
 		log.DefaultLogger.Debugf("[network] receive new connection event %s, try to handle", event)
 	}
-	for _, listener := range conn.connCallbacks {
+	for _, listener := range c.connCallbacks {
 		listener.OnEvent(event)
 	}
 }

--- a/pkg/network/idlechecker.go
+++ b/pkg/network/idlechecker.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"mosn.io/api"
+
 	"mosn.io/mosn/pkg/log"
 	"mosn.io/mosn/pkg/types"
 )
@@ -48,15 +49,15 @@ type idleChecker struct {
 	lastRead     int64
 }
 
-func (conn *connection) newIdleChecker(readTimeout time.Duration, idleTimeout time.Duration) {
+func (c *connection) newIdleChecker(readTimeout time.Duration, idleTimeout time.Duration) {
 	checker := &idleChecker{
-		conn:         conn,
+		conn:         c,
 		maxIdleCount: getIdleCount(readTimeout, idleTimeout),
 	}
 	if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
-		log.DefaultLogger.Debugf("new idlechecker: maxIdleCount:%d, conn:%d", checker.maxIdleCount, conn.id)
+		log.DefaultLogger.Debugf("new idlechecker: maxIdleCount:%d, conn:%d", checker.maxIdleCount, c.id)
 	}
-	conn.AddConnectionEventListener(checker)
+	c.AddConnectionEventListener(checker)
 }
 
 func (c *idleChecker) closeConnection() {


### PR DESCRIPTION
### Issues associated with this PR

fix, receiver names are different for connection object

