### PR TITLE
add the ability for fast failure of health checks

### DIFF
--- a/pkg/stream/xprotocol/keepalive.go
+++ b/pkg/stream/xprotocol/keepalive.go
@@ -30,6 +30,10 @@ import (
 	"mosn.io/pkg/utils"
 )
 
+var (
+	nilTask = &fastKeepAliveTask{}
+)
+
 // StreamReceiver to receive keep alive response
 type xprotocolKeepAlive struct {
 	Codec     str.Client
@@ -40,6 +44,7 @@ type xprotocolKeepAlive struct {
 	heartbeatFailCount atomicex.Uint32 // the number of consecutive heartbeat failures, will be reset after hb succ
 	previousIsSucc     atomicex.Bool   // the previous heartbeat result
 	tickCount          atomicex.Uint32 // tick intervals after the last heartbeat request sent
+	fastFailTask       atomicex.Value  // fast fail task for keepalive check.
 
 	idleFree *idleFree
 
@@ -87,6 +92,9 @@ func NewKeepAlive(codec str.Client, proto api.XProtocol, timeout time.Duration) 
 
 	// initially set previous heartbeat request success
 	kp.previousIsSucc.Store(true)
+
+	// initially setup sets the heartbeat check fast failure task to nil
+	kp.fastFailTask.Store(nilTask)
 
 	// register keepalive to connection event listener
 	// if connection is closed, keepalive should stop
@@ -146,7 +154,6 @@ func (kp *xprotocolKeepAlive) StartIdleTimeout() {
 
 // The function will be called when connection in the codec is idle
 func (kp *xprotocolKeepAlive) sendKeepAlive() {
-
 	ctx := context.Background()
 	sender := kp.Codec.NewStream(ctx, kp)
 	id := sender.GetStream().ID()
@@ -174,6 +181,39 @@ func (kp *xprotocolKeepAlive) GetTimeout() time.Duration {
 	return kp.Timeout
 }
 
+func (kp *xprotocolKeepAlive) startFastKeepAliveTask() {
+	select {
+	case <-kp.stop:
+		if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
+			log.DefaultLogger.Debugf("[stream] [xprotocol] [keepalive] connection %d allready stop keepalive, skip start fast fail task", kp.Codec.ConnID())
+		}
+		return
+	default:
+	}
+
+	if v := kp.fastFailTask.Load(); v == nilTask {
+		task := NewFastKeepAliveTask(kp.Codec.ConnID(), kp.sendKeepAlive, kp.stop)
+		if kp.fastFailTask.CompareAndSwap(nilTask, task) {
+			if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
+				log.DefaultLogger.Debugf("[stream] [xprotocol] [keepalive] connection %d start fast fail task", kp.Codec.ConnID())
+			}
+			task.Start()
+		}
+	}
+}
+
+func (kp *xprotocolKeepAlive) stopFastKeepAliveTask() {
+	if v := kp.fastFailTask.Load(); v != nilTask {
+		task := v.(*fastKeepAliveTask)
+		if kp.fastFailTask.CompareAndSwap(task, nilTask) {
+			if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
+				log.DefaultLogger.Debugf("[stream] [xprotocol] [keepalive] connection %d stop fast fail task", kp.Codec.ConnID())
+			}
+			task.Stop()
+		}
+	}
+}
+
 func (kp *xprotocolKeepAlive) HandleTimeout(id uint64) {
 	c := xprotoKeepaliveConfig.Load().(KeepaliveConfig)
 	select {
@@ -198,6 +238,11 @@ func (kp *xprotocolKeepAlive) HandleTimeout(id uint64) {
 		kp.Codec.Close()
 	}
 	kp.runCallback(types.KeepAliveTimeout)
+
+	if c.FastFail {
+		// start the heartbeat check fast failure task when the heartbeat check fails
+		kp.startFastKeepAliveTask()
+	}
 }
 
 func (kp *xprotocolKeepAlive) HandleSuccess(id uint64) {
@@ -222,6 +267,9 @@ func (kp *xprotocolKeepAlive) HandleSuccess(id uint64) {
 	kp.heartbeatFailCount.Store(0)
 	kp.previousIsSucc.Store(true)
 
+	// stop the heartbeat check fast failure task when the heartbeat check success
+	kp.stopFastKeepAliveTask()
+
 	kp.runCallback(types.KeepAliveSuccess)
 }
 
@@ -229,6 +277,7 @@ func (kp *xprotocolKeepAlive) Stop() {
 	kp.once.Do(func() {
 		log.DefaultLogger.Infof("[stream] [xprotocol] [keepalive] connection %d stopped keepalive", kp.Codec.ConnID())
 		close(kp.stop)
+		kp.stopFastKeepAliveTask()
 	})
 }
 
@@ -263,4 +312,72 @@ func startTimeout(id uint64, keep types.KeepAlive) *keepAliveTimeout {
 
 func (t *keepAliveTimeout) onTimeout() {
 	t.KeepAlive.HandleTimeout(t.ID)
+}
+
+func NewFastKeepAliveTask(connID uint64, sendKeepAlive func(), stopKeepAlive chan struct{}) *fastKeepAliveTask {
+	f := &fastKeepAliveTask{
+		connID:        connID,
+		sendKeepAlive: sendKeepAlive,
+		stopKeepAlive: stopKeepAlive,
+	}
+	f.start.Store(false)
+	return f
+}
+
+type fastKeepAliveTask struct {
+	connID        uint64
+	sendKeepAlive func()
+	start         atomicex.Bool
+	stopTask      chan struct{}
+	stopKeepAlive chan struct{}
+}
+
+func (f *fastKeepAliveTask) Start() {
+	if f.start.CAS(false, true) {
+		f.stopTask = make(chan struct{})
+		go f.safeFastSendKeepAliveLoop()
+	}
+}
+
+func (f *fastKeepAliveTask) safeFastSendKeepAliveLoop() {
+	defer func() {
+		if err := recover(); err != nil {
+			log.DefaultLogger.Debugf("[stream] [xprotocol] [keepalive] [fastfail] connection %d fast send keepalive loop panic: %v", f.connID, err)
+		}
+	}()
+
+	var (
+		c      = xprotoKeepaliveConfig.Load().(KeepaliveConfig)
+		ticker = time.NewTicker(c.FastSendInterval)
+	)
+
+	for {
+		select {
+		case <-f.stopKeepAlive:
+			if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
+				log.DefaultLogger.Debugf("[stream] [xprotocol] [keepalive] [fastfail] connection %d allready stop keepalive, quit fast fail task", f.connID)
+			}
+			return
+		case <-f.stopTask:
+			if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
+				log.DefaultLogger.Debugf("[stream] [xprotocol] [keepalive] [fastfail] connection %d already stop fast fail task", f.connID)
+			}
+			return
+		case <-ticker.C:
+			if c.FastFail {
+				if log.DefaultLogger.GetLogLevel() >= log.DEBUG {
+					log.DefaultLogger.Debugf("[stream] [xprotocol] [keepalive] [fastfail] connection %d send a keepalive request", f.connID)
+				}
+				f.sendKeepAlive()
+			} else {
+				return
+			}
+		}
+	}
+}
+
+func (f *fastKeepAliveTask) Stop() {
+	if f.start.CAS(true, false) {
+		close(f.stopTask)
+	}
 }

--- a/pkg/stream/xprotocol/keepalive_configure.go
+++ b/pkg/stream/xprotocol/keepalive_configure.go
@@ -33,8 +33,9 @@ type KeepaliveConfig struct {
 	TickCountIfSucc uint32
 	// if hb fails in a line, and count = fail_count_to_close, close this connection
 	FailCountToClose uint32
-
-	FastFail         bool
+	// whether to enable fast failure for heartbeat detection
+	FastFail bool
+	// the interval between heartbeat detections when fast failure for heartbeat detection is triggered
 	FastSendInterval time.Duration
 }
 

--- a/pkg/stream/xprotocol/keepalive_configure.go
+++ b/pkg/stream/xprotocol/keepalive_configure.go
@@ -19,6 +19,7 @@ package xprotocol
 
 import (
 	"sync/atomic"
+	"time"
 )
 
 // KeepaliveConfig is the config for xprotocol keepalive
@@ -32,6 +33,9 @@ type KeepaliveConfig struct {
 	TickCountIfSucc uint32
 	// if hb fails in a line, and count = fail_count_to_close, close this connection
 	FailCountToClose uint32
+
+	FastFail         bool
+	FastSendInterval time.Duration
 }
 
 var xprotoKeepaliveConfig atomic.Value
@@ -41,6 +45,8 @@ var DefaultKeepaliveConfig = KeepaliveConfig{
 	TickCountIfFail:  1,
 	TickCountIfSucc:  1,
 	FailCountToClose: 6,
+	FastFail:         false,
+	FastSendInterval: time.Second,
 }
 
 func init() {

--- a/pkg/stream/xprotocol/keepalive_test.go
+++ b/pkg/stream/xprotocol/keepalive_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"mosn.io/api"
 	v2 "mosn.io/mosn/pkg/config/v2"
 	"mosn.io/mosn/pkg/log"
 	"mosn.io/mosn/pkg/protocol/xprotocol/bolt"
@@ -50,8 +51,9 @@ func (s *testStats) Record(status types.KeepAliveStatus) {
 
 // use bolt v1 to test keep alive
 type testCase struct {
-	KeepAlive *xprotocolKeepAlive
-	Server    *mockServer
+	KeepAlive  *xprotocolKeepAlive
+	Server     *mockServer
+	ClientConn types.ClientConnection
 }
 
 func newTestCase(t *testing.T, srvTimeout, keepTimeout time.Duration) *testCase {
@@ -87,8 +89,9 @@ func newTestCase(t *testing.T, srvTimeout, keepTimeout time.Duration) *testCase 
 	keepAlive := NewKeepAlive(codec, (&bolt.XCodec{}).NewXProtocol(ctx), keepTimeout)
 	keepAlive.StartIdleTimeout()
 	return &testCase{
-		KeepAlive: keepAlive.(*xprotocolKeepAlive),
-		Server:    srv,
+		KeepAlive:  keepAlive.(*xprotocolKeepAlive),
+		Server:     srv,
+		ClientConn: conn.Connection,
 	}
 
 }
@@ -271,7 +274,9 @@ func TestKeepAliveFastFail(t *testing.T) {
 
 	// create a mock server that delays the response by 50ms and has a heartbeat timeout of 10ms
 	tc := newTestCase(t, 50*time.Millisecond, 10*time.Millisecond)
+	defer tc.KeepAlive.Stop()
 	defer tc.Server.Close()
+
 	testStats := &testStats{}
 	tc.KeepAlive.AddCallback(testStats.Record)
 
@@ -284,4 +289,10 @@ func TestKeepAliveFastFail(t *testing.T) {
 	if testStats.success != 0 || testStats.timeout != 6 {
 		t.Error("keep alive handle status not expected", testStats)
 	}
+
+	connState := tc.ClientConn.State()
+	if connState != api.ConnClosed {
+		t.Error("client connection status not expected, client connection should be closed", testStats)
+	}
+
 }


### PR DESCRIPTION
### Issues associated with this PR
BOLT 协议的心跳检测耗时较长 #2364

### Solutions
解决方案和在 Issues 里提到的建议一致。在心跳检测失败的时候，另起协程以短间隔快速检测几次，如果这几次检测都失败了就断开链接。这样正常的场景下，心跳频率仍然是一次 Read Timeout 也就是 15s 一次。异常情况下才会减少心跳检测间隔。默认行为为不开启快速检测。

### UT result
添加了一个开启快速检测的单测 TestKeepAliveFastFail

### Benchmark
心跳检测是一个旁路，不影响主链路的性能

