### PR TITLE
[optimize] support set reuseport option to UDP listener and connection

### DIFF
--- a/pkg/config/v2/server.go
+++ b/pkg/config/v2/server.go
@@ -63,6 +63,7 @@ type ListenerConfig struct {
 	Type                  ListenerType        `json:"type,omitempty"`
 	AddrConfig            string              `json:"address,omitempty"`
 	BindToPort            bool                `json:"bind_port,omitempty"`
+	ReusePort             bool                `json:"reuseport,omitempty"` // recommended to use in UDP bidirectional data transmission scenarios.
 	Network               string              `json:"network,omitempty"`
 	OriginalDst           OriginalDstType     `json:"use_original_dst,omitempty"`
 	AccessLogs            []AccessLog         `json:"access_logs,omitempty"`

--- a/pkg/filter/network/streamproxy/streamproxy.go
+++ b/pkg/filter/network/streamproxy/streamproxy.go
@@ -230,7 +230,6 @@ func (p *proxy) onUpstreamEvent(event api.ConnectionEvent) {
 	case api.OnConnect:
 	case api.Connected:
 		p.readCallbacks.Connection().SetReadDisable(false)
-		p.onConnectionSuccess()
 	case api.ConnectTimeout:
 		p.finalizeUpstreamConnectionStats()
 
@@ -283,14 +282,6 @@ func (p *proxy) onUpstreamEventStats(event api.ConnectionEvent) {
 		host.HostStats().UpstreamConnectionActive.Dec(1)
 		host.HostStats().UpstreamConnectionClose.Inc(1)
 	}
-}
-
-func (p *proxy) onConnectionSuccess() {
-	// In udp proxy, each upstream connection needs a idle checker
-	if p.network == "udp" {
-		p.upstreamConnection.SetIdleTimeout(p.config.GetReadTimeout("udp"), p.config.GetIdleTimeout("udp"))
-	}
-	log.DefaultLogger.Debugf("new upstream connection %d created", p.upstreamConnection.ID())
 }
 
 func (p *proxy) onDownstreamEvent(event api.ConnectionEvent) {

--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -935,6 +935,7 @@ func (c *connection) Close(ccType api.ConnectionCloseType, eventType api.Connect
 		rawc.CloseRead()
 	}
 
+
 	if c.network == "udp" && c.RawConn().RemoteAddr() == nil {
 		key := GetProxyMapKey(c.localAddr.String(), c.remoteAddr.String())
 		DelUDPProxyMap(key)

--- a/pkg/network/control.go
+++ b/pkg/network/control.go
@@ -1,0 +1,21 @@
+package network
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func Control(network, address string, c syscall.RawConn) (err error) {
+	controlErr := c.Control(func(fd uintptr) {
+		err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+		if err != nil {
+			return
+		}
+		err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+	})
+	if controlErr != nil {
+		err = controlErr
+	}
+	return
+}

--- a/pkg/network/listener.go
+++ b/pkg/network/listener.go
@@ -70,6 +70,7 @@ type listener struct {
 	name                    string
 	localAddress            net.Addr
 	bindToPort              bool
+	reuseport               bool
 	listenerTag             uint64
 	perConnBufferLimitBytes uint32
 	OriginalDst             v2.OriginalDstType
@@ -93,6 +94,7 @@ func NewListener(lc *v2.Listener) types.Listener {
 		perConnBufferLimitBytes: lc.PerConnBufferLimitBytes,
 		OriginalDst:             lc.OriginalDst,
 		network:                 lc.Network,
+		reuseport:               lc.ReusePort,
 		config:                  lc,
 	}
 
@@ -406,6 +408,9 @@ func (l *listener) listen(lctx context.Context) error {
 	switch l.network {
 	case "udp":
 		lc := net.ListenConfig{}
+		if l.reuseport {
+			lc.Control = Control
+		}
 		if rconn, err = lc.ListenPacket(context.Background(), l.network, l.localAddress.String()); err != nil {
 			return err
 		}

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -526,7 +526,7 @@ func (al *activeListener) OnNewConnection(ctx context.Context, conn api.Connecti
 
 	ac := newActiveConnection(al, conn)
 
-	if conn.LocalAddr().Network() == "udp" {
+	if conn.LocalAddr().Network() == "udp" && conn.RawConn().RemoteAddr() == nil {
 		network.SetUDPProxyMap(network.GetProxyMapKey(conn.LocalAddr().String(), conn.RemoteAddr().String()), conn)
 	}
 


### PR DESCRIPTION
### Issues associated with this PR

When the UDP listener is bidirectional data transmission listener, multiple go routine will write the same socket to send packet to clients, which will cause  high softirqs.

### Solutions
So we change our implements to generate a new UDP socket and connect to client remote address, and use this socket to fulfill the subsequent data transmission.

This is the CPU usage comparision:

![Uploading image.png…]()
