### PR TITLE
feat: use pointer to avoid overhead of duffcopy and duffzero

### DIFF
--- a/pkg/mock/upstream.go
+++ b/pkg/mock/upstream.go
@@ -693,10 +693,10 @@ func (mr *MockHostMockRecorder) HealthFlag() *gomock.Call {
 }
 
 // HostStats mocks base method.
-func (m *MockHost) HostStats() types.HostStats {
+func (m *MockHost) HostStats() *types.HostStats {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HostStats")
-	ret0, _ := ret[0].(types.HostStats)
+	ret0, _ := ret[0].(*types.HostStats)
 	return ret0
 }
 
@@ -1032,10 +1032,10 @@ func (mr *MockClusterInfoMockRecorder) SlowStart() *gomock.Call {
 }
 
 // Stats mocks base method.
-func (m *MockClusterInfo) Stats() types.ClusterStats {
+func (m *MockClusterInfo) Stats() *types.ClusterStats {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stats")
-	ret0, _ := ret[0].(types.ClusterStats)
+	ret0, _ := ret[0].(*types.ClusterStats)
 	return ret0
 }
 

--- a/pkg/proxy/gomock_test.go
+++ b/pkg/proxy/gomock_test.go
@@ -32,9 +32,9 @@ import (
 // gomock func wrapper
 func gomockClusterInfo(ctrl *gomock.Controller) types.ClusterInfo {
 	info := mock.NewMockClusterInfo(ctrl)
-	info.EXPECT().Stats().DoAndReturn(func() types.ClusterStats {
+	info.EXPECT().Stats().DoAndReturn(func() *types.ClusterStats {
 		s := metrics.NewClusterStats("mockcluster")
-		return types.ClusterStats{
+		return &types.ClusterStats{
 			UpstreamRequestDuration:      s.Histogram(metrics.UpstreamRequestDuration),
 			UpstreamRequestDurationTotal: s.Counter(metrics.UpstreamRequestDurationTotal),
 			UpstreamResponseSuccess:      s.Counter(metrics.UpstreamResponseSuccess),
@@ -95,7 +95,7 @@ func gomockStreamSender(ctrl *gomock.Controller) types.StreamSender {
 
 }
 
-//  mock a simple route rule that route a request to a cluster
+// mock a simple route rule that route a request to a cluster
 func gomockRouteMatchCluster(ctrl *gomock.Controller, cluster_name string) api.Route {
 	r := mock.NewMockRoute(ctrl)
 	// mock route rule returns cluster name : mock_cluster

--- a/pkg/proxy/proxy_downstream_test.go
+++ b/pkg/proxy/proxy_downstream_test.go
@@ -85,9 +85,9 @@ func TestProxyWithFilters(t *testing.T) {
 				pool := mock.NewMockConnectionPool(ctrl)
 				// mock connPool.NewStream to call upstreamRequest.OnReady (see stream/xprotocol/connpool.go:NewStream)
 				h := mock.NewMockHost(ctrl)
-				h.EXPECT().HostStats().DoAndReturn(func() types.HostStats {
+				h.EXPECT().HostStats().DoAndReturn(func() *types.HostStats {
 					s := metrics.NewHostStats("mockhost", "mockhost")
-					return types.HostStats{
+					return &types.HostStats{
 						UpstreamRequestDuration:      s.Histogram(metrics.UpstreamRequestDuration),
 						UpstreamRequestDurationTotal: s.Counter(metrics.UpstreamRequestDurationTotal),
 						UpstreamResponseFailed:       s.Counter(metrics.UpstreamResponseFailed),

--- a/pkg/proxy/retrystate_test.go
+++ b/pkg/proxy/retrystate_test.go
@@ -41,8 +41,8 @@ type fakeClusterInfo struct {
 func (ci *fakeClusterInfo) ResourceManager() types.ResourceManager {
 	return ci.mgr
 }
-func (ci *fakeClusterInfo) Stats() types.ClusterStats {
-	return types.ClusterStats{
+func (ci *fakeClusterInfo) Stats() *types.ClusterStats {
+	return &types.ClusterStats{
 		UpstreamRequestRetryOverflow: metrics.NewCounter(),
 		UpstreamRequestRetry:         metrics.NewCounter(),
 	}

--- a/pkg/stream/http/connpool_test.go
+++ b/pkg/stream/http/connpool_test.go
@@ -79,8 +79,8 @@ func (ci *fakeClusterInfo) ConnBufferLimitBytes() uint32 {
 	return 0
 }
 
-func (ci *fakeClusterInfo) Stats() types.ClusterStats {
-	return types.ClusterStats{
+func (ci *fakeClusterInfo) Stats() *types.ClusterStats {
+	return &types.ClusterStats{
 		UpstreamRequestPendingOverflow:                 metrics.NewCounter(),
 		UpstreamConnectionRemoteCloseWithActiveRequest: metrics.NewCounter(),
 		UpstreamConnectionTotal:                        metrics.NewCounter(),

--- a/pkg/stream/xprotocol/connpool_pingpong_test.go
+++ b/pkg/stream/xprotocol/connpool_pingpong_test.go
@@ -33,8 +33,8 @@ import (
 	"mosn.io/mosn/pkg/stream"
 	"mosn.io/mosn/pkg/types"
 	"mosn.io/mosn/pkg/upstream/cluster"
-	"mosn.io/pkg/variable"
 	"mosn.io/pkg/buffer"
+	"mosn.io/pkg/variable"
 )
 
 func TestPingPong(t *testing.T) {
@@ -94,7 +94,7 @@ func TestPingPongBoundary(t *testing.T) {
 	// set mock host info
 	mockClusterInfo := mock.NewMockClusterInfo(ctrl)
 	s1 := metrics.NewClusterStats("test_clustername")
-	mockClusterInfo.EXPECT().Stats().Return(types.ClusterStats{
+	mockClusterInfo.EXPECT().Stats().Return(&types.ClusterStats{
 		UpstreamRequestPendingOverflow: s1.Counter(metrics.UpstreamRequestPendingOverflow),
 		UpstreamRequestFailureEject:    s1.Counter(metrics.UpstreamRequestFailureEject),
 		UpstreamRequestLocalReset:      s1.Counter(metrics.UpstreamRequestLocalReset),
@@ -102,7 +102,7 @@ func TestPingPongBoundary(t *testing.T) {
 	}).AnyTimes()
 	host.EXPECT().ClusterInfo().Return(mockClusterInfo).AnyTimes()
 	s := metrics.NewHostStats("test_clustername", "test_host_addr")
-	host.EXPECT().HostStats().Return(types.HostStats{
+	host.EXPECT().HostStats().Return(&types.HostStats{
 		UpstreamRequestPendingOverflow: s.Counter(metrics.UpstreamRequestPendingOverflow),
 		UpstreamRequestFailureEject:    s.Counter(metrics.UpstreamRequestFailureEject),
 		UpstreamRequestLocalReset:      s.Counter(metrics.UpstreamRequestLocalReset),

--- a/pkg/types/upstream.go
+++ b/pkg/types/upstream.go
@@ -153,7 +153,7 @@ type Host interface {
 	api.HostInfo
 
 	// HostStats returns the host stats metrics
-	HostStats() HostStats
+	HostStats() *HostStats
 
 	// ClusterInfo returns the cluster info
 	ClusterInfo() ClusterInfo
@@ -200,7 +200,7 @@ type ClusterInfo interface {
 	Mark() uint32
 
 	// Stats returns the cluster's stats metrics
-	Stats() ClusterStats
+	Stats() *ClusterStats
 
 	// ResourceManager returns the ResourceManager
 	ResourceManager() ResourceManager

--- a/pkg/upstream/cluster/cluster.go
+++ b/pkg/upstream/cluster/cluster.go
@@ -212,7 +212,7 @@ type clusterInfo struct {
 	maxRequestsPerConn   uint32
 	mark                 uint32
 	resourceManager      types.ResourceManager
-	stats                types.ClusterStats
+	stats                *types.ClusterStats
 	lbSubsetInfo         types.LBSubsetInfo
 	lbOriDstInfo         types.LBOriDstInfo
 	clusterManagerTLS    bool
@@ -247,7 +247,7 @@ func (ci *clusterInfo) Mark() uint32 {
 	return ci.mark
 }
 
-func (ci *clusterInfo) Stats() types.ClusterStats {
+func (ci *clusterInfo) Stats() *types.ClusterStats {
 	return ci.stats
 }
 

--- a/pkg/upstream/cluster/host.go
+++ b/pkg/upstream/cluster/host.go
@@ -38,7 +38,7 @@ type simpleHost struct {
 	hostname                string
 	addressString           string
 	clusterInfo             atomic.Value // store types.ClusterInfo
-	stats                   types.HostStats
+	stats                   *types.HostStats
 	metaData                api.Metadata
 	tlsDisable              bool
 	weight                  uint32
@@ -95,7 +95,7 @@ func (sh *simpleHost) AddressString() string {
 	return sh.addressString
 }
 
-func (sh *simpleHost) HostStats() types.HostStats {
+func (sh *simpleHost) HostStats() *types.HostStats {
 	return sh.stats
 }
 

--- a/pkg/upstream/cluster/mock_test.go
+++ b/pkg/upstream/cluster/mock_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 var _ types.HostSet = &mockHostSet{}
+
 type mockHostSet struct {
 	hosts                   []types.Host
 	healthCheckVisitedCount int
@@ -40,8 +41,8 @@ func (hs *mockHostSet) Get(i int) types.Host {
 }
 
 func (hs *mockHostSet) Range(f func(types.Host) bool) {
-	for _, h := range hs.hosts{
-		if !f(h){
+	for _, h := range hs.hosts {
+		if !f(h) {
 			break
 		}
 	}
@@ -50,7 +51,7 @@ func (hs *mockHostSet) Range(f func(types.Host) bool) {
 func (hs *mockHostSet) Hosts() []types.Host {
 	return hs.hosts
 }
-func (hs *mockHostSet)Size()int{
+func (hs *mockHostSet) Size() int {
 	return len(hs.hosts)
 }
 
@@ -78,7 +79,7 @@ type mockHost struct {
 	w          uint32
 	healthFlag *uint64
 	types.Host
-	stats   types.HostStats
+	stats   *types.HostStats
 	hostSet types.HostSet
 }
 
@@ -123,7 +124,7 @@ func (h *mockHost) SetHealthFlag(flag api.HealthFlag) {
 func (h *mockHost) HealthFlag() api.HealthFlag {
 	return api.HealthFlag(atomic.LoadUint64(h.healthFlag))
 }
-func (h *mockHost) HostStats() types.HostStats {
+func (h *mockHost) HostStats() *types.HostStats {
 	return h.stats
 }
 

--- a/pkg/upstream/cluster/stats.go
+++ b/pkg/upstream/cluster/stats.go
@@ -22,10 +22,10 @@ import (
 	"mosn.io/mosn/pkg/types"
 )
 
-func newHostStats(clustername string, addr string) types.HostStats {
+func newHostStats(clustername string, addr string) *types.HostStats {
 	s := metrics.NewHostStats(clustername, addr)
 
-	return types.HostStats{
+	return &types.HostStats{
 		UpstreamConnectionTotal:                        s.Counter(metrics.UpstreamConnectionTotal),
 		UpstreamConnectionClose:                        s.Counter(metrics.UpstreamConnectionClose),
 		UpstreamConnectionActive:                       s.Counter(metrics.UpstreamConnectionActive),
@@ -49,9 +49,9 @@ func newHostStats(clustername string, addr string) types.HostStats {
 	}
 }
 
-func newClusterStats(clustername string) types.ClusterStats {
+func newClusterStats(clustername string) *types.ClusterStats {
 	s := metrics.NewClusterStats(clustername)
-	return types.ClusterStats{
+	return &types.ClusterStats{
 		UpstreamConnectionTotal:                        s.Counter(metrics.UpstreamConnectionTotal),
 		UpstreamConnectionClose:                        s.Counter(metrics.UpstreamConnectionClose),
 		UpstreamConnectionActive:                       s.Counter(metrics.UpstreamConnectionActive),

--- a/pkg/upstream/cluster/subset_loadbalancer.go
+++ b/pkg/upstream/cluster/subset_loadbalancer.go
@@ -29,7 +29,7 @@ import (
 
 type subsetLoadBalancer struct {
 	lbType         types.LoadBalancerType
-	stats          types.ClusterStats
+	stats          *types.ClusterStats
 	subSets        types.LbSubsetMap  // final trie-like structure used to stored easily searched subset
 	fallbackSubset *LBSubsetEntryImpl // subset entry generated according to fallback policy
 	hostSet        types.HostSet

--- a/pkg/upstream/cluster/subset_loadbalancer_test.go
+++ b/pkg/upstream/cluster/subset_loadbalancer_test.go
@@ -245,14 +245,14 @@ func (r *subSetMapResult) RangeSubsetMap(prefix string, subsetMap types.LbSubset
 		}
 	}
 }
-func newSubsetLoadBalancers(lbType types.LoadBalancerType, hosts *hostSet, stats types.ClusterStats, subsets types.LBSubsetInfo) map[string]*subsetLoadBalancer {
+func newSubsetLoadBalancers(lbType types.LoadBalancerType, hosts *hostSet, stats *types.ClusterStats, subsets types.LBSubsetInfo) map[string]*subsetLoadBalancer {
 	return map[string]*subsetLoadBalancer{
 		"default":  newSubsetLoadBalancer(lbType, hosts, stats, subsets),
 		"preIndex": newSubsetLoadBalancerPreIndex(lbType, hosts, stats, subsets),
 	}
 }
 
-func newSubsetLoadBalancerPreIndex(lbType types.LoadBalancerType, hosts *hostSet, stats types.ClusterStats, subsets types.LBSubsetInfo) *subsetLoadBalancer {
+func newSubsetLoadBalancerPreIndex(lbType types.LoadBalancerType, hosts *hostSet, stats *types.ClusterStats, subsets types.LBSubsetInfo) *subsetLoadBalancer {
 	info := &clusterInfo{
 		lbType:       lbType,
 		stats:        stats,
@@ -262,7 +262,7 @@ func newSubsetLoadBalancerPreIndex(lbType types.LoadBalancerType, hosts *hostSet
 	return lb.(*subsetLoadBalancer)
 }
 
-func newSubsetLoadBalancer(lbType types.LoadBalancerType, hosts *hostSet, stats types.ClusterStats, subsets types.LBSubsetInfo) *subsetLoadBalancer {
+func newSubsetLoadBalancer(lbType types.LoadBalancerType, hosts *hostSet, stats *types.ClusterStats, subsets types.LBSubsetInfo) *subsetLoadBalancer {
 	info := &clusterInfo{
 		lbType:       lbType,
 		stats:        stats,


### PR DESCRIPTION
### Issues associated with this PR

#2271 

### Solutions
Use pointer to avoid overhead of duffcopy and duffzero

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
A simple benchmark (uncommited)
```go
func BenchmarkHostStats(b *testing.B) {
	host := mockHost{
		stats: types.HostStats{
			UpstreamRequestTotal: metrics.NilCounter{},
		},
	}
	for i := 0; i < b.N; i++ {
		host.HostStats().UpstreamRequestTotal.Inc(1)
	}
}
```

Original:
```
goos: darwin
goarch: amd64
pkg: mosn.io/mosn/pkg/upstream/cluster
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkHostStats
BenchmarkHostStats-16    	157849017	         7.770 ns/op
PASS
```

Now:
```
goos: darwin
goarch: amd64
pkg: mosn.io/mosn/pkg/upstream/cluster
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkHostStats
BenchmarkHostStats-16    	751526236	         1.638 ns/op
PASS
```

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
