### PR TITLE
[opt] reduce UDP read buffer size

### DIFF
--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -46,7 +46,7 @@ import (
 
 // Network related const
 const (
-	DefaultReadBufferSize = 1 << 7
+	DefaultReadBufferSize    = 1 << 7
 	DefaultUDPReadBufferSize = 4096
 
 	NetBufferDefaultSize     = 0

--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -47,6 +47,7 @@ import (
 // Network related const
 const (
 	DefaultReadBufferSize = 1 << 7
+	DefaultUDPReadBufferSize = 4096
 
 	NetBufferDefaultSize     = 0
 	NetBufferDefaultCapacity = 1 << 4
@@ -208,7 +209,7 @@ func newServerConnection(ctx context.Context, rawc net.Conn, stopChan chan struc
 	if conn.network == "udp" {
 		if val, err := variable.Get(ctx, types.VariableAcceptBuffer); err == nil && val != nil {
 			buf := val.([]byte)
-			conn.readBuffer = buffer.GetIoBuffer(UdpPacketMaxSize)
+			conn.readBuffer = buffer.GetIoBuffer(conn.getUDPReadBufferSize())
 			conn.readBuffer.Write(buf)
 			conn.updateReadBufStats(int64(conn.readBuffer.Len()), int64(conn.readBuffer.Len()))
 		}
@@ -550,12 +551,20 @@ func (c *connection) setReadDeadline() {
 	}
 }
 
+func (c *connection) getUDPReadBufferSize() int {
+	if c.defaultReadBufferSize != 0 && c.defaultReadBufferSize != DefaultReadBufferSize {
+		return c.defaultReadBufferSize
+	} else {
+		return DefaultUDPReadBufferSize
+	}
+}
+
 func (c *connection) doRead() (err error) {
 	if c.readBuffer == nil {
 		switch c.network {
 		case "udp":
 			// A UDP socket will Read up to the size of the receiving buffer and will discard the rest
-			c.readBuffer = buffer.GetIoBuffer(UdpPacketMaxSize)
+			c.readBuffer = buffer.GetIoBuffer(c.getUDPReadBufferSize())
 		default: // unix or tcp
 			c.readBuffer = buffer.GetIoBuffer(c.defaultReadBufferSize)
 		}


### PR DESCRIPTION
### Issues associated with this PR

The default UDP read buffer size is now set to UDP packet max size, which is 64*1024 bytes, when the number of UDP connection increases, the memory usage will increase rapidly

### Solutions
Enable using the "default_read_buffer_size" configuration value as read buffer size and change the default UDP read buffer size to 4096

