### PR TITLE
bugfix: fix host weight in each `weightFunc` but not in `edfScheduler`

### DIFF
--- a/pkg/upstream/cluster/edf.go
+++ b/pkg/upstream/cluster/edf.go
@@ -50,7 +50,6 @@ type WeightItem interface {
 
 // Add new item into the edfScheduler
 func (edf *edfScheduler) Add(item WeightItem, weight float64) {
-	weight = fixHostWeight(weight)
 	edf.lock.Lock()
 	defer edf.lock.Unlock()
 	entry := edfEntry{

--- a/pkg/upstream/cluster/edf.go
+++ b/pkg/upstream/cluster/edf.go
@@ -50,7 +50,7 @@ type WeightItem interface {
 
 // Add new item into the edfScheduler
 func (edf *edfScheduler) Add(item WeightItem, weight float64) {
-	weight = edfFixedWeight(weight)
+	weight = fixHostWeight(weight)
 	edf.lock.Lock()
 	defer edf.lock.Unlock()
 	entry := edfEntry{
@@ -73,7 +73,6 @@ func (edf *edfScheduler) NextAndPush(weightFunc func(item WeightItem) float64) i
 	entry := edf.items.Peek()
 	edf.currentTime = entry.deadline
 	weight := weightFunc(entry.item)
-	weight = edfFixedWeight(weight)
 	// update the entry.deadline and put into priorityQueue again
 	entry.deadline = entry.deadline + 1.0/weight
 	entry.weight = weight
@@ -87,7 +86,7 @@ func (edf *edfScheduler) tick() int64 {
 	return edf.clock
 }
 
-func edfFixedWeight(weight float64) float64 {
+func fixHostWeight(weight float64) float64 {
 	if weight <= float64(v2.MinHostWeight) {
 		return float64(v2.MinHostWeight)
 	}

--- a/pkg/upstream/cluster/edf_test.go
+++ b/pkg/upstream/cluster/edf_test.go
@@ -54,14 +54,14 @@ func Test(t *testing.T) {
 }
 
 func TestEdfFixedWeight(t *testing.T) {
-	if edfFixedWeight(0) != float64(v2.MinHostWeight) {
-		t.Fatalf("Except %f but %f", float64(v2.MinHostWeight), edfFixedWeight(0))
+	if fixHostWeight(0) != float64(v2.MinHostWeight) {
+		t.Fatalf("Except %f but %f", float64(v2.MinHostWeight), fixHostWeight(0))
 	}
-	if edfFixedWeight(math.MaxFloat64) != float64(v2.MaxHostWeight) {
-		t.Fatalf("Except %f but %f", float64(v2.MaxHostWeight), edfFixedWeight(math.MaxFloat64))
+	if fixHostWeight(math.MaxFloat64) != float64(v2.MaxHostWeight) {
+		t.Fatalf("Except %f but %f", float64(v2.MaxHostWeight), fixHostWeight(math.MaxFloat64))
 	}
-	if edfFixedWeight(10.0) != 10.0 {
-		t.Fatalf("Except %f but %f", 10.0, edfFixedWeight(10.0))
+	if fixHostWeight(10.0) != 10.0 {
+		t.Fatalf("Except %f but %f", 10.0, fixHostWeight(10.0))
 	}
 }
 

--- a/pkg/upstream/cluster/edf_test.go
+++ b/pkg/upstream/cluster/edf_test.go
@@ -191,7 +191,7 @@ func TestEdfSchedulerDistribution(t *testing.T) {
 	}
 }
 
-func TestEdfSchedulerWhenWeightsVerySmall(t *testing.T) {
+func TestEdfSchedulerWhenDynamicWeightsVerySmall(t *testing.T) {
 	dynamicWeights := make(map[WeightItem]float64)
 	scheduler := newEdfScheduler(10)
 	for i := 0; i < 10; i++ {

--- a/pkg/upstream/cluster/lb_leastconnection.go
+++ b/pkg/upstream/cluster/lb_leastconnection.go
@@ -49,7 +49,7 @@ func (lb *leastActiveConnectionLoadBalancer) hostWeight(item WeightItem) float64
 		return float64(item.Weight())
 	}
 
-	weight := float64(host.Weight())
+	weight := fixHostWeight(float64(host.Weight()))
 
 	biasedActiveConnection := math.Pow(float64(host.HostStats().UpstreamConnectionActive.Count())+1, lb.activeConnectionBias)
 

--- a/pkg/upstream/cluster/lb_leastconnection_test.go
+++ b/pkg/upstream/cluster/lb_leastconnection_test.go
@@ -96,20 +96,20 @@ func TestLeastActiveConnectionLoadBalancer_ChooseHost(t *testing.T) {
 	}
 
 	t.Run("no bias", func(t *testing.T) {
-		verify(t, nil, 0.15)
+		verify(t, nil, 1e-4)
 	})
 	t.Run("low bias", func(t *testing.T) {
 		verify(t, &clusterInfo{
 			lbConfig: &v2.LbConfig{
 				ActiveRequestBias: 0.5,
 			},
-		}, 0.15)
+		}, 1e-4)
 	})
 	t.Run("high bias", func(t *testing.T) {
 		verify(t, &clusterInfo{
 			lbConfig: &v2.LbConfig{
 				ActiveRequestBias: 1.5,
 			},
-		}, 0.15)
+		}, 1e-4)
 	})
 }

--- a/pkg/upstream/cluster/loadbalancer.go
+++ b/pkg/upstream/cluster/loadbalancer.go
@@ -228,7 +228,7 @@ func (lb *WRRLoadBalancer) HostNum(metadata api.MetadataMatchCriteria) int {
 
 func (lb *WRRLoadBalancer) hostWeight(item WeightItem) float64 {
 	host := item.(types.Host)
-	return float64(host.Weight())
+	return fixHostWeight(float64(host.Weight()))
 }
 
 // do unweighted (fast) selection
@@ -265,7 +265,7 @@ func (lb *leastActiveRequestLoadBalancer) hostWeight(item WeightItem) float64 {
 		return float64(item.Weight())
 	}
 
-	weight := float64(host.Weight())
+	weight := fixHostWeight(float64(host.Weight()))
 
 	biasedActiveRequest := math.Pow(float64(host.HostStats().UpstreamRequestActive.Count())+1, lb.activeRequestBias)
 
@@ -676,10 +676,10 @@ func newPeakEwmaLoadBalancer(info types.ClusterInfo, hosts types.HostSet) types.
 func (lb *peakEwmaLoadBalancer) hostWeight(item WeightItem) float64 {
 	host, ok := item.(types.Host)
 	if !ok {
-		return float64(item.Weight())
+		return fixHostWeight(float64(item.Weight()))
 	}
 
-	return float64(host.Weight()) / lb.unweightedPeakEwmaScore(host)
+	return fixHostWeight(float64(host.Weight())) / lb.unweightedPeakEwmaScore(host)
 }
 
 func (lb *peakEwmaLoadBalancer) unweightedChoose(context types.LoadBalancerContext) types.Host {

--- a/pkg/upstream/cluster/loadbalancer_test.go
+++ b/pkg/upstream/cluster/loadbalancer_test.go
@@ -128,7 +128,7 @@ func testWRRLBCase(t *testing.T, hostNum int, weightFunc func(int) int) {
 		for i := 0; i < hostNum; i++ {
 			addr := hosts[i].AddressString()
 			rate := float64(results[addr]) / float64(subTotal)
-			expected := edfFixedWeight(float64(weightFunc(i))) / allWeight
+			expected := fixHostWeight(float64(weightFunc(i))) / allWeight
 			if math.Abs(rate-expected) > 0.1 { // no lock, have deviation 10% is acceptable
 				t.Errorf("%s request rate is %f, expected %f", addr, rate, expected)
 			}
@@ -514,21 +514,21 @@ func TestLeastActiveRequestLoadBalancer_ChooseHost(t *testing.T) {
 	}
 
 	t.Run("no bias", func(t *testing.T) {
-		verify(t, nil, 0.15)
+		verify(t, nil, 1e-4)
 	})
 	t.Run("low bias", func(t *testing.T) {
 		verify(t, &clusterInfo{
 			lbConfig: &v2.LbConfig{
 				ActiveRequestBias: 0.5,
 			},
-		}, 0.15)
+		}, 1e-4)
 	})
 	t.Run("high bias", func(t *testing.T) {
 		verify(t, &clusterInfo{
 			lbConfig: &v2.LbConfig{
 				ActiveRequestBias: 1.5,
 			},
-		}, 0.15)
+		}, 1e-4)
 	})
 }
 


### PR DESCRIPTION
### Issues associated with this PR

Fix #2303
Fix #2305

### Solutions
`weightFunc` is responsible for ensuring that the weight is legal, not adjusted by EDF, so we adjusted the logic of modifying hostWeight to each `weightFunc`, and `edfScheduler` is only responsible for scheduling

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
