### PR TITLE
bugfix: close the ticker for fast-fail heartbeats detection

### DIFF
--- a/pkg/stream/xprotocol/keepalive.go
+++ b/pkg/stream/xprotocol/keepalive.go
@@ -351,6 +351,8 @@ func (f *fastKeepAliveTask) safeFastSendKeepAliveLoop() {
 		ticker = time.NewTicker(c.FastSendInterval)
 	)
 
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-f.stopKeepAlive:

--- a/pkg/stream/xprotocol/keepalive_configure.go
+++ b/pkg/stream/xprotocol/keepalive_configure.go
@@ -36,6 +36,8 @@ type KeepaliveConfig struct {
 	// whether to enable fast failure for heartbeat detection
 	FastFail bool
 	// the interval between heartbeat detections when fast failure for heartbeat detection is triggered
+	// this property should be set to a value greater than 0 to have any meaning.
+	// if set to an invalid value, it will be automatically set to 1s by default.
 	FastSendInterval time.Duration
 }
 
@@ -56,5 +58,8 @@ func init() {
 
 // RefreshKeepaliveConfig refresh the keepalive config
 func RefreshKeepaliveConfig(c KeepaliveConfig) {
+	if c.FastFail && c.FastSendInterval <= 0 {
+		c.FastSendInterval = time.Second
+	}
 	xprotoKeepaliveConfig.Store(c)
 }


### PR DESCRIPTION
### Issues associated with this PR
这个 PR 也是解决这个 issues 里提到的问题的 https://github.com/mosn/mosn/issues/2364
上一个 PR https://github.com/mosn/mosn/pull/2365 已经合并了，然后我本地重新拉取 master 代码做验证比对 debug 日志的时候发现这个地方没有释放申请的 ticker 资源。之前本地验证的时候只验证了功能是否正确，没有发现这里的问题。

我这里做了下修复，非常抱歉给大家添麻烦了

Solutions
通过 defer 释放在方法内申请了临时 ticker 对象
