### PR TITLE
fix: precision loss for xprotocol clientStreamIDBase

### DIFF
--- a/pkg/protocol/xprotocol/bolt/protocol.go
+++ b/pkg/protocol/xprotocol/bolt/protocol.go
@@ -224,5 +224,6 @@ func (proto boltProtocol) EnableWorkerPool() bool {
 }
 
 func (proto boltProtocol) GenerateRequestID(streamID *uint64) uint64 {
-	return atomic.AddUint64(streamID, 1)
+	// fix bug for issue: https://github.com/mosn/mosn/issues/2403
+	return uint64(uint32(atomic.AddUint64(streamID, 1)))
 }

--- a/pkg/protocol/xprotocol/bolt/protocol_test.go
+++ b/pkg/protocol/xprotocol/bolt/protocol_test.go
@@ -19,6 +19,7 @@ package bolt
 
 import (
 	"context"
+	"math"
 	"net/http"
 	"testing"
 
@@ -112,4 +113,37 @@ func TestBufferReset(t *testing.T) {
 
 	assert.Nil(t, buf.request.Content)
 	assert.Nil(t, buf.response.Content)
+}
+
+func Test_boltProtocol_GenerateRequestID(t *testing.T) {
+	streamID := uint64(math.MaxUint32 - 1)
+	type args struct {
+		streamID *uint64
+	}
+	tests := []struct {
+		name string
+		args args
+		want uint64
+	}{
+		{
+			name: "test1",
+			args: args{
+				streamID: &streamID,
+			},
+			want: uint64(math.MaxUint32),
+		},
+		{
+			name: "test uint32 overflow",
+			args: args{
+				streamID: &streamID,
+			},
+			want: uint64(0),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proto := boltProtocol{}
+			assert.Equalf(t, tt.want, proto.GenerateRequestID(tt.args.streamID), "GenerateRequestID(%v)", tt.args.streamID)
+		})
+	}
 }

--- a/pkg/protocol/xprotocol/boltv2/protocol.go
+++ b/pkg/protocol/xprotocol/boltv2/protocol.go
@@ -213,5 +213,6 @@ func (proto boltv2Protocol) EnableWorkerPool() bool {
 }
 
 func (proto boltv2Protocol) GenerateRequestID(streamID *uint64) uint64 {
-	return atomic.AddUint64(streamID, 1)
+	// fix bug for issue: https://github.com/mosn/mosn/issues/2403
+	return uint64(uint32(atomic.AddUint64(streamID, 1)))
 }

--- a/pkg/protocol/xprotocol/boltv2/protocol_test.go
+++ b/pkg/protocol/xprotocol/boltv2/protocol_test.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package boltv2
 
 import (

--- a/pkg/protocol/xprotocol/boltv2/protocol_test.go
+++ b/pkg/protocol/xprotocol/boltv2/protocol_test.go
@@ -1,0 +1,41 @@
+package boltv2
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_boltProtocol_GenerateRequestID(t *testing.T) {
+	streamID := uint64(math.MaxUint32 - 1)
+	type args struct {
+		streamID *uint64
+	}
+	tests := []struct {
+		name string
+		args args
+		want uint64
+	}{
+		{
+			name: "test1",
+			args: args{
+				streamID: &streamID,
+			},
+			want: uint64(math.MaxUint32),
+		},
+		{
+			name: "test uint32 overflow",
+			args: args{
+				streamID: &streamID,
+			},
+			want: uint64(0),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proto := boltv2Protocol{}
+			assert.Equalf(t, tt.want, proto.GenerateRequestID(tt.args.streamID), "GenerateRequestID(%v)", tt.args.streamID)
+		})
+	}
+}

--- a/pkg/protocol/xprotocol/dubbothrift/protocol.go
+++ b/pkg/protocol/xprotocol/dubbothrift/protocol.go
@@ -48,6 +48,7 @@ import (
  *   string - service name
  *   long   - dubbo request id
  */
+
 var MagicTag = []byte{0xda, 0xbc}
 
 type thriftProtocol struct{}

--- a/pkg/protocol/xprotocol/example/protocol.go
+++ b/pkg/protocol/xprotocol/example/protocol.go
@@ -131,5 +131,6 @@ func (proto proto) EnableWorkerPool() bool {
 }
 
 func (proto proto) GenerateRequestID(streamID *uint64) uint64 {
-	return atomic.AddUint64(streamID, 1)
+	// fix bug for issue: https://github.com/mosn/mosn/issues/2403
+	return uint64(uint32(atomic.AddUint64(streamID, 1)))
 }

--- a/pkg/protocol/xprotocol/example/protocol_test.go
+++ b/pkg/protocol/xprotocol/example/protocol_test.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package example
 
 import (

--- a/pkg/protocol/xprotocol/example/protocol_test.go
+++ b/pkg/protocol/xprotocol/example/protocol_test.go
@@ -1,0 +1,41 @@
+package example
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_proto_GenerateRequestID(t *testing.T) {
+	streamID := uint64(math.MaxUint32 - 1)
+	type args struct {
+		streamID *uint64
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "test uint32 max",
+			args: args{
+				streamID: &streamID,
+			},
+		},
+		{
+			name: "test uint32 overflow",
+			args: args{
+				streamID: &streamID,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proto := proto{}
+			r := Request{}
+			got := proto.GenerateRequestID(tt.args.streamID)
+			r.SetRequestId(got)
+			assert.Equalf(t, got, r.GetRequestId(), "GenerateRequestID(%v)", tt.args.streamID)
+		})
+	}
+}

--- a/pkg/protocol/xprotocol/tars/protocol.go
+++ b/pkg/protocol/xprotocol/tars/protocol.go
@@ -124,5 +124,5 @@ func (proto tarsProtocol) EnableWorkerPool() bool {
 }
 
 func (proto tarsProtocol) GenerateRequestID(streamID *uint64) uint64 {
-	return atomic.AddUint64(streamID, 1)
+	return uint64(int32(atomic.AddUint64(streamID, 1)))
 }

--- a/pkg/protocol/xprotocol/tars/protocol.go
+++ b/pkg/protocol/xprotocol/tars/protocol.go
@@ -124,5 +124,6 @@ func (proto tarsProtocol) EnableWorkerPool() bool {
 }
 
 func (proto tarsProtocol) GenerateRequestID(streamID *uint64) uint64 {
+	// fix bug for issue: https://github.com/mosn/mosn/issues/2403
 	return uint64(int32(atomic.AddUint64(streamID, 1)))
 }

--- a/pkg/protocol/xprotocol/tars/protocol_test.go
+++ b/pkg/protocol/xprotocol/tars/protocol_test.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tars
 
 import (

--- a/pkg/protocol/xprotocol/tars/protocol_test.go
+++ b/pkg/protocol/xprotocol/tars/protocol_test.go
@@ -1,0 +1,65 @@
+package tars
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TarsCloud/TarsGo/tars/protocol/res/requestf"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_proto_GenerateRequestID(t *testing.T) {
+	streamID := uint64(math.MaxUint32 - 1)
+	streamID2 := uint64(math.MaxInt32 - 1)
+	streamID3 := uint64(math.MaxInt32 - 1 + math.MaxUint32)
+	type args struct {
+		streamID *uint64
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "test max uint32",
+			args: args{
+				streamID: &streamID,
+			},
+		},
+		{
+			name: "test uint32 overflow",
+			args: args{
+				streamID: &streamID,
+			},
+		},
+		{
+			name: "test max int32",
+			args: args{
+				streamID: &streamID2,
+			},
+		},
+		{
+			name: "test int32 overflow",
+			args: args{
+				streamID: &streamID2,
+			},
+		},
+		{
+			name: "test int32 overflow",
+			args: args{
+				streamID: &streamID3,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proto := tarsProtocol{}
+			r := Request{
+				cmd: &requestf.RequestPacket{},
+			}
+			got := proto.GenerateRequestID(tt.args.streamID)
+			r.SetRequestId(got)
+			assert.Equalf(t, got, r.GetRequestId(), "GenerateRequestID(%v)", tt.args.streamID)
+		})
+	}
+}


### PR DESCRIPTION
### Issues associated with this PR

#2403 

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, details and the changes. At this time, Chinese is allowed to describe these.

### UT result

```bash
$ go test -v -run=. ./pkg/protocol/xprotocol/...
?       mosn.io/mosn/pkg/protocol/xprotocol     [no test files]
?       mosn.io/mosn/pkg/protocol/xprotocol/internal/registry   [no test files]
=== RUN   TestEncodeDecode
--- PASS: TestEncodeDecode (0.00s)
=== RUN   TestConfigHandler
=== RUN   TestConfigHandler/test_bolt_config
=== RUN   TestConfigHandler/test_invalid_default
--- PASS: TestConfigHandler (0.00s)
    --- PASS: TestConfigHandler/test_bolt_config (0.00s)
    --- PASS: TestConfigHandler/test_invalid_default (0.00s)
=== RUN   TestHeaderOverrideBody
--- PASS: TestHeaderOverrideBody (0.00s)
=== RUN   TestSofaMapping
--- PASS: TestSofaMapping (0.00s)
=== RUN   TestMatcher
--- PASS: TestMatcher (0.00s)
=== RUN   TestProto
--- PASS: TestProto (0.00s)
=== RUN   TestMapping
--- PASS: TestMapping (0.00s)
=== RUN   TestReply
--- PASS: TestReply (0.00s)
=== RUN   TestHijack
--- PASS: TestHijack (0.00s)
=== RUN   TestBufferReset
--- PASS: TestBufferReset (0.00s)
=== RUN   Test_boltProtocol_GenerateRequestID
=== RUN   Test_boltProtocol_GenerateRequestID/test1
=== RUN   Test_boltProtocol_GenerateRequestID/test_uint32_overflow
--- PASS: Test_boltProtocol_GenerateRequestID (0.00s)
    --- PASS: Test_boltProtocol_GenerateRequestID/test1 (0.00s)
    --- PASS: Test_boltProtocol_GenerateRequestID/test_uint32_overflow (0.00s)
PASS
ok      mosn.io/mosn/pkg/protocol/xprotocol/bolt        (cached)
=== RUN   TestEncodeDecode
--- PASS: TestEncodeDecode (0.00s)
=== RUN   Test_boltProtocol_GenerateRequestID
=== RUN   Test_boltProtocol_GenerateRequestID/test1
=== RUN   Test_boltProtocol_GenerateRequestID/test_uint32_overflow
--- PASS: Test_boltProtocol_GenerateRequestID (0.00s)
    --- PASS: Test_boltProtocol_GenerateRequestID/test1 (0.00s)
    --- PASS: Test_boltProtocol_GenerateRequestID/test_uint32_overflow (0.00s)
PASS
ok      mosn.io/mosn/pkg/protocol/xprotocol/boltv2      (cached)
=== RUN   TestEncode
--- PASS: TestEncode (0.00s)
=== RUN   TestFrame
--- PASS: TestFrame (0.00s)
=== RUN   TestDecodeFramePanic
--- PASS: TestDecodeFramePanic (0.00s)
=== RUN   TestDecodeSkipCheap
--- PASS: TestDecodeSkipCheap (0.00s)
=== RUN   TestDecodeSkip
--- PASS: TestDecodeSkip (0.00s)
=== RUN   TestMetadata_Register
=== RUN   TestMetadata_Register/register_node_#1
=== RUN   TestMetadata_Register/register_node_#2
=== RUN   TestMetadata_Register/register_node_#3
=== RUN   TestMetadata_Register/register_node_#4
--- PASS: TestMetadata_Register (0.00s)
    --- PASS: TestMetadata_Register/register_node_#1 (0.00s)
    --- PASS: TestMetadata_Register/register_node_#2 (0.00s)
    --- PASS: TestMetadata_Register/register_node_#3 (0.00s)
    --- PASS: TestMetadata_Register/register_node_#4 (0.00s)
=== RUN   Test_dubboProtocol_Hijack
=== RUN   Test_dubboProtocol_Hijack/normal
=== RUN   Test_dubboProtocol_Hijack/status_not_registry
--- PASS: Test_dubboProtocol_Hijack (0.00s)
    --- PASS: Test_dubboProtocol_Hijack/normal (0.00s)
    --- PASS: Test_dubboProtocol_Hijack/status_not_registry (0.00s)
PASS
ok      mosn.io/mosn/pkg/protocol/xprotocol/dubbo       (cached)
=== RUN   TestFrame
    command_test.go:71: [0 0 0 67 218 188 0 0 0 67 0 45 1 0 0 0 24 99 111 109 46 112 107 103 46 116 101 115 116 46 84 101 115 116 83 101 114 118 105 99 101 0 0 0 0 0 0 0 1 128 1 0 1 0 0 0 10 116 101 115 116 77 101 116 104 111 100 0 0 0 1]
--- PASS: TestFrame (0.00s)
=== RUN   TestDecodeFramePanic
    decoder_test.go:32: recover thrift decode panic:[xprotocol][thrift]decode message error :runtime error: slice bounds out of range [:2581249222] with capacity 97
        goroutine 37 [running]:
        runtime/debug.Stack()
                /Users/fujianhao/.g/go/src/runtime/debug/stack.go:24 +0x64
        mosn.io/mosn/pkg/protocol/xprotocol/dubbothrift.decodeFrame.func1()
                /Users/fujianhao/opensource/mosn/pkg/protocol/xprotocol/dubbothrift/decoder.go:39 +0x3c
        panic({0x1049c9ca0?, 0x1400013a0d8?})
                /Users/fujianhao/.g/go/src/runtime/panic.go:770 +0x124
        mosn.io/mosn/pkg/protocol/xprotocol/dubbothrift.decodeFrame({0x1049f0060, 0x104c2e7e0}, {0x1049f4280, 0x140001fc840})
                /Users/fujianhao/opensource/mosn/pkg/protocol/xprotocol/dubbothrift/decoder.go:54 +0x88c
        mosn.io/mosn/pkg/protocol/xprotocol/dubbothrift.TestDecodeFramePanic(0x1400013e9c0)
                /Users/fujianhao/opensource/mosn/pkg/protocol/xprotocol/dubbothrift/decoder_test.go:30 +0x58
        testing.tRunner(0x1400013e9c0, 0x1049ebbd0)
                /Users/fujianhao/.g/go/src/testing/testing.go:1689 +0xec
        created by testing.(*T).Run in goroutine 1
                /Users/fujianhao/.g/go/src/testing/testing.go:1742 +0x318
--- PASS: TestDecodeFramePanic (0.00s)
=== RUN   TestDecode
--- PASS: TestDecode (0.00s)
=== RUN   Test_dubboProtocol_Hijack
=== RUN   Test_dubboProtocol_Hijack/normal
    protocol_test.go:82: hڼh-com.pkg.test.TestService�
        testMethod
                  502|no health upstream
    protocol_test.go:93: message length is : 104
    protocol_test.go:100: magic is : -9540
    protocol_test.go:128: name: testMethod, type: 3, seqId: 1
    protocol_test.go:151: terr: {0 502|no health upstream}, err: 502|no health upstream, mType 0
=== RUN   Test_dubboProtocol_Hijack/status_not_registry
2024-07-20 13:09:42,931 [INFO] hijack: &{{0 [] 0 0 0 1 0 map[method:testMethod seqId:1 service:com.pkg.test.TestService]} [] [] <nil> <nil>},  502
    protocol_test.go:82: oڼo-com.pkg.test.TestService�
        testMethod
                  unknown application exception
2024-07-20 13:09:42,931 [INFO] hijack: &{{0 [] 0 0 0 1 0 map[method:testMethod seqId:1 service:com.pkg.test.TestService]} [] [] <nil> <nil>},  99
    protocol_test.go:93: message length is : 111
    protocol_test.go:100: magic is : -9540
    protocol_test.go:128: name: testMethod, type: 3, seqId: 1
    protocol_test.go:151: terr: {0 unknown application exception}, err: unknown application exception, mType 0
--- PASS: Test_dubboProtocol_Hijack (0.00s)
    --- PASS: Test_dubboProtocol_Hijack/normal (0.00s)
    --- PASS: Test_dubboProtocol_Hijack/status_not_registry (0.00s)
PASS
ok      mosn.io/mosn/pkg/protocol/xprotocol/dubbothrift (cached)
=== RUN   Test_proto_GenerateRequestID
=== RUN   Test_proto_GenerateRequestID/test_uint32_max
=== RUN   Test_proto_GenerateRequestID/test_uint32_overflow
--- PASS: Test_proto_GenerateRequestID (0.00s)
    --- PASS: Test_proto_GenerateRequestID/test_uint32_max (0.00s)
    --- PASS: Test_proto_GenerateRequestID/test_uint32_overflow (0.00s)
PASS
ok      mosn.io/mosn/pkg/protocol/xprotocol/example     (cached)
=== RUN   Test_proto_GenerateRequestID
=== RUN   Test_proto_GenerateRequestID/test_max_uint32
=== RUN   Test_proto_GenerateRequestID/test_uint32_overflow
=== RUN   Test_proto_GenerateRequestID/test_max_int32
=== RUN   Test_proto_GenerateRequestID/test_int32_overflow
=== RUN   Test_proto_GenerateRequestID/test_int32_overflow#01
--- PASS: Test_proto_GenerateRequestID (0.00s)
    --- PASS: Test_proto_GenerateRequestID/test_max_uint32 (0.00s)
    --- PASS: Test_proto_GenerateRequestID/test_uint32_overflow (0.00s)
    --- PASS: Test_proto_GenerateRequestID/test_max_int32 (0.00s)
    --- PASS: Test_proto_GenerateRequestID/test_int32_overflow (0.00s)
    --- PASS: Test_proto_GenerateRequestID/test_int32_overflow#01 (0.00s)
PASS
ok      mosn.io/mosn/pkg/protocol/xprotocol/tars        (cached)
?       mosn.io/mosn/pkg/protocol/xprotocol/wasm        [no test files]
```

使用 issue 中手动复现的方式重新测试，测试通过，client 日志如下：

```log
[Xprotocol RPC Client] Receive Data:stream: 4294967287  status: 0
[Xprotocol RPC Client] Receive Data:stream: 4294967288  status: 0
[Xprotocol RPC Client] Receive Data:stream: 4294967289  status: 0
[Xprotocol RPC Client] Receive Data:stream: 4294967290  status: 0
[Xprotocol RPC Client] Receive Data:stream: 4294967291  status: 0
[Xprotocol RPC Client] Receive Data:stream: 4294967292  status: 0
[Xprotocol RPC Client] Receive Data:stream: 4294967293  status: 0
[Xprotocol RPC Client] Receive Data:stream: 4294967294  status: 0
[Xprotocol RPC Client] Receive Data:stream: 4294967295  status: 0
[Xprotocol RPC Client] Receive Data:stream: 0  status: 0
[Xprotocol RPC Client] Receive Data:stream: 1  status: 0
[Xprotocol RPC Client] Receive Data:stream: 2  status: 0
[Xprotocol RPC Client] Receive Data:stream: 3  status: 0
[Xprotocol RPC Client] Receive Data:stream: 4  status: 0
[Xprotocol RPC Client] Receive Data:stream: 5  status: 0
[Xprotocol RPC Client] Receive Data:stream: 6  status: 0
[Xprotocol RPC Client] Receive Data:stream: 7  status: 0
// ...
```

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
