### PR TITLE
feat: fix duration when response error occurred

### DIFF
--- a/pkg/metrics/upstream.go
+++ b/pkg/metrics/upstream.go
@@ -48,6 +48,9 @@ const (
 	UpstreamRequestDurationTotal                   = "request_duration_time_total"
 	UpstreamResponseSuccess                        = "response_success"
 	UpstreamResponseFailed                         = "response_failed"
+	UpstreamResponseTotalEWMA                      = "response_total_ewma"
+	UpstreamResponseClientErrorEWMA                = "response_client_error_ewma"
+	UpstreamResponseServerErrorEWMA                = "response_server_error_ewma"
 )
 
 // key in cluster

--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -1229,6 +1229,14 @@ func (s *downStream) handleUpstreamStatusCode() {
 			s.upstreamRequest.host.HostStats().UpstreamResponseSuccess.Inc(1)
 			s.upstreamRequest.host.ClusterInfo().Stats().UpstreamResponseSuccess.Inc(1)
 		}
+
+		s.upstreamRequest.host.HostStats().UpstreamResponseTotalEWMA.Update(1)
+		switch {
+		case s.requestInfo.ResponseCode() >= 400 && s.requestInfo.ResponseCode() < 500:
+			s.upstreamRequest.host.HostStats().UpstreamResponseClientErrorEWMA.Update(1)
+		case s.requestInfo.ResponseCode() >= 500 && s.requestInfo.ResponseCode() < 600:
+			s.upstreamRequest.host.HostStats().UpstreamResponseServerErrorEWMA.Update(1)
+		}
 	}
 }
 

--- a/pkg/proxy/proxy_downstream_test.go
+++ b/pkg/proxy/proxy_downstream_test.go
@@ -97,6 +97,10 @@ func TestProxyWithFilters(t *testing.T) {
 
 						UpstreamResponseFailed:  s.Counter(metrics.UpstreamResponseFailed),
 						UpstreamResponseSuccess: s.Counter(metrics.UpstreamResponseSuccess),
+
+						UpstreamResponseTotalEWMA:       s.EWMA(metrics.UpstreamResponseTotalEWMA, ewma.Alpha(math.Exp(-5), time.Second)),
+						UpstreamResponseClientErrorEWMA: s.EWMA(metrics.UpstreamResponseClientErrorEWMA, ewma.Alpha(math.Exp(-5), time.Second)),
+						UpstreamResponseServerErrorEWMA: s.EWMA(metrics.UpstreamResponseServerErrorEWMA, ewma.Alpha(math.Exp(-5), time.Second)),
 					}
 				}).AnyTimes()
 				h.EXPECT().AddressString().Return("mockhost").AnyTimes()

--- a/pkg/types/upstream.go
+++ b/pkg/types/upstream.go
@@ -23,7 +23,7 @@ import (
 	"sort"
 	"time"
 
-	metrics "github.com/rcrowley/go-metrics"
+	"github.com/rcrowley/go-metrics"
 	"mosn.io/api"
 	v2 "mosn.io/mosn/pkg/config/v2"
 )
@@ -281,6 +281,9 @@ type HostStats struct {
 	UpstreamRequestDurationTotal                   metrics.Counter
 	UpstreamResponseSuccess                        metrics.Counter
 	UpstreamResponseFailed                         metrics.Counter
+	UpstreamResponseTotalEWMA                      metrics.EWMA
+	UpstreamResponseClientErrorEWMA                metrics.EWMA
+	UpstreamResponseServerErrorEWMA                metrics.EWMA
 }
 
 // ClusterStats defines a cluster's statistics information

--- a/pkg/types/upstream.go
+++ b/pkg/types/upstream.go
@@ -23,7 +23,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/rcrowley/go-metrics"
+	metrics "github.com/rcrowley/go-metrics"
 	"mosn.io/api"
 	v2 "mosn.io/mosn/pkg/config/v2"
 )

--- a/pkg/upstream/cluster/stats.go
+++ b/pkg/upstream/cluster/stats.go
@@ -53,6 +53,9 @@ func newHostStats(clustername string, addr string) *types.HostStats {
 		UpstreamRequestDurationTotal:                   s.Counter(metrics.UpstreamRequestDurationTotal),
 		UpstreamResponseSuccess:                        s.Counter(metrics.UpstreamResponseSuccess),
 		UpstreamResponseFailed:                         s.Counter(metrics.UpstreamResponseFailed),
+		UpstreamResponseTotalEWMA:                      s.EWMA(metrics.UpstreamResponseTotalEWMA, alpha),
+		UpstreamResponseClientErrorEWMA:                s.EWMA(metrics.UpstreamResponseClientErrorEWMA, alpha),
+		UpstreamResponseServerErrorEWMA:                s.EWMA(metrics.UpstreamResponseServerErrorEWMA, alpha),
 	}
 }
 


### PR DESCRIPTION
### Issues associated with this PR

#2295 

### Solutions
PeakEWMA records the response time to select the optimal host, but may select the wrong host when it fails fast. Record the EWMA of the total number of responses, client errors, and server errors, and use it to calculate the decaying failure rate, thereby correcting the response time for fast failures.

TODO: supports configuring bias for client errors and server errors.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
