### PR TITLE
bugfix: request duration reflect the time to establish connection

### DIFF
--- a/pkg/metrics/upstream.go
+++ b/pkg/metrics/upstream.go
@@ -24,7 +24,7 @@ import (
 // UpstreamType represents upstream metrics type
 const UpstreamType = "upstream"
 
-//  key in cluster/host
+// key in cluster/host
 const (
 	UpstreamConnectionTotal                        = "connection_total"
 	UpstreamConnectionClose                        = "connection_close"
@@ -45,11 +45,13 @@ const (
 	UpstreamRequestPendingOverflow                 = "request_pending_overflow"
 	UpstreamRequestDuration                        = "request_duration_time"
 	UpstreamRequestDurationTotal                   = "request_duration_time_total"
+	UpstreamProxyDuration                          = "proxy_duration_time"
+	UpstreamProxyDurationTotal                     = "proxy_duration_time_total"
 	UpstreamResponseSuccess                        = "response_success"
 	UpstreamResponseFailed                         = "response_failed"
 )
 
-//  key in cluster
+// key in cluster
 const (
 	UpstreamRequestRetry         = "request_retry"
 	UpstreamRequestRetryOverflow = "request_retry_overflow"

--- a/pkg/proxy/gomock_test.go
+++ b/pkg/proxy/gomock_test.go
@@ -37,6 +37,8 @@ func gomockClusterInfo(ctrl *gomock.Controller) types.ClusterInfo {
 		return types.ClusterStats{
 			UpstreamRequestDuration:      s.Histogram(metrics.UpstreamRequestDuration),
 			UpstreamRequestDurationTotal: s.Counter(metrics.UpstreamRequestDurationTotal),
+			UpstreamProxyDuration:        s.Histogram(metrics.UpstreamProxyDuration),
+			UpstreamProxyDurationTotal:   s.Counter(metrics.UpstreamProxyDurationTotal),
 			UpstreamResponseSuccess:      s.Counter(metrics.UpstreamResponseSuccess),
 			UpstreamResponseFailed:       s.Counter(metrics.UpstreamResponseFailed),
 		}
@@ -95,7 +97,7 @@ func gomockStreamSender(ctrl *gomock.Controller) types.StreamSender {
 
 }
 
-//  mock a simple route rule that route a request to a cluster
+// mock a simple route rule that route a request to a cluster
 func gomockRouteMatchCluster(ctrl *gomock.Controller, cluster_name string) api.Route {
 	r := mock.NewMockRoute(ctrl)
 	// mock route rule returns cluster name : mock_cluster

--- a/pkg/proxy/proxy_downstream_test.go
+++ b/pkg/proxy/proxy_downstream_test.go
@@ -90,6 +90,8 @@ func TestProxyWithFilters(t *testing.T) {
 					return types.HostStats{
 						UpstreamRequestDuration:      s.Histogram(metrics.UpstreamRequestDuration),
 						UpstreamRequestDurationTotal: s.Counter(metrics.UpstreamRequestDurationTotal),
+						UpstreamProxyDuration:        s.Histogram(metrics.UpstreamProxyDuration),
+						UpstreamProxyDurationTotal:   s.Counter(metrics.UpstreamProxyDurationTotal),
 						UpstreamResponseFailed:       s.Counter(metrics.UpstreamResponseFailed),
 						UpstreamResponseSuccess:      s.Counter(metrics.UpstreamResponseSuccess),
 					}

--- a/pkg/proxy/upstream.go
+++ b/pkg/proxy/upstream.go
@@ -167,6 +167,8 @@ func (r *upstreamRequest) appendHeaders(endStream bool) {
 		failReason   types.PoolFailureReason
 	)
 
+	r.startTime = time.Now()
+
 	if r.downStream.oneway {
 		_, streamSender, failReason = r.connPool.NewStream(r.downStream.context, nil)
 	} else {
@@ -232,8 +234,6 @@ func (r *upstreamRequest) OnReady(sender types.StreamSender) {
 
 	r.requestSender = sender
 	r.requestSender.GetStream().AddEventListener(r)
-	// start a upstream send
-	r.startTime = time.Now()
 
 	if trace.IsEnabled() {
 		span := trace.SpanFromContext(r.downStream.context)

--- a/pkg/types/upstream.go
+++ b/pkg/types/upstream.go
@@ -275,6 +275,8 @@ type HostStats struct {
 	UpstreamRequestPendingOverflow                 metrics.Counter
 	UpstreamRequestDuration                        metrics.Histogram
 	UpstreamRequestDurationTotal                   metrics.Counter
+	UpstreamProxyDuration                          metrics.Histogram
+	UpstreamProxyDurationTotal                     metrics.Counter
 	UpstreamResponseSuccess                        metrics.Counter
 	UpstreamResponseFailed                         metrics.Counter
 }
@@ -304,6 +306,8 @@ type ClusterStats struct {
 	UpstreamRequestPendingOverflow                 metrics.Counter
 	UpstreamRequestDuration                        metrics.Histogram
 	UpstreamRequestDurationTotal                   metrics.Counter
+	UpstreamProxyDuration                          metrics.Histogram
+	UpstreamProxyDurationTotal                     metrics.Counter
 	UpstreamResponseSuccess                        metrics.Counter
 	UpstreamResponseFailed                         metrics.Counter
 	LBSubSetsFallBack                              metrics.Counter

--- a/pkg/upstream/cluster/stats.go
+++ b/pkg/upstream/cluster/stats.go
@@ -44,6 +44,8 @@ func newHostStats(clustername string, addr string) types.HostStats {
 		UpstreamRequestPendingOverflow:                 s.Counter(metrics.UpstreamRequestPendingOverflow),
 		UpstreamRequestDuration:                        s.Histogram(metrics.UpstreamRequestDuration),
 		UpstreamRequestDurationTotal:                   s.Counter(metrics.UpstreamRequestDurationTotal),
+		UpstreamProxyDuration:                          s.Histogram(metrics.UpstreamProxyDuration),
+		UpstreamProxyDurationTotal:                     s.Counter(metrics.UpstreamProxyDurationTotal),
 		UpstreamResponseSuccess:                        s.Counter(metrics.UpstreamResponseSuccess),
 		UpstreamResponseFailed:                         s.Counter(metrics.UpstreamResponseFailed),
 	}
@@ -75,6 +77,8 @@ func newClusterStats(clustername string) types.ClusterStats {
 		UpstreamRequestPendingOverflow:                 s.Counter(metrics.UpstreamRequestPendingOverflow),
 		UpstreamRequestDuration:                        s.Histogram(metrics.UpstreamRequestDuration),
 		UpstreamRequestDurationTotal:                   s.Counter(metrics.UpstreamRequestDurationTotal),
+		UpstreamProxyDuration:                          s.Histogram(metrics.UpstreamProxyDuration),
+		UpstreamProxyDurationTotal:                     s.Counter(metrics.UpstreamProxyDurationTotal),
 		UpstreamResponseSuccess:                        s.Counter(metrics.UpstreamResponseSuccess),
 		UpstreamResponseFailed:                         s.Counter(metrics.UpstreamResponseFailed),
 		LBSubSetsFallBack:                              s.Counter(metrics.UpstreamLBSubSetsFallBack),


### PR DESCRIPTION
### Issues associated with this PR

#2266 

### Solutions
Record request start time before getting connection.