### PR TITLE
fix: `activeRequestBias` missing default value (1.0 but not 0.0), and fix typo

### DIFF
--- a/pkg/upstream/cluster/benchmark_test.go
+++ b/pkg/upstream/cluster/benchmark_test.go
@@ -303,7 +303,7 @@ func BenchmarkLeastActiveRequestLB(b *testing.B) {
 	hostSet := &hostSet{}
 	hosts := makePool(10).MakeHosts(10, map[string]string{"cluster": ""})
 	hostSet.setFinalHost(hosts)
-	lb := newleastActiveRequestLoadBalancer(nil, hostSet)
+	lb := newLeastActiveRequestLoadBalancer(nil, hostSet)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			lb.ChooseHost(nil)

--- a/pkg/upstream/cluster/lb_leastconnection.go
+++ b/pkg/upstream/cluster/lb_leastconnection.go
@@ -30,13 +30,14 @@ type leastActiveConnectionLoadBalancer struct {
 	activeConnectionBias float64
 }
 
-func newleastActiveConnectionLoadBalancer(info types.ClusterInfo, hosts types.HostSet) types.LoadBalancer {
+func newLeastActiveConnectionLoadBalancer(info types.ClusterInfo, hosts types.HostSet) types.LoadBalancer {
 	lb := &leastActiveConnectionLoadBalancer{}
 	if info != nil && info.LbConfig() != nil {
 		lb.choice = info.LbConfig().ChoiceCount
 		lb.activeConnectionBias = info.LbConfig().ActiveRequestBias
 	} else {
-		lb.choice = default_choice
+		lb.choice = defaultChoice
+		lb.activeConnectionBias = defaultActiveRequestBias
 	}
 	lb.EdfLoadBalancer = newEdfLoadBalancer(info, hosts, lb.unweightChooseHost, lb.hostWeight)
 	return lb

--- a/pkg/upstream/cluster/lb_leastconnection_test.go
+++ b/pkg/upstream/cluster/lb_leastconnection_test.go
@@ -98,14 +98,14 @@ func TestLeastActiveConnectionLoadBalancer_ChooseHost(t *testing.T) {
 	t.Run("no bias", func(t *testing.T) {
 		verify(t, nil, 0.15)
 	})
-	t.Run("bias 0.9", func(t *testing.T) {
+	t.Run("low bias", func(t *testing.T) {
 		verify(t, &clusterInfo{
 			lbConfig: &v2.LbConfig{
 				ActiveRequestBias: 0.5,
 			},
 		}, 0.15)
 	})
-	t.Run("bias 1.1", func(t *testing.T) {
+	t.Run("high bias", func(t *testing.T) {
 		verify(t, &clusterInfo{
 			lbConfig: &v2.LbConfig{
 				ActiveRequestBias: 1.5,

--- a/pkg/upstream/cluster/lb_leastconnection_test.go
+++ b/pkg/upstream/cluster/lb_leastconnection_test.go
@@ -18,9 +18,12 @@
 package cluster
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	v2 "mosn.io/mosn/pkg/config/v2"
 	"mosn.io/mosn/pkg/types"
 )
 
@@ -52,4 +55,61 @@ func TestLACChooseHost(t *testing.T) {
 	balancer = NewLoadBalancer(&clusterInfo{lbType: types.LeastActiveConnection}, hosts)
 	actual = balancer.ChooseHost(nil)
 	assert.Nil(t, actual)
+}
+
+func TestLeastActiveConnectionLoadBalancer_ChooseHost(t *testing.T) {
+	verify := func(t *testing.T, info types.ClusterInfo, delta float64) {
+		bias := 1.0
+		if info != nil && info.LbConfig() != nil {
+			bias = info.LbConfig().ActiveRequestBias
+		}
+
+		hosts := createHostsetWithStats(exampleHostConfigs(), "test")
+		i := 0
+		hosts.Range(func(host types.Host) bool {
+			i++
+			h := host.(*mockHost)
+			h.w = uint32(i)
+			h.HostStats().UpstreamConnectionActive.Inc(int64(i))
+			return true
+		})
+
+		lb := newLeastActiveConnectionLoadBalancer(info, hosts)
+
+		expect := make(map[types.Host]float64)
+		actual := make(map[types.Host]float64)
+
+		hosts.Range(func(h types.Host) bool {
+			weight := h.Weight()
+			activeConnection := h.HostStats().UpstreamConnectionActive.Count()
+			expect[h] = float64(weight) / math.Pow(float64(activeConnection+1), bias)
+
+			return true
+		})
+
+		for i := 0.0; i < 100000; i++ {
+			h := lb.ChooseHost(nil)
+			actual[h]++
+		}
+
+		compareDistribution(t, expect, actual, delta)
+	}
+
+	t.Run("no bias", func(t *testing.T) {
+		verify(t, nil, 0.15)
+	})
+	t.Run("bias 0.9", func(t *testing.T) {
+		verify(t, &clusterInfo{
+			lbConfig: &v2.LbConfig{
+				ActiveRequestBias: 0.5,
+			},
+		}, 0.15)
+	})
+	t.Run("bias 1.1", func(t *testing.T) {
+		verify(t, &clusterInfo{
+			lbConfig: &v2.LbConfig{
+				ActiveRequestBias: 1.5,
+			},
+		}, 0.15)
+	})
 }

--- a/pkg/upstream/cluster/loadbalancer.go
+++ b/pkg/upstream/cluster/loadbalancer.go
@@ -64,10 +64,10 @@ func init() {
 	RegisterLBType(types.RoundRobin, rrFactory.newRoundRobinLoadBalancer)
 	RegisterLBType(types.Random, newRandomLoadBalancer)
 	RegisterLBType(types.WeightedRoundRobin, newWRRLoadBalancer)
-	RegisterLBType(types.LeastActiveRequest, newleastActiveRequestLoadBalancer)
+	RegisterLBType(types.LeastActiveRequest, newLeastActiveRequestLoadBalancer)
 	RegisterLBType(types.Maglev, newMaglevLoadBalancer)
 	RegisterLBType(types.RequestRoundRobin, newReqRoundRobinLoadBalancer)
-	RegisterLBType(types.LeastActiveConnection, newleastActiveConnectionLoadBalancer)
+	RegisterLBType(types.LeastActiveConnection, newLeastActiveConnectionLoadBalancer)
 
 	RegisterSlowStartMode(types.ModeDuration, slowStartDurationFactorFunc)
 
@@ -235,7 +235,8 @@ func (lb *WRRLoadBalancer) unweightChooseHost(context types.LoadBalancerContext)
 	return lb.rrLB.ChooseHost(context)
 }
 
-const default_choice = 2
+const defaultChoice = 2
+const defaultActiveRequestBias = 1.0
 
 // leastActiveRequestLoadBalancer choose the host with the least active request
 type leastActiveRequestLoadBalancer struct {
@@ -244,13 +245,14 @@ type leastActiveRequestLoadBalancer struct {
 	activeRequestBias float64
 }
 
-func newleastActiveRequestLoadBalancer(info types.ClusterInfo, hosts types.HostSet) types.LoadBalancer {
+func newLeastActiveRequestLoadBalancer(info types.ClusterInfo, hosts types.HostSet) types.LoadBalancer {
 	lb := &leastActiveRequestLoadBalancer{}
 	if info != nil && info.LbConfig() != nil {
 		lb.choice = info.LbConfig().ChoiceCount
 		lb.activeRequestBias = info.LbConfig().ActiveRequestBias
 	} else {
-		lb.choice = default_choice
+		lb.choice = defaultChoice
+		lb.activeRequestBias = defaultActiveRequestBias
 	}
 	lb.EdfLoadBalancer = newEdfLoadBalancer(info, hosts, lb.unweightChooseHost, lb.hostWeight)
 	return lb

--- a/pkg/upstream/cluster/loadbalancer_test.go
+++ b/pkg/upstream/cluster/loadbalancer_test.go
@@ -513,14 +513,14 @@ func TestLeastActiveRequestLoadBalancer_ChooseHost(t *testing.T) {
 	t.Run("no bias", func(t *testing.T) {
 		verify(t, nil, 0.15)
 	})
-	t.Run("bias 0.9", func(t *testing.T) {
+	t.Run("low bias", func(t *testing.T) {
 		verify(t, &clusterInfo{
 			lbConfig: &v2.LbConfig{
 				ActiveRequestBias: 0.5,
 			},
 		}, 0.15)
 	})
-	t.Run("bias 1.1", func(t *testing.T) {
+	t.Run("high bias", func(t *testing.T) {
 		verify(t, &clusterInfo{
 			lbConfig: &v2.LbConfig{
 				ActiveRequestBias: 1.5,

--- a/pkg/upstream/cluster/loadbalancer_test.go
+++ b/pkg/upstream/cluster/loadbalancer_test.go
@@ -468,7 +468,88 @@ func TestLARChooseHost(t *testing.T) {
 	balancer = NewLoadBalancer(&clusterInfo{lbType: types.LeastActiveRequest}, hosts)
 	actual = balancer.ChooseHost(nil)
 	assert.Nil(t, actual)
+}
 
+func TestLeastActiveRequestLoadBalancer_ChooseHost(t *testing.T) {
+	verify := func(t *testing.T, info types.ClusterInfo, delta float64) {
+		bias := 1.0
+		if info != nil && info.LbConfig() != nil {
+			bias = info.LbConfig().ActiveRequestBias
+		}
+
+		hosts := createHostsetWithStats(exampleHostConfigs(), "test")
+		i := 0
+		hosts.Range(func(host types.Host) bool {
+			i++
+			h := host.(*mockHost)
+			h.w = uint32(i)
+			h.HostStats().UpstreamRequestActive.Inc(int64(i))
+			return true
+		})
+
+		lb := newLeastActiveRequestLoadBalancer(info, hosts)
+
+		expect := make(map[types.Host]float64)
+		actual := make(map[types.Host]float64)
+		total := 0.0
+
+		hosts.Range(func(h types.Host) bool {
+			weight := h.Weight()
+			activeRequest := h.HostStats().UpstreamRequestActive.Count()
+			expect[h] = float64(weight) / math.Pow(float64(activeRequest+1), bias)
+			total += float64(weight) / math.Pow(float64(activeRequest+1), bias)
+
+			return true
+		})
+
+		for i := 0.0; i < total*100000; i++ {
+			h := lb.ChooseHost(nil)
+			actual[h]++
+		}
+
+		compareDistribution(t, expect, actual, delta)
+	}
+
+	t.Run("no bias", func(t *testing.T) {
+		verify(t, nil, 0.15)
+	})
+	t.Run("bias 0.9", func(t *testing.T) {
+		verify(t, &clusterInfo{
+			lbConfig: &v2.LbConfig{
+				ActiveRequestBias: 0.5,
+			},
+		}, 0.15)
+	})
+	t.Run("bias 1.1", func(t *testing.T) {
+		verify(t, &clusterInfo{
+			lbConfig: &v2.LbConfig{
+				ActiveRequestBias: 1.5,
+			},
+		}, 0.15)
+	})
+}
+
+func compareDistribution(t *testing.T, expect, actual map[types.Host]float64, delta float64) {
+	normalize := func(counter map[types.Host]float64) map[types.Host]float64 {
+		total := 0.0
+		for _, v := range counter {
+			total += v
+		}
+
+		result := make(map[types.Host]float64)
+		for k, v := range counter {
+			result[k] = v / total
+		}
+
+		return result
+	}
+
+	expect = normalize(expect)
+	actual = normalize(actual)
+
+	for h, e := range expect {
+		assert.InDelta(t, e, actual[h], delta)
+	}
 }
 
 func mockRequest(host types.Host, active bool, times int) {


### PR DESCRIPTION
The current LAR and LAC load balancing algorithms do not have a test for request distribution, adding tests to avoid untestable changes in the future

### Issues associated with this PR

Your PR should present related issues you want to solve.

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, details and the changes. At this time, Chinese is allowed to describe these.

### UT result
Use a fixed weight and a fixed number of connections, but use a looser statistical error (delta)

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
