### PR TITLE
feat: PeakEWMA supports configuring different bias of client errors a…

### DIFF
--- a/pkg/config/v2/loadbalancer.go
+++ b/pkg/config/v2/loadbalancer.go
@@ -29,6 +29,14 @@ type LbConfig struct {
 	// The larger the active request bias is, the more aggressively active requests
 	// will lower the effective weight when all host weights are not equal.
 	ActiveRequestBias float64 `json:"active_request_bias,omitempty"`
+
+	// The larger the client error bias,
+	// the smaller the reduction effect of the client error on the success rate
+	ClientErrorBias float64 `json:"client_error_bias,omitempty"`
+
+	// The larger the server error bias,
+	// the smaller the reduction effect of the server error on the success rate
+	ServerErrorBias float64 `json:"server_error_bias,omitempty"`
 }
 
 type HashPolicy struct {


### PR DESCRIPTION
…nd server errors

### #2324 

Your PR should present related issues you want to solve.

### Solutions
Add `ClientErrorBias` and `ServerErrorBias`.
The larger the `ClientErrorBias`, the smaller the reduction effect of the client error on the success rate, and the same effect applies to  `ServerErrorBias`. 

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
