### PR TITLE
[bugfix] xds update panics when cluster with empty hosts tries to stop health check tasks

### DIFF
--- a/pkg/upstream/healthcheck/healthchecker.go
+++ b/pkg/upstream/healthcheck/healthchecker.go
@@ -141,6 +141,9 @@ func (hc *healthChecker) Stop() {
 }
 
 func (hc *healthChecker) stop() {
+	if hc.hosts == nil {
+		return
+	}
 	hc.hosts.Range(func(h types.Host) bool {
 		hc.stopCheck(h)
 		return true


### PR DESCRIPTION
```
gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/healthcheck.(*healthChecker).stop(0xc000cfa340)
        /root/go/src/gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/healthcheck/healthchecker.go:144 +0x59
gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/healthcheck.(*healthChecker).Stop(0x6)
        /root/go/src/gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/healthcheck/healthchecker.go:140 +0x19
gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/cluster.(*simpleCluster).StopHealthChecking(0x20adbf0)
        /root/go/src/gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/cluster/cluster.go:178 +0x96
gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/cluster.CleanOldClusterHandler(...)
        /root/go/src/gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/cluster/cluster_manager.go:144
gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/cluster.(*clusterManager).AddOrUpdatePrimaryCluster.func1({0x20adbf0, 0xc000cca420}, {0x20adbf0, 0xc000e57020})
        /root/go/src/gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/cluster/cluster_manager.go:165 +0x43
gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/cluster.(*clusterManager).UpdateCluster(_, {{0xc000c36f00, 0x3d}, {0x1dc0c96, 0x3}, {0x0, 0x0}, {0x1dce7b9, 0xd}, 0x0, ...}, ...)
        /root/go/src/gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/cluster/cluster_manager.go:197 +0x334
gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/cluster.(*clusterManager).AddOrUpdatePrimaryCluster(_, {{0xc000c36f00, 0x3d}, {0x1dc0c96, 0x3}, {0x0, 0x0}, {0x1dce7b9, 0xd}, 0x0, ...})
        /root/go/src/gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/cluster/cluster_manager.go:163 +0x5f
gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/cluster.(*MngAdapter).TriggerClusterAddOrUpdate(...)
        /root/go/src/gitlab.alibaba-inc.com/apsara-edge/mosn/vendor/mosn.io/mosn/pkg/upstream/cluster/cluster_adapter.go:41
```
When the cluster update is triggered after CDS received, it will try to stop the current health check task. When the endpoints of the cluster is empty, it will panic