### PR TITLE
fix: nil interface panic

### DIFF
--- a/pkg/upstream/cluster/host.go
+++ b/pkg/upstream/cluster/host.go
@@ -116,12 +116,12 @@ func (sh *simpleHost) Config() v2.Host {
 }
 
 func (sh *simpleHost) SupportTLS() bool {
-	return IsSupportTLS() && !sh.tlsDisable && sh.ClusterInfo().TLSMng().Enabled()
+	return IsSupportTLS() && !sh.tlsDisable && sh.ClusterInfo().TLSMng() != nil && sh.ClusterInfo().TLSMng().Enabled()
 }
 
 func (sh *simpleHost) TLSHashValue() *types.HashValue {
 	// check tls_disable config
-	if sh.tlsDisable || !sh.ClusterInfo().TLSMng().Enabled() {
+	if sh.tlsDisable || sh.ClusterInfo().TLSMng() == nil || !sh.ClusterInfo().TLSMng().Enabled() {
 		return disableTLSHashValue
 	}
 	// check global tls


### PR DESCRIPTION
### Issues associated with this PR

修复 #2289 

错误原因：证书路径有问题，新建 clientContextManager 返回 nil，后续使用它的 Enabled 函数判断是否支持 tls。

clientContextManager.Enabled() 有对指针是否为空的判断，但是新建时如果返回空接口(而不是空结构体指针)，接口调用时会直接 panic

```go
func (mng *clientContextManager) Enabled() bool {
	return mng != nil && mng.provider != nil && mng.provider.Ready()
}
```

```go
func NewTLSClientContextManager(name string, cfg *v2.TLSConfig) (*clientContextManager, error) {
	provider, err := NewProvider(clientContextPrefix+name, cfg)
	if err != nil {
		return nil, err  //  <-------- 如果返回接口，调用 Enabled 时无法判断类型 panic
	}
	mng := &clientContextManager{
		provider: provider,
		fallback: cfg.Fallback,
	}
	return mng, nil
}
```