### PR TITLE
ci: exclude forked stdlib tls tests and pin golangci-lint v1

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -46,6 +46,11 @@ jobs:
         uses: reviewdog/action-golangci-lint@v2
         if: github.event_name == 'pull_request'
         with:
+          # reviewdog/action-golangci-lint@v2 defaults to golangci-lint v2.x, which
+          # removed the v1-style flags below (--enable-all, --skip-dirs,
+          # --exclude-use-default). Pin to the last v1 release so the existing
+          # rule set keeps working. TODO: migrate to a v2 config file.
+          golangci_lint_version: v1.61.0
           golangci_lint_flags: "--skip-dirs=mtls/crypto,module/http2 --enable-all --timeout=10m --exclude-use-default=false --tests=false --disable=gochecknoinits,gochecknoglobals,exhaustive,exhaustruct,exhaustivestruct,nakedret,ireturn,interfacer,tagliatelle,varnamelen"
           workdir: pkg
 

--- a/etc/script/report.sh
+++ b/etc/script/report.sh
@@ -3,7 +3,7 @@
 set -e
 echo "" > coverage.txt
 
-for d in $(go list ./pkg/...  | grep -v pkg/networkextention); do
+for d in $(go list ./pkg/...  | grep -v pkg/networkextention | grep -v pkg/mtls/crypto/tls); do
     echo "--------Run test package: $d"
     GO111MODULE=on go test -gcflags="all=-N -l" -v -coverprofile=profile.out -covermode=atomic $d
     echo "--------Finish test package: $d"


### PR DESCRIPTION
### Issues associated with this PR

- etc/script/report.sh: skip pkg/mtls/crypto/tls in coverage, matching Makefile ut-local. The package forks crypto/tls from the Go stdlib with hardcoded test certificates that expired on 2025-01-01, causing TestResumption (TLSv12/TLSv13) to fail with 'bad certificate' on every PR. The package was already excluded from unit tests.
- .github/workflows/reviewdog.yml: pin golangci-lint to v1.61.0. reviewdog/action-golangci-lint@v2 now ships golangci-lint v2, which removed the v1 flags used here (--enable-all, --skip-dirs, --exclude-use-default), breaking every PR with 'unknown flag'.

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, details and the changes. At this time, Chinese is allowed to describe these.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases. And you need to show the UT result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result.

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
