### PR TITLE
fix: lbconfig use default values correctly

### DIFF
--- a/pkg/config/v2/loadbalancer.go
+++ b/pkg/config/v2/loadbalancer.go
@@ -32,11 +32,11 @@ type LbConfig struct {
 
 	// The larger the client error bias,
 	// the smaller the reduction effect of the client error on the success rate
-	ClientErrorBias float64 `json:"client_error_bias,omitempty"`
+	ClientErrorBias *float64 `json:"client_error_bias,omitempty"`
 
 	// The larger the server error bias,
 	// the smaller the reduction effect of the server error on the success rate
-	ServerErrorBias float64 `json:"server_error_bias,omitempty"`
+	ServerErrorBias *float64 `json:"server_error_bias,omitempty"`
 }
 
 type HashPolicy struct {

--- a/pkg/upstream/cluster/loadbalancer.go
+++ b/pkg/upstream/cluster/loadbalancer.go
@@ -660,8 +660,19 @@ func newPeakEwmaLoadBalancer(info types.ClusterInfo, hosts types.HostSet) types.
 	if info != nil && info.LbConfig() != nil {
 		lb.choice = info.LbConfig().ChoiceCount
 		lb.activeRequestBias = info.LbConfig().ActiveRequestBias
-		lb.clientErrorBias = info.LbConfig().ClientErrorBias
-		lb.serverErrorBias = info.LbConfig().ServerErrorBias
+
+		if info.LbConfig().ClientErrorBias != nil {
+			lb.clientErrorBias = *info.LbConfig().ClientErrorBias
+		} else {
+			lb.clientErrorBias = defaultClientErrorBias
+		}
+
+		if info.LbConfig().ServerErrorBias != nil {
+			lb.serverErrorBias = *info.LbConfig().ServerErrorBias
+		} else {
+			lb.serverErrorBias = defaultServerErrorBias
+		}
+
 	} else {
 		lb.choice = defaultChoice
 		lb.activeRequestBias = defaultActiveRequestBias


### PR DESCRIPTION
### Issues associated with this PR

#2374 

### Solutions

use `*float` instead of `float`, so when it is `nil` after `json.Unmarshal()`, we can manually load the default value

### UT result

### Benchmark

### Code Style
